### PR TITLE
refactor: add toolkit lifecycle hooks

### DIFF
--- a/rpent/cli/dashboard.py
+++ b/rpent/cli/dashboard.py
@@ -1,3 +1,4 @@
+# Copyright 2026 RPent Contributors
 """CLI orchestration for one long-lived Dashboard Session."""
 
 from __future__ import annotations
@@ -13,7 +14,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from rpent.cli.main import _serialize_messages
+from rpent.cli.main import (
+    _finalize_and_cleanup,
+    _merge_errors,
+    _serialize_messages,
+)
 from rpent.dashboard.events import RunStartedEvent
 from rpent.envs import get_toolkit
 from rpent.planner.base import build_planner
@@ -134,6 +139,7 @@ def _run_dashboard_task(
     output_dir = init_output_dir(run_config.output_dir, verbose=args.verbose)
 
     recipe_tag = run_config.recipe_tag
+    planner_result = None
     finish_result = None
     messages: list[dict] = []
     stats: dict = {}
@@ -189,7 +195,8 @@ def _run_dashboard_task(
                     max_turns=args.max_turns,
                     dashboard_interaction=state,
                 )
-                finish_result = result.finish_result
+                planner_result = result.finish_result
+                finish_result = planner_result
                 messages = result.messages
                 stats = result.stats
                 agent_error = result.error
@@ -199,23 +206,30 @@ def _run_dashboard_task(
     finally:
         cleanup_errors: list[str] = []
         if toolkit is not None:
-            try:
-                toolkit.close()
-                recipe_path = toolkit.write_recipe(recipe_tag)
-                logger.info("recipe: %s", recipe_path)
-            except Exception as exc:
-                cleanup_errors.append(f"Toolkit cleanup failed: {exc}")
-        for daemon in reversed(task_daemons):
-            try:
-                daemon.stop()
-            except Exception as exc:
-                cleanup_errors.append(f"env cleanup failed: {exc}")
+            finalization, finalization_error, cleanup_errors = _finalize_and_cleanup(
+                toolkit=toolkit,
+                recipe_tag=recipe_tag,
+                planner_result=planner_result,
+                planner_error=agent_error,
+                daemons=reversed(task_daemons),
+            )
+            if finalization is not None:
+                finish_result = finalization.final_result
+            agent_error = _merge_errors(agent_error, finalization_error)
+        else:
+            _, _, cleanup_errors = _finalize_and_cleanup(
+                toolkit=None,
+                recipe_tag=recipe_tag,
+                planner_result=planner_result,
+                planner_error=agent_error,
+                daemons=reversed(task_daemons),
+            )
         if cleanup_errors:
             cleanup_error = "; ".join(cleanup_errors)
             if agent_error is None:
                 agent_error = cleanup_error
             else:
-                logger.warning("%s", cleanup_error)
+                logger.warning("TaskRun cleanup failed: %s", cleanup_error)
 
         transcript_path = output_dir / f"transcript_{run_config.recipe_tag}.json"
         record = {
@@ -225,6 +239,8 @@ def _run_dashboard_task(
             "finish": finish_result,
             "stats": stats,
             "messages": _serialize_messages(messages),
+            "run_error": agent_error,
+            "cleanup_errors": cleanup_errors,
         }
         try:
             with open(transcript_path, "a") as transcript_file:

--- a/rpent/cli/main.py
+++ b/rpent/cli/main.py
@@ -1,3 +1,4 @@
+# Copyright 2026 RPent Contributors
 """Physical agent main CLI entrypoint."""
 # `rpent/cli/`
 #
@@ -74,6 +75,59 @@ def _serialize_messages(messages: list[dict]) -> list[dict]:
          "content": _strip_images(m.get("content"))}
         for m in messages
     ]
+
+
+def _merge_errors(*errors: str | None) -> str | None:
+    """Join independent run errors without dropping either source."""
+    present = [error for error in errors if error]
+    return "; ".join(present) if present else None
+
+
+def _finalize_and_cleanup(
+    *,
+    toolkit,
+    recipe_tag: str,
+    planner_result: dict | None,
+    planner_error: str | None,
+    daemons,
+):
+    """Finalize against a live environment, then release owned resources."""
+    finalization = None
+    finalization_error = None
+    cleanup_errors: list[str] = []
+
+    if toolkit is not None:
+        try:
+            finalization = toolkit.finalize_run(
+                planner_result=planner_result,
+                planner_error=planner_error,
+            )
+        except Exception as exc:
+            logger.error("failed to finalize run: %s", exc)
+            finalization_error = f"{type(exc).__name__}: {exc}"
+        else:
+            finalization_error = finalization.error
+
+        try:
+            recipe_path = toolkit.write_recipe(recipe_tag)
+            logger.info("recipe: %s", recipe_path)
+        except Exception as exc:
+            cleanup_errors.append(f"recipe write failed: {exc}")
+        try:
+            toolkit.close()
+        except Exception as exc:
+            cleanup_errors.append(f"toolkit cleanup failed: {exc}")
+
+    for daemon in daemons:
+        try:
+            daemon.stop()
+        except Exception as exc:
+            name = getattr(daemon, "name", type(daemon).__name__)
+            cleanup_errors.append(f"{name} cleanup failed: {exc}")
+
+    if cleanup_errors:
+        logger.warning("cleanup errors: %s", "; ".join(cleanup_errors))
+    return finalization, finalization_error, cleanup_errors
 
 
 # ---------------------------------------------------------------------------
@@ -223,24 +277,28 @@ def main() -> int:
         dashboard_events,
     )
 
