### PR TITLE
fix: align EGL device with --cuda-device to prevent env_server crash on multi-GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ For more detailed documentation, see the [RPent documentation](https://rpent.rea
     <tr><td><code>--no-images</code></td><td>off</td><td>Text-only mode: never send image bytes (for models that reject image input)</td></tr>
     <tr><td><code>--max-episode-steps</code></td><td><code>10000</code></td><td>Max env steps</td></tr>
     <tr><td><code>--libero-type</code></td><td><code>LIBERO_TYPE</code> or <code>pro</code></td><td>LIBERO variant: <code>standard</code> | <code>pro</code> | <code>plus</code></td></tr>
-    <tr><td><code>--cuda-device</code></td><td>inherited</td><td>GPU device(s) exposed to the env / VLA / SAM3 servers</td></tr>
+    <tr><td><code>--cuda-device</code></td><td>inherited</td><td>GPU device exposed to the env / VLA / SAM3 servers</td></tr>
     <tr><td><code>--dashboard</code></td><td>off</td><td>Start the local dashboard for this run</td></tr>
     <tr><td><code>--dashboard-language</code></td><td><code>en</code></td><td>Dashboard UI language: <code>en</code> | <code>zh-cn</code></td></tr>
     <tr><td><code>--env-endpoint</code></td><td>— (spawn)</td><td><code>[protocol://]host:port</code> of an existing env_server (<code>protocol=http|socket</code>, default <code>http</code>). If unset, one is spawned locally.</td></tr>

--- a/README.md
+++ b/README.md
@@ -119,12 +119,11 @@ export PI05_CHECKPOINT_PATH=/path/to/rlinf-pi05-libero-130-fullshot-sft
 # https://modelscope.cn/models/facebook/sam3
 export SAM3_CHECKPOINT_PATH=/path/to/sam3/sam3.pt
 export LIBERO_TYPE=pro
-export CUDA_VISIBLE_DEVICES=0
 
 # Run one task: libero_object_swap, task 2, seed 0, using Claude Code
 # with Claude Opus 4.8.
 rpent --env libero --suite libero_object_swap --task 2 --seed 0 \
-  --planner claude_code --model claude-opus-4-8
+  --cuda-device 0 --planner claude_code --model claude-opus-4-8
 ```
 
 See the [planner docs](https://rpent.readthedocs.io/en/latest/rst_source/usage/configure_planner.html) to configure other planners (`api`, `codex`) and model providers.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,12 +120,11 @@ export PI05_CHECKPOINT_PATH=/path/to/rlinf-pi05-libero-130-fullshot-sft
 # https://modelscope.cn/models/facebook/sam3
 export SAM3_CHECKPOINT_PATH=/path/to/sam3/sam3.pt
 export LIBERO_TYPE=pro
-export CUDA_VISIBLE_DEVICES=0
 
 # 运行一个任务：libero_object_swap，task 2，seed 0，使用 Claude Code
 # 和 Claude Opus 4.8。
 rpent --env libero --suite libero_object_swap --task 2 --seed 0 \
-  --planner claude_code --model claude-opus-4-8
+  --cuda-device 0 --planner claude_code --model claude-opus-4-8
 ```
 
 其他规划器（`api`、`codex`）与模型提供商的配置见[规划器文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/configure_planner.html)。

--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -328,7 +328,7 @@ subprocesses as it needs. The current LIBERO implementation starts
   for any supporting services here as well, such as LIBERO's ``sam3_client``.
 
 Endpoint parsing (``--env-endpoint``, ``--vla-endpoint``, and LIBERO's
-``--sam3-endpoint``) and subprocess env composition (``CUDA_VISIBLE_DEVICES``,
+``--sam3-endpoint``) and subprocess spawning (``--cuda-device`` passthrough,
 ``MUJOCO_GL``, ...) live here — main.py knows nothing about them. See
 ``robots/libero/__init__.py`` for the reference implementation.
 

--- a/docs/source-en/rst_source/usage/advanced_deployment.rst
+++ b/docs/source-en/rst_source/usage/advanced_deployment.rst
@@ -20,10 +20,10 @@ steps; those values must match the RPent client exactly. On the env host:
 .. code-block:: bash
 
    export LIBERO_TYPE=pro
-   export CUDA_VISIBLE_DEVICES=0
    python -m robots.libero.env_server \
      --suite libero_object_swap --task 2 --seed 0 \
      --max-episode-steps 10000 \
+     --cuda-device 0 \
      --transport http --host 0.0.0.0 --port ENV_PORT
 
 The environment service is task-bound. To change any of those parameters,
@@ -37,8 +37,8 @@ On the VLA host, set the checkpoint path and start the HTTP service:
 .. code-block:: bash
 
    export PI05_CHECKPOINT_PATH=/path/to/rlinf-pi05-libero-130-fullshot-sft
-   export CUDA_VISIBLE_DEVICES=0
    python -m robots.libero.vla_server \
+     --cuda-device 0 \
      --transport http --host 0.0.0.0 --port VLA_PORT
 
 The VLA service loads the model once and can be reused by multiple RPent runs.
@@ -51,8 +51,8 @@ On the SAM3 host, set the local checkpoint path and start the HTTP service:
 .. code-block:: bash
 
    export SAM3_CHECKPOINT_PATH=/path/to/sam3/sam3.pt
-   export CUDA_VISIBLE_DEVICES=0
    python -m robots.libero.sam3_server \
+     --cuda-device 0 \
      --transport http --host 0.0.0.0 --port SAM3_PORT
 
 The SAM3 service loads the model once and can be reused by multiple RPent runs.

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -310,8 +310,8 @@ toolkit 所需的参数。环境实现可以自行决定启动多少个子进程
   也在这里加入相应的 client，例如 LIBERO 的 ``sam3_client``。
 
 endpoint（``--env-endpoint``、``--vla-endpoint``，以及 LIBERO 的
-``--sam3-endpoint``）解析和子进程环境变量（如 ``CUDA_VISIBLE_DEVICES``、
-``MUJOCO_GL``）的设置也在这里完成，main.py 不处理这些细节。参考实现见
+``--sam3-endpoint``）解析和子进程启动（``--cuda-device`` 透传、
+``MUJOCO_GL``）也在这里完成，main.py 不处理这些细节。参考实现见
 ``robots/libero/__init__.py``。
 
 冒烟测试

--- a/docs/source-zh/rst_source/usage/advanced_deployment.rst
+++ b/docs/source-zh/rst_source/usage/advanced_deployment.rst
@@ -19,10 +19,10 @@ RPent 客户端完全一致。在环境主机上运行：
 .. code-block:: bash
 
    export LIBERO_TYPE=pro
-   export CUDA_VISIBLE_DEVICES=0
    python -m robots.libero.env_server \
      --suite libero_object_swap --task 2 --seed 0 \
      --max-episode-steps 10000 \
+     --cuda-device 0 \
      --transport http --host 0.0.0.0 --port ENV_PORT
 
 环境服务与任务绑定。需要修改上述任一参数时，请先停止旧服务再重新启动。
@@ -35,8 +35,8 @@ Pi0.5 VLA 服务
 .. code-block:: bash
 
    export PI05_CHECKPOINT_PATH=/path/to/rlinf-pi05-libero-130-fullshot-sft
-   export CUDA_VISIBLE_DEVICES=0
    python -m robots.libero.vla_server \
+     --cuda-device 0 \
      --transport http --host 0.0.0.0 --port VLA_PORT
 
 VLA 服务只加载一次模型，可以由多个 RPent 运行复用。
@@ -49,8 +49,8 @@ SAM3 服务
 .. code-block:: bash
 
    export SAM3_CHECKPOINT_PATH=/path/to/sam3/sam3.pt
-   export CUDA_VISIBLE_DEVICES=0
    python -m robots.libero.sam3_server \
+     --cuda-device 0 \
      --transport http --host 0.0.0.0 --port SAM3_PORT
 
 SAM3 服务只加载一次模型，可以由多个 RPent 运行复用。

--- a/robots/libero/__init__.py
+++ b/robots/libero/__init__.py
@@ -86,7 +86,7 @@ def _add_cli_args(parser: argparse.ArgumentParser, use_dashboard: bool) -> None:
                              "(protocol=http|socket, defaults to http). "
                              "If unset, a local SAM3 server is spawned.")
     parser.add_argument("--cuda-device", default=None,
-                        help="GPU device(s) to expose via CUDA_VISIBLE_DEVICES.")
+                        help="GPU device to expose via CUDA_VISIBLE_DEVICES.")
 
 
 def _parse_config(args: argparse.Namespace) -> RunConfig:

