### PR TITLE
docs: add LIBERO reproduction results

### DIFF
--- a/docs/source-en/rst_source/usage/libero.rst
+++ b/docs/source-en/rst_source/usage/libero.rst
@@ -201,8 +201,8 @@ client without touching the env by:
 
 See :doc:`../development/add_primitive` for the full walkthrough.
 
-Harness VLA reproduction results
---------------------------------
+Reproducing results
+-------------------
 
 The following results reproduce
 :doc:`Harness VLA <../awesome_works/harnessvla>` on two LIBERO-PRO suites.

--- a/docs/source-en/rst_source/usage/libero.rst
+++ b/docs/source-en/rst_source/usage/libero.rst
@@ -100,31 +100,6 @@ Minimal command
 
 To switch planners, see :doc:`configure_planner`.
 
-Reference reproduction results
-------------------------------
-
-On the `reproduce/libero
-<https://github.com/RLinf/RPent/tree/reproduce/libero>`_ branch, use
-``gpt-5.5`` to reproduce the following results:
-
-- ``libero_10_task``: 70% (70/100)
-- ``libero_10_swap``: 55% (55/100)
-
-Reproduction command:
-
-.. code-block:: bash
-
-   rpent --env libero \
-     --suite libero_10_task --task "task" --seed "seed" \
-     --planner codex \
-     --model gpt-5.5 \
-     --max-turns 100 \
-     --planner-timeout-s 5000 \
-     --max-episode-steps 10000 \
-     --libero-type pro \
-     --vla-endpoint http://127.0.0.1:8220 \
-     --sam3-endpoint http://127.0.0.1:8114
-
 What runs where
 ---------------
 
@@ -225,3 +200,30 @@ client without touching the env by:
    surface (e.g. ``pi0_pick`` → ``mymodel_pick``) needs to change.
 
 See :doc:`../development/add_primitive` for the full walkthrough.
+
+Harness VLA reproduction results
+--------------------------------
+
+The following results reproduce
+:doc:`Harness VLA <../awesome_works/harnessvla>` on two LIBERO-PRO suites.
+On the `reproduce/libero
+<https://github.com/RLinf/RPent/tree/reproduce/libero>`_ branch, use
+``gpt-5.5`` to reproduce these results:
+
+- ``libero_10_task``: 70% (70/100)
+- ``libero_10_swap``: 55% (55/100)
+
+Reproduction command:
+
+.. code-block:: bash
+
+   rpent --env libero \
+     --suite libero_10_task --task "task" --seed "seed" \
+     --planner codex \
+     --model gpt-5.5 \
+     --max-turns 100 \
+     --planner-timeout-s 5000 \
+     --max-episode-steps 10000 \
+     --libero-type pro \
+     --vla-endpoint http://127.0.0.1:8220 \
+     --sam3-endpoint http://127.0.0.1:8114

--- a/docs/source-en/rst_source/usage/libero.rst
+++ b/docs/source-en/rst_source/usage/libero.rst
@@ -100,6 +100,31 @@ Minimal command
 
 To switch planners, see :doc:`configure_planner`.
 
+Reference reproduction results
+------------------------------
+
+On the `reproduce/libero
+<https://github.com/RLinf/RPent/tree/reproduce/libero>`_ branch, use
+``gpt-5.5`` to reproduce the following results:
+
+- ``libero_10_task``: 70% (70/100)
+- ``libero_10_swap``: 55% (55/100)
+
+Reproduction command:
+
+.. code-block:: bash
+
+   rpent --env libero \
+     --suite libero_10_task --task "task" --seed "seed" \
+     --planner codex \
+     --model gpt-5.5 \
+     --max-turns 100 \
+     --planner-timeout-s 5000 \
+     --max-episode-steps 10000 \
+     --libero-type pro \
+     --vla-endpoint http://127.0.0.1:8220 \
+     --sam3-endpoint http://127.0.0.1:8114
+
 What runs where
 ---------------
 

--- a/docs/source-zh/rst_source/usage/libero.rst
+++ b/docs/source-zh/rst_source/usage/libero.rst
@@ -193,8 +193,8 @@ Dashboard launcher 支持 ``api``、``claude_code`` 和 ``codex`` planner。
 
 完整流程见 :doc:`../development/add_primitive`。
 
