### PR TITLE
fix(dashboard): support standard LIBERO suites

### DIFF
--- a/rpent/dashboard/index.html
+++ b/rpent/dashboard/index.html
@@ -15,6 +15,10 @@
         <div class="lfield full">
           <label for="f-suite" data-i18n="suite">Suite</label>
           <select id="f-suite">
+            <option value="libero_spatial">libero_spatial</option>
+            <option value="libero_object">libero_object</option>
+            <option value="libero_goal">libero_goal</option>
+            <option value="libero_90">libero_90</option>
             <option value="libero_object_task">libero_object_task</option>
             <option value="libero_object_swap">libero_object_swap</option>
             <option value="libero_object_lan">libero_object_lan</option>

--- a/rpent/dashboard/static/dashboard.js
+++ b/rpent/dashboard/static/dashboard.js
@@ -1209,7 +1209,12 @@ function selectedModel() {
 function showLauncher(defaults) {
   const d = defaults || {};
   const set = (id, val) => { $(id).value = val == null ? "" : val; };
-  set("#f-suite", d.suite);
+  const suite = d.suite == null ? "" : String(d.suite);
+  const suiteSelect = $("#f-suite");
+  if (suite && !Array.from(suiteSelect.options).some(option => option.value === suite)) {
+    suiteSelect.add(new Option(suite, suite));
+  }
+  set("#f-suite", suite);
   set("#f-task", d.task);
   set("#f-seed", d.seed);
   set("#f-planner", d.planner || "claude_code");


### PR DESCRIPTION
## Summary

- add the missing standard LIBERO suites (`libero_spatial`, `libero_object`, `libero_goal`, and `libero_90`) to the Dashboard launcher
- preserve CLI-provided custom or future suite names by adding unknown defaults to the selector instead of clearing them

## Problem

RPent supports `--libero-type standard`, but the Dashboard launcher only exposes `libero_10` from the standard benchmark. Passing another standard suite such as `--suite libero_spatial` assigns a value that is absent from the `<select>`, which clears the suite and prevents launching the run.

## Verification

- `node --check rpent/dashboard/static/dashboard.js`
- parsed the launcher HTML and verified that all five standard suite options are present and unique
- `git diff --check`