--- a/robots/libero/__init__.py
+++ b/robots/libero/__init__.py
@@ -136,16 +136,13 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
     )
 
 
-def _subprocess_env(cuda_device: str | None, **extra: str) -> dict[str, str]:
-    """Build the env dict for a subprocess: inherit from parent, apply
-    ``--cuda-device`` uniformly, layer optional extras on top.
+def _subprocess_env(**extra: str) -> dict[str, str]:
+    """Build the env dict for a subprocess: inherit from parent, layer extras on top.
 
-    If ``cuda_device`` is None, ``CUDA_VISIBLE_DEVICES`` is left as inherited
-    (respecting whatever the parent shell set). If given, it wins.
+    CUDA device selection is passed via ``--cuda-device`` on the server command
+    line — the server itself handles ``CUDA_VISIBLE_DEVICES`` and EGL alignment.
     """
     env = os.environ.copy()
-    if cuda_device is not None:
-        env["CUDA_VISIBLE_DEVICES"] = str(cuda_device)
     env.update(extra)
     return env
 
@@ -174,6 +171,7 @@ def _init_runtime(
 
     daemons: list[ProcessDaemon] = []
     libero_type = args.libero_type or get_libero_type()
+    _cuda_args = ["--cuda-device", str(args.cuda_device)] if args.cuda_device is not None else []
 
     # --- env_server --------------------------------------------------------
     if args.env_endpoint is None:
@@ -191,9 +189,9 @@ def _init_runtime(
                 "--host", host,
                 "--port", str(port),
                 "--parent-watch",
+                *_cuda_args,
             ],
             env=_subprocess_env(
-                args.cuda_device,
                 LIBERO_TYPE=libero_type,
                 MUJOCO_GL="egl",
                 ROBOT_PLATFORM="LIBERO",
@@ -228,8 +226,9 @@ def _init_runtime(
                 "--host", host,
                 "--port", str(port),
                 "--parent-watch",
+                *_cuda_args,
             ],
-            env=_subprocess_env(args.cuda_device),
+            env=_subprocess_env(),
             log_path=str(Path(output_dir) / "vla_server.log"),
         )
         vla_daemon.start()
@@ -260,8 +259,9 @@ def _init_runtime(
                 "--host", host,
                 "--port", str(port),
                 "--parent-watch",
+                *_cuda_args,
             ],
-            env=_subprocess_env(args.cuda_device),
+            env=_subprocess_env(),
             log_path=str(Path(output_dir) / "sam3_server.log"),
         )
         sam3_daemon.start()

--- a/robots/libero/__init__.py
+++ b/robots/libero/__init__.py
@@ -17,7 +17,6 @@ from rpent.envs.prompt_bundle import PromptBundle
 from rpent.utils.config import get_repo_root
 
 if TYPE_CHECKING:
-    from rpent.dashboard.state import State
     from rpent.utils.daemon import ProcessDaemon
     from rpent.utils.rpc import RpcClient
 

--- a/robots/libero/__init__.py
+++ b/robots/libero/__init__.py
@@ -85,7 +85,7 @@ def _add_cli_args(parser: argparse.ArgumentParser, use_dashboard: bool) -> None:
                         help="[protocol://]host:port of an existing SAM3 server "
                              "(protocol=http|socket, defaults to http). "
                              "If unset, a local SAM3 server is spawned.")
-    parser.add_argument("--cuda-device", default=None,
+    parser.add_argument("--cuda-device", type=int, default=None,
                         help="GPU device to expose via CUDA_VISIBLE_DEVICES.")
 
 

--- a/robots/libero/env_server.py
+++ b/robots/libero/env_server.py
@@ -26,10 +26,11 @@ if str(RLINF_REPO_PATH) not in sys.path:
 os.environ.setdefault("ROBOT_PLATFORM", "LIBERO")
 
 import numpy as np
-import torch
 from omegaconf import OmegaConf
 
 from rlinf.envs.libero.libero_env import LiberoEnv
+
+# torch import is deferred into main() after --cuda-device sets CUDA_VISIBLE_DEVICES.
 
 
 # ---------------------------------------------------------------------------
@@ -298,9 +299,20 @@ def main():
     args = p.parse_args()
 
     if args.cuda_device is not None:
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
+        assert "torch" not in sys.modules, \
+            "torch must not be imported before --cuda-device is applied"
+        target = str(args.cuda_device)
+        prev = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if prev is not None and prev != target:
+            logger.warning(
+                "CUDA_VISIBLE_DEVICES=%s is already set; overriding with --cuda-device=%s",
+                prev, args.cuda_device,
+            )
+        os.environ["CUDA_VISIBLE_DEVICES"] = target
         from rpent.utils.egl import configure_egl_device
         configure_egl_device(args.cuda_device)
+
+    import torch
 
     raw_env = make_env(args.task, args.seed, suite_name=args.suite,
                        max_episode_steps=args.max_episode_steps)

--- a/robots/libero/env_server.py
+++ b/robots/libero/env_server.py
@@ -302,22 +302,34 @@ def main():
     p.add_argument("--parent-watch", action="store_true",
                    help="watch parent process via stdin pipe and exit when it dies")
     p.add_argument("--cuda-device", type=int, default=None,
-                   help="GPU device exposed through CUDA_VISIBLE_DEVICES.")
+                   help="GPU device to pin MuJoCo EGL rendering and the torch "
+                        "default device to (physical CUDA ordinal).")
     args = p.parse_args()
 
     if args.cuda_device is not None:
-        assert "torch" not in sys.modules, \
-            "torch must not be imported before --cuda-device is applied"
-        target = str(args.cuda_device)
+        # Deliberately do NOT set CUDA_VISIBLE_DEVICES. robosuite (imported
+        # transitively via libero) asserts at import time that
+        # ``MUJOCO_EGL_DEVICE_ID in CUDA_VISIBLE_DEVICES`` (substring check),
+        # which assumes the EGL index equals the CUDA ordinal and crashes on
+        # multi-GPU boxes where the EGL order differs. That assertion is gated
+        # on ``CUDA_VISIBLE_DEVICES != ""``, so leaving it unset skips it in
+        # both this process and the multiprocessing-spawned render workers
+        # (which inherit the env). Pin the two backends directly instead:
+        #   - MuJoCo render device <- MUJOCO_EGL_DEVICE_ID (configure_egl_device)
+        #   - torch default device  <- torch.cuda.set_device(N)
         prev = os.environ.get("CUDA_VISIBLE_DEVICES")
-        if prev is not None and prev != target:
+        if prev is not None:
             logger.warning(
-                "CUDA_VISIBLE_DEVICES=%s is already set; overriding with --cuda-device=%s",
+                "CUDA_VISIBLE_DEVICES=%s is set; clearing it and pinning via "
+                "MUJOCO_EGL_DEVICE_ID + torch.cuda.set_device(--cuda-device=%s) "
+                "instead (robosuite's CVD assertion is incompatible with EGL<->CUDA mapping)",
                 prev, args.cuda_device,
             )
-        os.environ["CUDA_VISIBLE_DEVICES"] = target
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
         from rpent.utils.egl import configure_egl_device
         configure_egl_device(args.cuda_device)
+        import torch
+        torch.cuda.set_device(args.cuda_device)
 
     raw_env = make_env(args.task, args.seed, suite_name=args.suite,
                        max_episode_steps=args.max_episode_steps)

--- a/robots/libero/env_server.py
+++ b/robots/libero/env_server.py
@@ -25,11 +25,10 @@ if str(RLINF_REPO_PATH) not in sys.path:
     sys.path.insert(0, str(RLINF_REPO_PATH))
 os.environ.setdefault("ROBOT_PLATFORM", "LIBERO")
 
-import numpy as np  # noqa: E402
-import torch  # noqa: E402
-from omegaconf import OmegaConf  # noqa: E402
-
-from rlinf.envs.libero.libero_env import LiberoEnv  # noqa: E402
+# Heavy imports (numpy, torch, OmegaConf, LiberoEnv) are deferred into main()
+# after --cuda-device has been parsed and CUDA/EGL alignment is done.
+# All type annotations are lazy (from __future__ import annotations) and
+# function/class bodies only reference these modules at call time.
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +282,8 @@ class LiberoEnvFacade(RpcFacade):
 
 
 def main():
+    global np, torch, OmegaConf, LiberoEnv
+
     p = argparse.ArgumentParser()
     p.add_argument("--transport", choices=["socket", "http"], default="http")
     p.add_argument("--host", type=str, default="127.0.0.1")
@@ -293,7 +294,20 @@ def main():
     p.add_argument("--max-episode-steps", type=int, default=600)
     p.add_argument("--parent-watch", action="store_true",
                    help="watch parent process via stdin pipe and exit when it dies")
+    p.add_argument("--cuda-device", type=int, default=None,
+                   help="GPU device exposed through CUDA_VISIBLE_DEVICES.")
     args = p.parse_args()
+
+    if args.cuda_device is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
+        from rpent.utils.egl import configure_egl_device
+        configure_egl_device(args.cuda_device)
+
+    import numpy as np
+    import torch
+    from omegaconf import OmegaConf
+
+    from rlinf.envs.libero.libero_env import LiberoEnv
 
     raw_env = make_env(args.task, args.seed, suite_name=args.suite,
                        max_episode_steps=args.max_episode_steps)

--- a/robots/libero/env_server.py
+++ b/robots/libero/env_server.py
@@ -25,10 +25,11 @@ if str(RLINF_REPO_PATH) not in sys.path:
     sys.path.insert(0, str(RLINF_REPO_PATH))
 os.environ.setdefault("ROBOT_PLATFORM", "LIBERO")
 
-# Heavy imports (numpy, torch, OmegaConf, LiberoEnv) are deferred into main()
-# after --cuda-device has been parsed and CUDA/EGL alignment is done.
-# All type annotations are lazy (from __future__ import annotations) and
-# function/class bodies only reference these modules at call time.
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+
+from rlinf.envs.libero.libero_env import LiberoEnv
 
 
 # ---------------------------------------------------------------------------
@@ -282,8 +283,6 @@ class LiberoEnvFacade(RpcFacade):
 
 
 def main():
-    global np, torch, OmegaConf, LiberoEnv
-
     p = argparse.ArgumentParser()
     p.add_argument("--transport", choices=["socket", "http"], default="http")
     p.add_argument("--host", type=str, default="127.0.0.1")
@@ -302,12 +301,6 @@ def main():
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
         from rpent.utils.egl import configure_egl_device
         configure_egl_device(args.cuda_device)
-
-    import numpy as np
-    import torch
-    from omegaconf import OmegaConf
-
-    from rlinf.envs.libero.libero_env import LiberoEnv
 
     raw_env = make_env(args.task, args.seed, suite_name=args.suite,
                        max_episode_steps=args.max_episode_steps)

--- a/robots/libero/env_server.py
+++ b/robots/libero/env_server.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-# MuJoCo env vars must be set BEFORE importing anything that touches MuJoCo.
-os.environ.setdefault("MUJOCO_GL", "egl")
-os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+import numpy as np
+from omegaconf import OmegaConf
 
 from rpent.utils.config import (
     get_repo_root,
@@ -16,6 +15,12 @@ from rpent.utils.config import (
 )
 from rpent.utils.logging import get_logger
 from rpent.utils.rpc import RpcFacade
+
+# MuJoCo env vars must be set BEFORE importing anything that touches MuJoCo.
+os.environ.setdefault("MUJOCO_GL", "egl")
+os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+assert "mujoco" not in sys.modules, \
+    "mujoco must not be imported before MUJOCO_GL/PYOPENGL_PLATFORM are set"
 
 logger = get_logger("env_server")
 
@@ -25,12 +30,11 @@ if str(RLINF_REPO_PATH) not in sys.path:
     sys.path.insert(0, str(RLINF_REPO_PATH))
 os.environ.setdefault("ROBOT_PLATFORM", "LIBERO")
 
-import numpy as np
-from omegaconf import OmegaConf
-
-from rlinf.envs.libero.libero_env import LiberoEnv
-
-# torch import is deferred into main() after --cuda-device sets CUDA_VISIBLE_DEVICES.
+# torch and LiberoEnv are only imported at call time (after --cuda-device
+# sets CUDA_VISIBLE_DEVICES in main()); LiberoEnv transitively imports torch.
+if TYPE_CHECKING:
+    import torch  # noqa: F401  (referenced at runtime in _to_numpy_tree)
+    from rlinf.envs.libero.libero_env import LiberoEnv
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +90,7 @@ def build_env_cfg(
 def make_env(task_id: int, seed: int, suite_name: str = "libero_spatial",
              max_episode_steps: int = 600) -> LiberoEnv:
     """Build a single-env LiberoEnv pinned to ``task_id`` / ``seed``."""
+    from rlinf.envs.libero.libero_env import LiberoEnv
     from rlinf.envs.libero.utils import benchmark as _bench_mod
     suite = _bench_mod.get_benchmark(suite_name)()
     first_id = sum(len(suite.get_task_init_states(t)) for t in range(task_id))
@@ -109,6 +114,8 @@ def make_env(task_id: int, seed: int, suite_name: str = "libero_spatial",
 def _to_numpy_tree(x):
     """Recursively convert torch tensors to CPU numpy arrays so the result
     pickles cleanly across the agent/env_server wire."""
+    import torch
+
     if isinstance(x, torch.Tensor):
         return x.detach().cpu().numpy()
     if isinstance(x, dict):
@@ -311,8 +318,6 @@ def main():
         os.environ["CUDA_VISIBLE_DEVICES"] = target
         from rpent.utils.egl import configure_egl_device
         configure_egl_device(args.cuda_device)
-
-    import torch
 
     raw_env = make_env(args.task, args.seed, suite_name=args.suite,
                        max_episode_steps=args.max_episode_steps)

--- a/robots/libero/sam3_server.py
+++ b/robots/libero/sam3_server.py
@@ -338,7 +338,14 @@ def main() -> None:
     args = _build_argparser().parse_args()
     logging.basicConfig(level=logging.INFO, format="[%(name)s] %(message)s")
     if args.cuda_device is not None:
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
+        target = str(args.cuda_device)
+        prev = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if prev is not None and prev != target:
+            logging.warning(
+                "CUDA_VISIBLE_DEVICES=%s is already set; overriding with --cuda-device=%s",
+                prev, args.cuda_device,
+            )
+        os.environ["CUDA_VISIBLE_DEVICES"] = target
     checkpoint = os.environ.get("SAM3_CHECKPOINT_PATH")
     if not checkpoint:
         raise RuntimeError(

--- a/robots/libero/sam3_server.py
+++ b/robots/libero/sam3_server.py
@@ -326,7 +326,7 @@ def _build_argparser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cuda-device",
         default=None,
-        help="GPU device(s) exposed through CUDA_VISIBLE_DEVICES.",
+        help="GPU device exposed through CUDA_VISIBLE_DEVICES.",
     )
     parser.add_argument("--parent-watch", action="store_true",
                         help="watch parent process via stdin pipe and exit when it dies")

--- a/robots/libero/sam3_server.py
+++ b/robots/libero/sam3_server.py
@@ -325,6 +325,7 @@ def _build_argparser() -> argparse.ArgumentParser:
     parser.add_argument("--port", type=int, default=8114)
     parser.add_argument(
         "--cuda-device",
+        type=int,
         default=None,
         help="GPU device exposed through CUDA_VISIBLE_DEVICES.",
     )

--- a/robots/libero/vla_server.py
+++ b/robots/libero/vla_server.py
@@ -175,7 +175,12 @@ def main() -> None:
     )
     p.add_argument("--parent-watch", action="store_true",
                    help="watch parent process via stdin pipe and exit when it dies")
+    p.add_argument("--cuda-device", type=int, default=None,
+                   help="GPU device exposed through CUDA_VISIBLE_DEVICES.")
     args = p.parse_args()
+
+    if args.cuda_device is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
 
     model_path = args.model_path or get_pi05_checkpoint_path()
     if not model_path:

--- a/robots/libero/vla_server.py
+++ b/robots/libero/vla_server.py
@@ -9,8 +9,9 @@ import sys
 import time
 from typing import Any
 
-os.environ.setdefault("MUJOCO_GL", "egl")
-os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+import numpy as np
+import torch
+from omegaconf import OmegaConf
 
 from rpent.utils.config import (
     get_pi05_checkpoint_path,
@@ -27,11 +28,6 @@ RLINF_REPO_PATH = get_rlinf_repo_path() or (RPENT_ROOT.parent / "rlinf").resolve
 if str(RLINF_REPO_PATH) not in sys.path:
     sys.path.insert(0, str(RLINF_REPO_PATH))
 os.environ.setdefault("ROBOT_PLATFORM", "LIBERO")
-
-import numpy as np  # noqa: E402
-import torch  # noqa: E402
-from omegaconf import OmegaConf  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Config builders

--- a/robots/libero/vla_server.py
+++ b/robots/libero/vla_server.py
@@ -180,7 +180,14 @@ def main() -> None:
     args = p.parse_args()
 
     if args.cuda_device is not None:
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
+        target = str(args.cuda_device)
+        prev = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if prev is not None and prev != target:
+            logger.warning(
+                "CUDA_VISIBLE_DEVICES=%s is already set; overriding with --cuda-device=%s",
+                prev, args.cuda_device,
+            )
+        os.environ["CUDA_VISIBLE_DEVICES"] = target
 
     model_path = args.model_path or get_pi05_checkpoint_path()
     if not model_path:

--- a/rpent/utils/egl.py
+++ b/rpent/utils/egl.py
@@ -6,8 +6,6 @@ process to CUDA device N (via ``--cuda-device``) without also pointing MuJoCo
 at the *matching* EGL device makes MuJoCo render on the wrong device — or on a
 software/DRM-only EGL entry — and env_server crashes. This module bridges the
 two enumerations.
-
-Must be called **before** any import that touches MuJoCo or CUDA.
 """
 from __future__ import annotations
 
