### PR TITLE
fix: make parent-watch opt-in to prevent false shutdown on standalone launch

### DIFF
--- a/robots/libero/__init__.py
+++ b/robots/libero/__init__.py
@@ -205,6 +205,7 @@ def _init_runtime(
                 "--transport", "http",
                 "--host", host,
                 "--port", str(port),
+                "--parent-watch",
             ],
             env=_subprocess_env(
                 args.cuda_device,
@@ -240,6 +241,7 @@ def _init_runtime(
                 "--transport", "http",
                 "--host", host,
                 "--port", str(port),
+                "--parent-watch",
             ],
             env=_subprocess_env(args.cuda_device),
             log_path=str(Path(output_dir) / "vla_server.log"),
@@ -270,6 +272,7 @@ def _init_runtime(
                 "--transport", "http",
                 "--host", host,
                 "--port", str(port),
+                "--parent-watch",
             ],
             env=_subprocess_env(args.cuda_device),
             log_path=str(Path(output_dir) / "sam3_server.log"),

--- a/robots/libero/env_server.py
+++ b/robots/libero/env_server.py
@@ -291,6 +291,8 @@ def main():
     p.add_argument("--task", type=int, default=9)
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--max-episode-steps", type=int, default=600)
+    p.add_argument("--parent-watch", action="store_true",
+                   help="watch parent process via stdin pipe and exit when it dies")
     args = p.parse_args()
 
     raw_env = make_env(args.task, args.seed, suite_name=args.suite,
@@ -304,7 +306,8 @@ def main():
             "max_episode_steps": args.max_episode_steps,
         },
     )
-    facade.serve(transport=args.transport, host=args.host, port=args.port)
+    facade.serve(transport=args.transport, host=args.host, port=args.port,
+                 parent_watch=args.parent_watch)
 
 
 if __name__ == "__main__":

--- a/robots/libero/sam3_server.py
+++ b/robots/libero/sam3_server.py
@@ -328,6 +328,8 @@ def _build_argparser() -> argparse.ArgumentParser:
         default=None,
         help="GPU device(s) exposed through CUDA_VISIBLE_DEVICES.",
     )
+    parser.add_argument("--parent-watch", action="store_true",
+                        help="watch parent process via stdin pipe and exit when it dies")
     return parser
 
 
@@ -345,7 +347,8 @@ def main() -> None:
         )
     engine = Sam3Engine.load(checkpoint)
     facade = Sam3Facade(engine)
-    facade.serve(transport=args.transport, host=args.host, port=args.port)
+    facade.serve(transport=args.transport, host=args.host, port=args.port,
+                 parent_watch=args.parent_watch)
 
 
 if __name__ == "__main__":

--- a/robots/libero/vla_server.py
+++ b/robots/libero/vla_server.py
@@ -173,6 +173,8 @@ def main() -> None:
         default=None,
         help="Pi0.5 checkpoint (defaults to PI05_CHECKPOINT_PATH env)",
     )
+    p.add_argument("--parent-watch", action="store_true",
+                   help="watch parent process via stdin pipe and exit when it dies")
     args = p.parse_args()
 
     model_path = args.model_path or get_pi05_checkpoint_path()
@@ -183,7 +185,8 @@ def main() -> None:
         )
 
     facade = VLAFacade(model_path=model_path)
-    facade.serve(transport=args.transport, host=args.host, port=args.port)
+    facade.serve(transport=args.transport, host=args.host, port=args.port,
+                 parent_watch=args.parent_watch)
 
 
 if __name__ == "__main__":

--- a/rpent/utils/rpc.py
+++ b/rpent/utils/rpc.py
@@ -85,8 +85,14 @@ class RpcFacade:
         transport: Literal["socket", "http"],
         host: str,
         port: int,
+        parent_watch: bool = False,
     ) -> None:
-        """Bind, announce, watch-parent, serve-forever, shut down cleanly."""
+        """Bind, announce, watch-parent, serve-forever, shut down cleanly.
+
+        When *parent_watch* is True, a background thread reads stdin (a pipe
+        from :class:`ProcessDaemon`) and triggers shutdown when the pipe
+        closes — i.e., when the parent process dies.
+        """
         from rpent.utils.daemon import watch_parent_death
         from rpent.utils.http_rpc import HttpRpcServer
         from rpent.utils.socket_rpc import SocketRpcServer
@@ -105,7 +111,8 @@ class RpcFacade:
         print(f"RPC server listening on {url}", flush=True)
         logger.info("RPC server listening on %s", url)
 
-        watch_parent_death(self._shutdown_event.set)
+        if parent_watch:
+            watch_parent_death(self._shutdown_event.set)
         try:
             threading.Thread(target=server.serve_forever, daemon=True).start()
             self._shutdown_event.wait()


### PR DESCRIPTION
## Summary
- `RpcFacade.serve()` no longer calls `watch_parent_death` unconditionally — requires explicit `--parent-watch` flag
- `ProcessDaemon` passes `--parent-watch` when spawning child processes, preserving existing behavior
- Standalone `nohup`/`setsid` launches omit the flag and keep running

Fixes #52.