### PR TITLE
fix: add api image reader

### DIFF
--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -272,8 +272,8 @@ def _prune_history_images(messages: list[ModelMessage]) -> list[ModelMessage]:
 
 
 def _build_tools(toolkit: Toolkit) -> list[Tool]:
-    """Wrap each toolkit tool as a pydantic-ai function tool from its schema."""
-    tools: list[Tool] = []
+    """Build the API-only image reader plus pydantic-ai toolkit wrappers."""
+    tools: list[Tool] = [Tool(read_image)]
     for spec in toolkit.get_tools_spec():
         name = spec["name"]
         tools.append(
@@ -287,6 +287,14 @@ def _build_tools(toolkit: Toolkit) -> list[Tool]:
             )
         )
     return tools
+
+
+def read_image(path: str) -> ToolReturn:
+    """Read a local image path returned by an RPent tool as visual input."""
+    return ToolReturn(
+        return_value=path,
+        content=[BinaryContent.from_path(path)],
+    )
 
 
 def _make_tool_function(toolkit: Toolkit, name: str):


### PR DESCRIPTION
## Summary

- Add an API-only `read_image` tool.
 
## Test

Verified with a real api call:

```text
2026-07-21 12:52:28 I [api_loop] [tool>] read_image({"path": "/mnt/public/ljy/runs/rpent-api-read-image-smoke-98hA9m/images_cam_hi/
image_cam_hi_01.png"})
2026-07-21 12:52:28 I [api_loop] [usage] in=244549 out=5294 cache_read=141430 cache_write=103103 requests=7
2026-07-21 12:52:28 I [api_loop] [tool<] read_image: /mnt/public/ljy/runs/rpent-api-read-image-smoke-98hA9m/images_cam_hi/image_cam_hi_01.png
```