@@ -31,10 +29,7 @@ def cuda_to_egl_map() -> dict[int, int]:
     which the driver reports regardless of ``CUDA_VISIBLE_DEVICES``.
     """
     os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
-    try:
-        from mujoco.egl import egl_ext as EGL            # mujoco ships a working binding
-    except Exception:
-        from OpenGL import EGL                            # fallback
+    from mujoco.egl import egl_ext as EGL
     from OpenGL import EGL as GLEGL
     from OpenGL.EGL.EXT.device_base import eglQueryDeviceStringEXT
 
@@ -61,8 +56,8 @@ def cuda_to_egl_map() -> dict[int, int]:
 def configure_egl_device(cuda_device: int) -> None:
     """Set ``MUJOCO_EGL_DEVICE_ID`` to the EGL device matching *cuda_device*.
 
-    Must be called before any MuJoCo or CUDA import. *cuda_device* is a single
-    integer CUDA device ordinal (as passed to ``--cuda-device``).
+    *cuda_device* is a single integer CUDA device ordinal (as passed to
+    ``--cuda-device``).
 
     No-op when ``MUJOCO_EGL_DEVICE_ID`` is already set.  If the EGL/CUDA
     mapping cannot be built, a warning is logged and MuJoCo falls back to its

--- a/rpent/utils/egl.py
+++ b/rpent/utils/egl.py
@@ -1,0 +1,98 @@
+"""Resolve ``MUJOCO_EGL_DEVICE_ID`` from the requested CUDA device.
+
+EGL enumerates devices independently of ``CUDA_VISIBLE_DEVICES``, and the EGL
+device order is not guaranteed to match the CUDA ordinal order. Pinning a
+process to CUDA device N (via ``--cuda-device``) without also pointing MuJoCo
+at the *matching* EGL device makes MuJoCo render on the wrong device — or on a
+software/DRM-only EGL entry — and env_server crashes. This module bridges the
+two enumerations.
+
+Must be called **before** any import that touches MuJoCo or CUDA.
+"""
+from __future__ import annotations
+
+import ctypes
+import os
+
+from rpent.utils.logging import get_logger
+
+logger = get_logger("egl")
+
+_EGL_EXTENSIONS = 0x3055
+_EGL_CUDA_DEVICE_NV = 0x323A
+
+
+def cuda_to_egl_map() -> dict[int, int]:
+    """Return ``{cuda_ordinal: egl_device_index}`` for every real NVIDIA EGL
+    device. Software/DRM-only EGL entries are skipped, so values always point
+    at GPU devices.
+
+    ``cuda_ordinal`` is the *global* CUDA device index (``EGL_CUDA_DEVICE_NV``),
+    which the driver reports regardless of ``CUDA_VISIBLE_DEVICES``.
+    """
+    os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+    try:
+        from mujoco.egl import egl_ext as EGL            # mujoco ships a working binding
+    except Exception:
+        from OpenGL import EGL                            # fallback
+    from OpenGL import EGL as GLEGL
+    from OpenGL.EGL.EXT.device_base import eglQueryDeviceStringEXT
+
+    # eglQueryDeviceAttribEXT isn't exposed by mujoco.egl; grab the raw pointer.
+    proc = GLEGL.eglGetProcAddress("eglQueryDeviceAttribEXT")
+    if not proc:
+        raise RuntimeError("eglQueryDeviceAttribEXT unavailable (need EGL_EXT_device_query)")
+    _query = ctypes.cast(int(proc), ctypes.CFUNCTYPE(
+        ctypes.c_uint, ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_ssize_t)))
+
+    mapping: dict[int, int] = {}
+    for egl_index, dev in enumerate(EGL.eglQueryDevicesEXT()):
+        ext = (eglQueryDeviceStringEXT(dev, _EGL_EXTENSIONS) or b"").decode(errors="replace")
+        if "EGL_NV_device_cuda" not in ext:
+            continue                                      # software / DRM-only — skip
+        addr = ctypes.cast(dev, ctypes.c_void_p).value
+        val = ctypes.c_ssize_t(-1)
+        if _query(ctypes.c_void_p(addr), _EGL_CUDA_DEVICE_NV, ctypes.byref(val)) == 1:
+            if val.value >= 0:
+                mapping[int(val.value)] = egl_index
+    return mapping
+
+
+def configure_egl_device(cuda_device: int) -> None:
+    """Set ``MUJOCO_EGL_DEVICE_ID`` to the EGL device matching *cuda_device*.
+
+    Must be called before any MuJoCo or CUDA import. *cuda_device* is a single
+    integer CUDA device ordinal (as passed to ``--cuda-device``).
+
+    No-op when ``MUJOCO_EGL_DEVICE_ID`` is already set.  If the EGL/CUDA
+    mapping cannot be built, a warning is logged and MuJoCo falls back to its
+    default EGL device selection.
+    """
+    if os.environ.get("MUJOCO_EGL_DEVICE_ID") is not None:
+        return
+    cuda_ordinal = cuda_device
+
+    try:
+        mapping = cuda_to_egl_map()
+    except Exception as e:
+        logger.warning("EGL device probe failed (%s); leaving MUJOCO_EGL_DEVICE_ID unset", e)
+        return
+
+    egl_index = mapping.get(cuda_ordinal)
+    if egl_index is None:
+        logger.warning(
+            "CUDA device %d has no matching EGL device (map=%s); "
+            "leaving MUJOCO_EGL_DEVICE_ID unset",
+            cuda_ordinal, mapping,
+        )
+        return
+
+    os.environ["MUJOCO_EGL_DEVICE_ID"] = str(egl_index)
+    if egl_index != cuda_ordinal:
+        logger.info(
+            "EGL device order != CUDA order: CUDA %d -> EGL %d "
+            "(set MUJOCO_EGL_DEVICE_ID=%d)",
+            cuda_ordinal, egl_index, egl_index,
+        )
+    else:
+        logger.debug("MUJOCO_EGL_DEVICE_ID=%d (CUDA %d)", egl_index, cuda_ordinal)

