### PR TITLE
fix: Update renamed LIBERO package name and python version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 authors = [{ name = "RPent Contributors" }]
 description = "Embodied agent framework for coordinating high-level reasoning and robot skills"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 license = {file = "LICENSE"}
 keywords = [
     "embodied-intelligence",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ openpi = [
     "openpi @ git+https://github.com/RLinf/openpi.git@feature/physical-agent",
 ]
 libero = [
-    "libero @ git+https://github.com/RLinf/LIBERO.git",
+    "rlinf-libero",
     "robosuite==1.4.1",
     "bddl",
     "easydict",
@@ -65,7 +65,7 @@ libero = [
 ]
 libero-pro = [
     "rpent[libero]",
-    "liberopro @ git+https://github.com/RLinf/LIBERO-PRO.git@feature/physical-agent",
+    "rpent-liberopro",
 ]
 libero-plus = [
     "rpent[libero]",


### PR DESCRIPTION
Fixes #37 

Due to updated package name on `RLinf/LIBERO-PRO@feature/physical-agent` ([commits](https://github.com/RLinf/LIBERO-PRO/compare/0bcf736...885ed69)), pip cannot resolve dependencies correctly:
```bash
# On clean machine
git clone https://github.com/RLinf/RPent rpent && cd rpent
pip install -e ".[full]"
```
```txt
WARNING: Generating metadata for package liberopro produced metadata for project name rpent-liberopro.
Discarding git+https://github.com/RLinf/LIBERO-PRO.git@feature/physical-agent: Requested
  rpent-liberopro from git+... has inconsistent name: expected 'liberopro', but metadata has
  'rpent-liberopro'
ERROR: No matching distribution found for liberopro (unavailable)
```

After resolving the package name, `Python 3.13` still fails to build because `numpy 1.26.4` has no `cp313` binary. 

## Fix
- `libero` extra: `libero @ git+https://github.com/RLinf/LIBERO.git` → `rlinf-libero`
- `libero-pro` extra: `liberopro @ git+…/LIBERO-PRO.git@feature/physical-agent` → `rpent-liberopro`
- `requires-python`: `">=3.10"` → `">=3.10,<3.13"`