-Harness VLA 复现结果
---------------------
+结果复现
+--------
 
 以下是在两个 LIBERO-PRO 套件上复现
 :doc:`Harness VLA <../awesome_works/harnessvla>` 得到的结果。实验使用

--- a/docs/source-zh/rst_source/usage/libero.rst
+++ b/docs/source-zh/rst_source/usage/libero.rst
@@ -97,6 +97,31 @@ LIBERO-PRO 核心套件一览
 
 如需切换 planner，请参阅 :doc:`configure_planner`。
 
+参考复现结果
+------------
+
+在 `reproduce/libero
+<https://github.com/RLinf/RPent/tree/reproduce/libero>`_ 分支，使用
+``gpt-5.5`` 可复现以下结果：
+
+- ``libero_10_task``：70%（70/100）
+- ``libero_10_swap``：55%（55/100）
+
+复现命令如下：
+
+.. code-block:: bash
+
+   rpent --env libero \
+     --suite libero_10_task --task "task" --seed "seed" \
+     --planner codex \
+     --model gpt-5.5 \
+     --max-turns 100 \
+     --planner-timeout-s 5000 \
+     --max-episode-steps 10000 \
+     --libero-type pro \
+     --vla-endpoint http://127.0.0.1:8220 \
+     --sam3-endpoint http://127.0.0.1:8114
+
 进程分工
 --------
 

--- a/docs/source-zh/rst_source/usage/libero.rst
+++ b/docs/source-zh/rst_source/usage/libero.rst
@@ -97,31 +97,6 @@ LIBERO-PRO 核心套件一览
 
 如需切换 planner，请参阅 :doc:`configure_planner`。
 
-参考复现结果
-------------
-
-在 `reproduce/libero
-<https://github.com/RLinf/RPent/tree/reproduce/libero>`_ 分支，使用
-``gpt-5.5`` 可复现以下结果：
-
-- ``libero_10_task``：70%（70/100）
-- ``libero_10_swap``：55%（55/100）
-
-复现命令如下：
-
-.. code-block:: bash
-
-   rpent --env libero \
-     --suite libero_10_task --task "task" --seed "seed" \
-     --planner codex \
-     --model gpt-5.5 \
-     --max-turns 100 \
-     --planner-timeout-s 5000 \
-     --max-episode-steps 10000 \
-     --libero-type pro \
-     --vla-endpoint http://127.0.0.1:8220 \
-     --sam3-endpoint http://127.0.0.1:8114
-
 进程分工
 --------
 
@@ -217,3 +192,29 @@ Dashboard launcher 支持 ``api``、``claude_code`` 和 ``codex`` planner。
    相应更新 ``robots/libero/toolkit.py``。
 
 完整流程见 :doc:`../development/add_primitive`。
+
+Harness VLA 复现结果
+--------------------
+
+以下是在两个 LIBERO-PRO 套件上复现
+:doc:`Harness VLA <../awesome_works/harnessvla>` 得到的结果。实验使用
+`reproduce/libero <https://github.com/RLinf/RPent/tree/reproduce/libero>`_
+分支和 ``gpt-5.5`` 模型：
+
+- ``libero_10_task``：70%（70/100）
+- ``libero_10_swap``：55%（55/100）
+
+复现命令如下：
+
+.. code-block:: bash
+
+   rpent --env libero \
+     --suite libero_10_task --task "task" --seed "seed" \
+     --planner codex \
+     --model gpt-5.5 \
+     --max-turns 100 \
+     --planner-timeout-s 5000 \
+     --max-episode-steps 10000 \
+     --libero-type pro \
+     --vla-endpoint http://127.0.0.1:8220 \
+     --sam3-endpoint http://127.0.0.1:8114


### PR DESCRIPTION
## Summary

- document the reference `gpt-5.5` results on `reproduce/libero`
- add the reproduction command to the English and Chinese LIBERO guides

PRs #73 and #78 were fast-forwarded separately into `reproduce/libero` 