--- a/rpent/utils/egl.py
+++ b/rpent/utils/egl.py
@@ -63,7 +63,12 @@ def configure_egl_device(cuda_device: int) -> None:
     mapping cannot be built, a warning is logged and MuJoCo falls back to its
     default EGL device selection.
     """
-    if os.environ.get("MUJOCO_EGL_DEVICE_ID") is not None:
+    existing = os.environ.get("MUJOCO_EGL_DEVICE_ID")
+    if existing is not None:
+        logger.warning(
+            "MUJOCO_EGL_DEVICE_ID=%s already set; keeping it "
+            "(ignoring --cuda-device=%s)", existing, cuda_device,
+        )
         return
     cuda_ordinal = cuda_device
 


### PR DESCRIPTION
## Summary

`--cuda-device N` sets `CUDA_VISIBLE_DEVICES` but MuJoCo's EGL backend still defaults to EGL device 0. When EGL enumeration order differs from CUDA order, `env_server` renders on the wrong GPU or a software/DRM-only EGL entry and crashes.

## Changes

- **`rpent/utils/egl.py`** (new) — bridges CUDA and EGL enumerations via `EGL_NV_device_cuda`; `configure_egl_device()` sets `MUJOCO_EGL_DEVICE_ID`
- **`robots/libero/env_server.py`** — defers heavy imports, calls `configure_egl_device()` after parsing `--cuda-device`
- **`robots/libero/vla_server.py`** — adds `--cuda-device` for `CUDA_VISIBLE_DEVICES` only (no EGL)
- **`robots/libero/__init__.py`** — passes `--cuda-device` to subprocesses via command line
- **Docs** — `advanced_deployment.rst` examples use `--cuda-device` instead of `export CUDA_VISIBLE_DEVICES`

Fixes #51.