-    # --- toolkit -----------------------------------------------------------
-    toolkit = get_toolkit(
-        env_name,
-        primitives_kwargs=primitives_kwargs,
-        dashboard_events=dashboard_events,
-    )
-
     # --- agent loop --------------------------------------------------------
     t0 = time.time()
-    finish_result, messages, agent_error = None, [], None
+    planner_result, finish_result, messages, agent_error = None, None, [], None
+    finalization = None
+    finalization_error: str | None = None
+    cleanup_errors: list[str] = []
     stats: dict = {}
+    toolkit = None
     first_user_msg: str | None = user_msg
-    if await_first_prompt is not None:
-        # Block until the opening prompt typed during startup is ready.
-        first_user_msg = await_first_prompt()
-        if first_user_msg is None:
-            logger.info("no task entered; ending session before start.")
     try:
+        # Toolkit construction may reset or capture from the environment, so
+        # it must be covered by the same cleanup path as planner execution.
+        toolkit = get_toolkit(
+            env_name,
+            primitives_kwargs=primitives_kwargs,
+            dashboard_events=dashboard_events,
+        )
+        if await_first_prompt is not None:
+            # Block until the opening prompt typed during startup is ready.
+            first_user_msg = await_first_prompt()
+            if first_user_msg is None:
+                logger.info("no task entered; ending session before start.")
         if first_user_msg is not None:
             dashboard_events.emit(RunStartedEvent())
             result = planner.solve(
@@ -250,7 +308,8 @@ def main() -> int:
                 max_turns=args.max_turns,
                 input_queue=input_queue,
             )
-            finish_result = result.finish_result
+            planner_result = result.finish_result
+            finish_result = planner_result
             messages = result.messages
             stats = result.stats
             agent_error = result.error
@@ -258,13 +317,17 @@ def main() -> int:
         logger.error("EXCEPTION in agent loop: %s", exc)
         agent_error = str(exc)
     finally:
-        # Agent-side: flush the episode video before the env+model
-        recipe_path = toolkit.write_recipe(recipe_tag)
-        logger.info("recipe: %s", recipe_path)
+        finalization, finalization_error, cleanup_errors = _finalize_and_cleanup(
+            toolkit=toolkit,
+            recipe_tag=recipe_tag,
+            planner_result=planner_result,
+            planner_error=agent_error,
+            daemons=daemons,
+        )
 
-        toolkit.close()
-        for d in daemons:
-            d.stop()
+    if finalization is not None:
+        finish_result = finalization.final_result
+    agent_error = _merge_errors(agent_error, finalization_error)
 
     elapsed = time.time() - t0
 
@@ -276,6 +339,8 @@ def main() -> int:
         "finish": finish_result,
         "stats": stats,
         "messages": _serialize_messages(messages),
+        "run_error": agent_error,
+        "cleanup_errors": cleanup_errors,
     }
     with open(transcript_path, "a") as f:
         json.dump(record, f, indent=2, default=str)

--- a/rpent/tools/toolkit.py
+++ b/rpent/tools/toolkit.py
@@ -22,7 +22,6 @@ from rpent.utils.templates import substitute
 if TYPE_CHECKING:
     from rpent.tools.state import EnvState, StepRecord
 
-
 @dataclass(slots=True)
 class _ToolOperation:
     cancel_event: threading.Event = field(default_factory=threading.Event)
@@ -120,6 +119,14 @@ class ToolResult:
         return blocks
 
 
+@dataclass(frozen=True, slots=True)
+class RunFinalization:
+    """Environment-neutral result derived after planner execution."""
+
+    final_result: dict[str, Any] | None
+    error: str | None = None
+
+
 class Toolkit:
     """Base toolkit: registers common tools and dispatches tool calls.
 
@@ -211,6 +218,16 @@ class Toolkit:
             self._active_operation = operation
 
         try:
+            try:
+                blocked = self.before_execute_tool(name, input_dict)
+            except Exception as error:  # noqa: BLE001
+                blocked = {
+                    "error": f"tool precondition failed: {error}",
+                    "traceback": traceback.format_exc(),
+                }
+            if blocked is not None:
+                return ToolResult(name=name, result=blocked)
+
             started = time.perf_counter()
             failed = False
             try:
@@ -264,6 +281,23 @@ class Toolkit:
             with self._operation_lock:
                 self._active_operation = None
                 operation.done_event.set()
+
+    def before_execute_tool(
+        self,
+        name: str,
+        input_dict: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Reject a tool call before its handler runs. Default: allow it."""
+        return None
+
+    def finalize_run(
+        self,
+        *,
+        planner_result: dict[str, Any] | None,
+        planner_error: str | None,
+    ) -> RunFinalization:
+        """Aggregate facts from an already-finished planner run."""
+        return RunFinalization(final_result=planner_result)
 
     def _publish_step(self, record: StepRecord) -> None:
         """Publish one recorded environment step to the dashboard sink."""


### PR DESCRIPTION
## Summary

- add pre-execution and post-result hooks to Toolkit
- add a run finalization hook for environment-specific result handling
- keep existing toolkit and LIBERO behavior unchanged through default implementations