### PR TITLE
fix(api): handle read_image file errors

### DIFF
--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -15,6 +15,7 @@ import dataclasses
 import json
 import queue
 from collections import deque
+from pathlib import Path
 from typing import Any
 
 from pydantic_ai import Agent, BinaryContent, ModelSettings, Tool, ToolReturn
@@ -43,6 +44,7 @@ from rpent.dashboard.interaction import DashboardInteractionPort, DashboardMessa
 from rpent.dashboard.planner_control import DashboardPlannerControl
 from rpent.planner.base import PlannerResult
 from rpent.tools.toolkit import Toolkit
+from rpent.utils.config import get_repo_root
 from rpent.utils.logging import get_logger
 
 logger = get_logger("api_loop")
@@ -706,11 +708,27 @@ def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
     return tools
 
 
-def read_image(path: str) -> ToolReturn:
-    """Read a local image path returned by an RPent tool as visual input."""
+def read_image(path: str) -> ToolReturn | dict[str, str]:
+    """Read a local image path returned by an RPent tool as visual input.
+
+    File-system failures are returned to the model as structured tool errors,
+    matching :func:`rpent.tools.common.read_text_file`, so a bad model-supplied
+    path does not abort the entire agent run.
+    """
+    image_path = Path(path)
+    if not image_path.is_absolute():
+        image_path = get_repo_root() / image_path
+    if not image_path.exists():
+        return {"error": f"file not found: {image_path}"}
+    if image_path.is_dir():
+        return {"error": f"is a directory: {image_path}"}
+    try:
+        content = BinaryContent.from_path(image_path)
+    except Exception as e:
+        return {"error": str(e)}
     return ToolReturn(
-        return_value=path,
-        content=[BinaryContent.from_path(path)],
+        return_value=str(image_path),
+        content=[content],
     )
 
 

--- a/tests/test_api_read_image.py
+++ b/tests/test_api_read_image.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pydantic_ai import ToolReturn
+
+from rpent.planner.api_loop import read_image
+
+
+def test_read_image_returns_error_when_file_is_missing(tmp_path):
+    path = tmp_path / "missing.png"
+
+    assert read_image(str(path)) == {"error": f"file not found: {path}"}
+
+
+def test_read_image_returns_error_for_directory(tmp_path):
+    assert read_image(str(tmp_path)) == {"error": f"is a directory: {tmp_path}"}
+
+
+def test_read_image_returns_error_when_read_fails(tmp_path):
+    path = tmp_path / "unreadable.png"
+    path.write_bytes(b"not important")
+
+    with patch(
+        "rpent.planner.api_loop.BinaryContent.from_path",
+        side_effect=PermissionError("permission denied"),
+    ):
+        assert read_image(str(path)) == {"error": "permission denied"}
+
+
+def test_read_image_resolves_relative_path_and_returns_image(tmp_path):
+    path = tmp_path / "image.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    with patch("rpent.planner.api_loop.get_repo_root", return_value=tmp_path):
+        result = read_image("image.png")
+
+    assert isinstance(result, ToolReturn)
+    assert result.return_value == str(path)
+    assert len(result.content) == 1


### PR DESCRIPTION
## Summary
- resolve relative image paths from the repository root, matching `read_text_file`
- return structured tool errors for missing files, directories, and image read failures instead of aborting the API agent run
- preserve `ToolReturn` with binary image content for successful reads
- add coverage for missing, directory, read-failure, and successful relative-path cases

## Motivation
API planner models can occasionally mistype a long image path. `BinaryContent.from_path()` currently lets `FileNotFoundError` escape, which terminates the entire agent after earlier physical actions may already have executed. Returning the error to the model makes this behavior consistent with `read_text_file` and allows the model to recover safely.

## Validation
- `git diff --check`
- `python -m compileall -q rpent/planner/api_loop.py tests/test_api_read_image.py`
- pytest was not run locally because the available Python environments do not have `pydantic_ai`/pytest installed