### PR TITLE
feat: support parallel MCP tool calls

### DIFF
--- a/docs/source-en/rst_source/development/add_primitive.rst
+++ b/docs/source-en/rst_source/development/add_primitive.rst
@@ -54,9 +54,14 @@ Adding a scripted primitive usually involves two steps:
               self._env.step(build_open_drawer_chunk(dx))
           return {"ok": True, "dx": dx}
 
-  You can mark read-only tools (``view_env_state``, ``back_project``, ``segment``,
-  ...) with :func:`~rpent.tools.toolkit.readonly` so the toolkit skips state
-  capture for them, improving performance.
+  Mark tools that do not advance the environment with
+  :func:`~rpent.tools.toolkit.readonly` so the toolkit skips state capture.
+  Add :func:`~rpent.tools.toolkit.parallel` when a read-only tool is also safe
+  to run concurrently, as with ``view_env_state`` and ``back_project``.
+  ``parallel`` requires ``readonly`` and is an explicit promise that the
+  handler only reads stable state and that all shared data it accesses is safe
+  for concurrent readers. A ``readonly`` tool without ``parallel`` remains
+  exclusive.
 
 2. **Add the tool schema.** Add an entry to ``TOOLS_SPEC`` in
    ``robots/<env>/tools.py``:

--- a/docs/source-zh/rst_source/development/add_primitive.rst
+++ b/docs/source-zh/rst_source/development/add_primitive.rst
@@ -51,9 +51,13 @@ primitives 方法，以及调用完成后的状态快照。区别仅在于方法
               self._env.step(build_open_drawer_chunk(dx))
           return {"ok": True, "dx": dx}
 
-   只读工具（``view_env_state``、``back_project``、``segment`` 等）
-     可以使用 :func:`~rpent.tools.toolkit.readonly` 标记，toolkit 会跳过
-     它们的状态捕获，提升性能。
+   不推进环境的工具可使用 :func:`~rpent.tools.toolkit.readonly`
+     标记，toolkit 会跳过状态捕获。如果该工具还可安全并行，例如
+     ``view_env_state`` 和 ``back_project``，再添加
+     :func:`~rpent.tools.toolkit.parallel` 标记。``parallel`` 必须与
+     ``readonly`` 同时使用，并明确承诺 handler 只读取稳定状态，而且其访问的
+     所有共享数据都支持并发读取。只有 ``readonly`` 而没有 ``parallel`` 的
+     工具仍保持独占执行。
 
 2. **添加工具定义。** 在 ``robots/<env>/tools.py`` 的 ``TOOLS_SPEC`` 中新增一项：
 

--- a/robots/libero/toolkit.py
+++ b/robots/libero/toolkit.py
@@ -121,6 +121,7 @@ class LiberoToolkit(Toolkit):
 
     def close(self) -> None:
         """Flush the agent-side video buffer through ``EnvState``."""
+        super().close()
         try:
             frames = self._primitives.stop_recording()
             if frames:

--- a/robots/libero/tools.py
+++ b/robots/libero/tools.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from robots.libero.env_client import LiberoEnvClient
 from rpent.tools.state import EnvState, StepRecord
-from rpent.tools.toolkit import readonly
+from rpent.tools.toolkit import parallel, readonly
 from rpent.utils.logging import get_logger
 from rpent.utils.sam3_client import Sam3Client
 from rpent.utils.vla_client import VLAClient
@@ -1409,6 +1409,7 @@ TOOLS_SPEC = [
 ]
 
 
+@parallel
 @readonly
 def view_env_state(step: int = -1, *, state: EnvState) -> dict:
     try:
@@ -1544,6 +1545,7 @@ def _make_segment_overlay(
     return overlay
 
 
+@parallel
 @readonly
 def view_camera_meta(
     camera: str = "agentview",
@@ -1569,6 +1571,7 @@ def view_camera_meta(
     return {"camera": "wrist", "step": record.step_idx, "camera_meta": meta}
 
 
+@parallel
 @readonly
 def back_project(
     row: int | None = None,

--- a/robots/robocasa/toolkit.py
+++ b/robots/robocasa/toolkit.py
@@ -5,7 +5,6 @@ RoboCasa primitives (``move_to``, ``rldx_skill``, ``release``, ...) on top.
 """
 from __future__ import annotations
 
-import time
 from functools import partial
 from typing import Any
 
@@ -136,6 +135,7 @@ class RoboCasaToolkit(Toolkit):
 
     def close(self) -> None:
         """Flush the agent-side video buffer through ``EnvState``."""
+        super().close()
         try:
             frames = self._primitives.stop_recording()
             if frames:

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from rpent.tools.state import EnvState, StepRecord
-from rpent.tools.toolkit import readonly
+from rpent.tools.toolkit import parallel, readonly
 
 if TYPE_CHECKING:
     from robots.robocasa.primitives import RoboCasaPrimitives
@@ -754,6 +754,7 @@ def _prune_heavy_artifacts(
 # ---- tool handlers (@readonly perception tools take state: EnvState) ----
 
 
+@parallel
 @readonly
 def view_env_state(step: int | None = None, *, state: EnvState) -> dict:
     """Read one recorded state with embedded camera / navview / wrist images."""
@@ -807,6 +808,7 @@ def view_env_state(step: int | None = None, *, state: EnvState) -> dict:
     return out
 
 
+@parallel
 @readonly
 def view_camera_meta(
     camera: str = "agentview",
@@ -818,6 +820,7 @@ def view_camera_meta(
     return {"error": "not implemented"}
 
 
+@parallel
 @readonly
 def back_project(
     row: int,
@@ -832,6 +835,7 @@ def back_project(
     return {"error": "not implemented"}
 
 
+@parallel
 @readonly
 def back_project_batch(
     pixels: list[list[int]],
@@ -903,6 +907,7 @@ def back_project_batch(
             "camera": camera, "resolution": resolution}
 
 
+@parallel
 @readonly
 def query_world_map(
     z_min: float = 0.85,

--- a/rpent/cli/main.py
+++ b/rpent/cli/main.py
@@ -258,11 +258,11 @@ def main() -> int:
         logger.error("EXCEPTION in agent loop: %s", exc)
         agent_error = str(exc)
     finally:
-        # Agent-side: flush the episode video before the env+model
+        # Drain tools and flush the episode video before env+model cleanup.
+        toolkit.close()
         recipe_path = toolkit.write_recipe(recipe_tag)
         logger.info("recipe: %s", recipe_path)
 
-        toolkit.close()
         for d in daemons:
             d.stop()
 

--- a/rpent/dashboard/planner_control.py
+++ b/rpent/dashboard/planner_control.py
@@ -17,12 +17,14 @@ class DashboardPlannerControl:
         *,
         interaction: DashboardInteractionPort,
         cancel_active_and_wait: Callable[[], None],
+        resume_operations: Callable[[], None],
         emit_user: Callable[[str], None],
         emit_initial_user: Callable[[], None],
         defer_message_ack: bool = False,
     ) -> None:
         self._interaction = interaction
         self._cancel_active_and_wait = cancel_active_and_wait
+        self._resume_operations = resume_operations
         self._emit_user = emit_user
         self._emit_initial_user = emit_initial_user
         self._defer_message_ack = defer_message_ack
@@ -79,7 +81,7 @@ class DashboardPlannerControl:
             self._interaction.mark_message_unsent(message_id)
 
     async def cancel_active_toolkit(self) -> None:
-        """Cancel and drain the active toolkit operation off the event loop."""
+        """Pause Toolkit admission and drain its operations off the event loop."""
         await asyncio.to_thread(self._cancel_active_and_wait)
 
     async def _process(self, driver: Any) -> None:
@@ -101,6 +103,7 @@ class DashboardPlannerControl:
                 try:
                     await self.cancel_active_toolkit()
                     completed = await driver.interrupt()
+                    self._resume_operations()
                     self._outstanding_completions = max(
                         0, self._outstanding_completions - completed
                     )

--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -292,6 +292,7 @@ class ApiAgentLoop:
         control = DashboardPlannerControl(
             interaction=interaction,
             cancel_active_and_wait=toolkit.cancel_active_and_wait,
+            resume_operations=toolkit.resume_operations,
             emit_user=emit_user,
             emit_initial_user=lambda: emit_user(user_message, initial=True),
             defer_message_ack=True,

--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -15,7 +15,7 @@ import dataclasses
 import json
 import queue
 from collections import deque
-from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +45,7 @@ from rpent.dashboard.interaction import DashboardInteractionPort, DashboardMessa
 from rpent.dashboard.planner_control import DashboardPlannerControl
 from rpent.planner.base import PlannerResult
 from rpent.tools.state import EnvState
-from rpent.tools.toolkit import Toolkit
+from rpent.tools.toolkit import Toolkit, parallel, readonly
 from rpent.utils.logging import get_logger
 
 logger = get_logger("api_loop")
@@ -60,6 +60,26 @@ _MAX_HISTORY_IMAGE_BYTES = 4 * 1024 * 1024
 #: Always retain at least this many of the most recent images, even if a single
 #: frame exceeds the byte budget, so the model never loses its current view.
 _MIN_RECENT_IMAGES = 2
+
+_READ_IMAGE_SPEC = {
+    "name": "read_image",
+    "description": "Read a step-scoped PNG artifact as visual input.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Artifact name from an environment observation.",
+            },
+            "step": {
+                "type": "integer",
+                "description": "Observation step; -1 selects the latest step.",
+                "default": -1,
+            },
+        },
+        "required": ["name"],
+    },
+}
 
 
 class ApiAgentLoop:
@@ -692,9 +712,14 @@ def _api_error_text(error: Exception, *, no_images: bool) -> str:
 
 
 def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
-    """Build the API-only image reader plus pydantic-ai toolkit wrappers."""
-    image_reader = _make_image_reader(toolkit.state, no_images=no_images)
-    tools: list[Tool] = [Tool(image_reader, name="read_image")]
+    """Register API-only tools and build pydantic-ai toolkit wrappers."""
+    image_reader = read_image_text_only if no_images else read_image
+    toolkit.add_tool(
+        "read_image",
+        _READ_IMAGE_SPEC,
+        partial(image_reader, state=toolkit.state),
+    )
+    tools: list[Tool] = []
     for spec in toolkit.get_tools_spec():
         name = spec["name"]
         tools.append(
@@ -710,65 +735,47 @@ def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
     return tools
 
 
-def _make_image_reader(
-    state: EnvState,
-    *,
-    no_images: bool,
-) -> Callable[[str, int], ToolReturn | dict[str, str] | str]:
-    if no_images:
-
-        def read_image_tool(name: str, step: int = -1) -> str:
-            return read_image_text_only(name, step, state=state)
-
-        read_image_tool.__name__ = "read_image"
-        read_image_tool.__doc__ = read_image_text_only.__doc__
-        return read_image_tool
-
-    def read_image_tool(
-        name: str, step: int = -1
-    ) -> ToolReturn | dict[str, str]:
-        return read_image(name, step, state=state)
-
-    read_image_tool.__name__ = "read_image"
-    read_image_tool.__doc__ = read_image.__doc__
-    return read_image_tool
-
-
+@parallel
+@readonly
 def read_image(
     name: str, step: int = -1, *, state: EnvState
-) -> ToolReturn | dict[str, str]:
+) -> dict[str, Any]:
     """Read a step-scoped image artifact as visual input.
 
     Artifact failures are returned as structured tool errors so a bad
     model-supplied name or step does not abort the agent run.
     """
     try:
-        resolved_step, path = _resolve_image_artifact(state, name, step)
-        content = BinaryContent(
-            data=state.load_bytes(name, step=resolved_step),
-            media_type=_image_media_type(path),
-        )
+        resolved_step, _ = _resolve_image_artifact(state, name, step)
+        image_bytes = state.load_bytes(name, step=resolved_step)
     except Exception as e:
         return {"error": str(e)}
-    return ToolReturn(
-        return_value={"artifact": name, "step": resolved_step},
-        content=[content],
-    )
+    return {
+        "artifact": name,
+        "step": resolved_step,
+        "_image_bytes": image_bytes,
+    }
 
 
+@parallel
+@readonly
 def read_image_text_only(
     name: str, step: int = -1, *, state: EnvState
-) -> str | dict[str, str]:
+) -> dict[str, Any]:
     """Acknowledge an image artifact without sending bytes to the model."""
     try:
         resolved_step, _ = _resolve_image_artifact(state, name, step)
     except Exception as e:
         return {"error": str(e)}
-    return (
-        f"Image artifact {name!r} exists at step {resolved_step}, but image "
-        "input is disabled (--no-images, text-only model). Reason from textual "
-        "state instead: view_env_state, back_project, and numeric tool results."
-    )
+    return {
+        "artifact": name,
+        "step": resolved_step,
+        "message": (
+            "Image input is disabled (--no-images, text-only model). Reason "
+            "from textual state instead: view_env_state, back_project, and "
+            "numeric tool results."
+        ),
+    }
 
 
 def _resolve_image_artifact(
@@ -782,13 +789,9 @@ def _resolve_image_artifact(
         raise FileNotFoundError(
             f"image artifact {name!r} is not available at step {step}"
         )
-    if path.suffix.lower() not in {".png", ".jpg", ".jpeg"}:
-        raise ValueError(f"artifact {name!r} is not an image")
+    if path.suffix.lower() != ".png":
+        raise ValueError(f"artifact {name!r} is not a PNG image")
     return record.step_idx, path
-
-
-def _image_media_type(path: Path) -> str:
-    return "image/jpeg" if path.suffix.lower() in {".jpg", ".jpeg"} else "image/png"
 
 
 def _make_tool_function(toolkit: Toolkit, name: str, *, no_images: bool = False):

--- a/rpent/planner/claude_code.py
+++ b/rpent/planner/claude_code.py
@@ -209,6 +209,7 @@ class ClaudeCodePlanner:
                         options,
                         recorder,
                         input_queue,
+                        toolkit=toolkit,
                         emit=_emit,
                         emit_user=_emit_user,
                     )
@@ -259,6 +260,7 @@ class ClaudeCodePlanner:
         recorder: "_Recorder",
         input_queue,
         *,
+        toolkit: Toolkit,
         emit,
         emit_user,
     ) -> None:
@@ -270,7 +272,12 @@ class ClaudeCodePlanner:
         sentinel (or ``/quit``) interrupts the run; the ``finish`` tool ends it
         normally. Because a human supervises, there is no wall-clock cap here.
         """
-        adapter = _TerminalSessionAdapter(input_queue=input_queue, emit_user=emit_user)
+        adapter = _TerminalSessionAdapter(
+            input_queue=input_queue,
+            cancel_active_and_wait=toolkit.cancel_active_and_wait,
+            resume_operations=toolkit.resume_operations,
+            emit_user=emit_user,
+        )
         driver = _ClaudeSessionDriver(
             sdk=sdk,
             options=options,
@@ -296,6 +303,7 @@ class ClaudeCodePlanner:
         adapter = _ClaudeDashboardAdapter(
             interaction=dashboard_interaction,
             cancel_active_and_wait=toolkit.cancel_active_and_wait,
+            resume_operations=toolkit.resume_operations,
             emit_user=emit_user,
             emit_initial_user=lambda: emit_user(
                 initial_user_text,
@@ -439,8 +447,17 @@ class _ClaudeSessionDriver:
 class _TerminalSessionAdapter:
     """Preserve the terminal TUI's interrupt-then-query steering policy."""
 
-    def __init__(self, *, input_queue: Any, emit_user) -> None:
+    def __init__(
+        self,
+        *,
+        input_queue: Any,
+        cancel_active_and_wait: Callable[[], None],
+        resume_operations: Callable[[], None],
+        emit_user,
+    ) -> None:
         self._input_queue = input_queue
+        self._cancel_active_and_wait = cancel_active_and_wait
+        self._resume_operations = resume_operations
         self._emit_user = emit_user
 
     async def initial_query_succeeded(self, driver: _ClaudeSessionDriver) -> None:
@@ -449,17 +466,23 @@ class _TerminalSessionAdapter:
     async def run(self, driver: _ClaudeSessionDriver) -> None:
         while True:
             nxt = await asyncio.to_thread(next_user_line, self._input_queue)
+            await asyncio.to_thread(self._cancel_active_and_wait)
             if nxt is None:
                 with contextlib.suppress(Exception):
                     await driver.interrupt()
                 return
-            self._emit_user(nxt)
             # Keep the current terminal semantics: every steering line
             # interrupts the in-flight turn, then enters the same session.
-            with contextlib.suppress(Exception):
+            try:
                 await driver.interrupt()
-            with contextlib.suppress(Exception):
+            except Exception:
+                return
+            self._resume_operations()
+            self._emit_user(nxt)
+            try:
                 await driver.query(nxt)
+            except Exception:
+                return
 
     async def on_message(
         self,
@@ -471,6 +494,7 @@ class _TerminalSessionAdapter:
     async def close(self) -> None:
         # Unblock next_user_line() if the consumer (for example finish) won.
         self._input_queue.put(None)
+        await asyncio.to_thread(self._cancel_active_and_wait)
 
 
 class _ClaudeDashboardAdapter:
@@ -481,12 +505,14 @@ class _ClaudeDashboardAdapter:
         *,
         interaction: DashboardInteractionPort,
         cancel_active_and_wait: Callable[[], None],
+        resume_operations: Callable[[], None],
         emit_user: Callable[[str], None],
         emit_initial_user: Callable[[], None],
     ) -> None:
         self._control = DashboardPlannerControl(
             interaction=interaction,
             cancel_active_and_wait=cancel_active_and_wait,
+            resume_operations=resume_operations,
             emit_user=emit_user,
             emit_initial_user=emit_initial_user,
         )
@@ -760,7 +786,6 @@ class _Recorder:
 
 def _build_rpent_server(sdk: Any, *, toolkit: Toolkit) -> Any:
     sdk_tools = []
-    tool_execution_lock = asyncio.Lock()
     for spec in toolkit.get_tools_spec():
         name = str(spec["name"])
         description = str(spec.get("description", ""))
@@ -771,12 +796,11 @@ def _build_rpent_server(sdk: Any, *, toolkit: Toolkit) -> Any:
             *,
             tool_name: str = name,
         ) -> dict[str, Any]:
-            async with tool_execution_lock:
-                result = await asyncio.to_thread(
-                    toolkit.execute_tool,
-                    tool_name,
-                    args or {},
-                )
+            result = await asyncio.to_thread(
+                toolkit.execute_tool,
+                tool_name,
+                args or {},
+            )
             return _tool_result_to_mcp(result)
 
         run_tool.__name__ = f"rpent_{name}"

--- a/rpent/planner/codex.py
+++ b/rpent/planner/codex.py
@@ -348,6 +348,7 @@ class CodexPlanner:
                 control = DashboardPlannerControl(
                     interaction=interaction,
                     cancel_active_and_wait=toolkit.cancel_active_and_wait,
+                    resume_operations=toolkit.resume_operations,
                     emit_user=emit_user,
                     emit_initial_user=lambda: emit_user(
                         initial_user_text, initial=True

--- a/rpent/tools/common.py
+++ b/rpent/tools/common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from rpent.tools.toolkit import readonly
+from rpent.tools.toolkit import parallel, readonly
 from rpent.utils.config import get_repo_root
 from rpent.utils.logging import get_output_dir
 
@@ -94,6 +94,7 @@ def _truncate(text: str, max_chars: int) -> str:
     )
 
 
+@parallel
 @readonly
 def read_text_file(path: str, max_chars: int = 40000) -> dict:
     p = _resolve(path)
@@ -116,6 +117,7 @@ def write_text_file(path: str, content: str) -> dict:
     return {"path": str(p), "bytes_written": len(content.encode("utf-8"))}
 
 
+@parallel
 @readonly
 def list_dir(path: str = "") -> dict:
     # Default to the current output dir (so parallel agents see their own).

--- a/rpent/tools/toolkit.py
+++ b/rpent/tools/toolkit.py
@@ -11,6 +11,7 @@ import json
 import threading
 import time
 import traceback
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import partial
@@ -23,10 +24,11 @@ if TYPE_CHECKING:
     from rpent.tools.state import EnvState, StepRecord
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, eq=False)
 class _ToolOperation:
+    is_parallel: bool
     cancel_event: threading.Event = field(default_factory=threading.Event)
-    done_event: threading.Event = field(default_factory=threading.Event)
+    cancelled_before_start: bool = False
 
 
 class ToolCancelled(Exception):
@@ -34,23 +36,26 @@ class ToolCancelled(Exception):
 
 
 def readonly(func):
-    """Mark a tool handler as not advancing environment state.
-
-    Tool handlers capture a fresh observation (:meth:`Toolkit.get_env_state`)
-    by default. Apply this marker to observational and file/IO tools that do
-    not move the robot or otherwise change the environment.
-    """
+    """Mark a tool handler as not advancing environment state."""
     func._readonly = True
     return func
 
 
-def _is_readonly(handler: Callable[..., Any]) -> bool:
-    """Whether ``handler`` was marked with :func:`readonly`."""
+def parallel(func):
+    """Mark a read-only tool handler as safe to run with other readers."""
+    func._parallel = True
+    return func
+
+
+def _tool_policy(handler: Callable[..., Any]) -> tuple[bool, bool]:
+    """Return ``(is_parallel, updates_env)`` for a registered handler."""
     target = handler
     while isinstance(target, partial):
         target = target.func
     target = getattr(target, "__func__", target)
-    return bool(getattr(target, "_readonly", False))
+    is_parallel = bool(getattr(target, "_parallel", False))
+    updates_env = not bool(getattr(target, "_readonly", False))
+    return is_parallel, updates_env
 
 
 @dataclass
@@ -131,7 +136,8 @@ class Toolkit:
     subclasses receive their env/model/etc. as constructor arguments and
     build the underlying env Primitives in ``__init__``; the toolkit
     base class only contributes the common file/IO tools. Override
-    :meth:`close` to release env-side primitives / servers at the end of the run.
+    :meth:`close` to release env-side primitives / servers at the end of the run,
+    and call ``super().close()`` before releasing them.
     """
 
     def __init__(
@@ -146,8 +152,15 @@ class Toolkit:
         ] = {}
         self._dashboard_events = dashboard_events
         self._state = state
-        self._operation_lock = threading.Lock()
-        self._active_operation: _ToolOperation | None = None
+        self._operation_condition = threading.Condition()
+        self._admission_queue: deque[_ToolOperation] = deque()
+        # Includes both queued and running calls so cancellation can drain all
+        # calls admitted before the gate closed.
+        self._registered_operations: set[_ToolOperation] = set()
+        self._running_readers = 0
+        self._active_exclusive_operation: _ToolOperation | None = None
+        self._admission_paused = False
+        self._closed = False
         self._register_common_tools()
 
     # ------------------------------------------------------------------
@@ -167,9 +180,16 @@ class Toolkit:
             spec: Anthropic-shaped tool schema dict (``name``,
                 ``description``, ``input_schema``).
             handler: Callable invoked with the tool's input kwargs; returns
-                a result dict. Decorate read-only handlers with
-                :func:`readonly`; all other handlers capture state.
+                a result dict. Decorate handlers that do not advance the
+                environment with :func:`readonly`, and add :func:`parallel`
+                when they are also safe to run concurrently. All other
+                handlers capture state after execution.
         """
+        is_parallel, updates_env = _tool_policy(handler)
+        if is_parallel and updates_env:
+            raise ValueError(
+                f"parallel tool {name!r} must also be marked readonly"
+            )
         self._tools[name] = (spec, handler)
 
     def _register_common_tools(self) -> None:
@@ -203,15 +223,17 @@ class Toolkit:
         if entry is None:
             return ToolResult(name=name, result={"error": f"unknown tool: {name}"})
         _, handler = entry
-
-        with self._operation_lock:
-            if self._active_operation is not None:
-                return ToolResult(
-                    name=name,
-                    result={"error": "another tool operation is still active"},
-                )
-            operation = _ToolOperation()
-            self._active_operation = operation
+        is_parallel, updates_env = _tool_policy(handler)
+        operation = self._begin_operation(is_parallel=is_parallel)
+        if operation is None:
+            return ToolResult(
+                name=name,
+                result={
+                    "error": "tool operation interrupted",
+                    "code": "tool_cancelled",
+                    "interrupted": True,
+                },
+            )
 
         try:
             started = time.perf_counter()
@@ -235,7 +257,7 @@ class Toolkit:
                 result = {"error": str(e), "traceback": traceback.format_exc()}
                 failed = True
 
-            if not _is_readonly(handler):
+            if updates_env:
                 elapsed_s = round(time.perf_counter() - started, 2)
                 result_dict = result if isinstance(result, dict) else {"value": result}
                 command = {"action": name, **input_dict}
@@ -264,9 +286,57 @@ class Toolkit:
 
             return ToolResult(name=name, result=result)
         finally:
-            with self._operation_lock:
-                self._active_operation = None
-                operation.done_event.set()
+            self._end_operation(operation)
+
+    def _begin_operation(self, *, is_parallel: bool) -> _ToolOperation | None:
+        """Register this call and wait for FIFO admission."""
+        with self._operation_condition:
+            if self._admission_paused or self._closed:
+                return None
+
+            operation = _ToolOperation(is_parallel=is_parallel)
+            self._registered_operations.add(operation)
+            self._admission_queue.append(operation)
+            self._operation_condition.wait_for(
+                lambda: operation.cancelled_before_start
+                or self._can_start_operation(operation)
+            )
+
+            if operation.cancelled_before_start:
+                self._registered_operations.discard(operation)
+                self._operation_condition.notify_all()
+                return None
+
+            self._admission_queue.popleft()
+            if operation.is_parallel:
+                self._running_readers += 1
+            else:
+                self._active_exclusive_operation = operation
+            # Wake the next queued reader so a consecutive reader group can
+            # enter without waiting for the first reader to finish.
+            self._operation_condition.notify_all()
+            return operation
+
+    def _can_start_operation(self, operation: _ToolOperation) -> bool:
+        """Return whether the FIFO head can enter the running set."""
+        if (
+            not self._admission_queue
+            or self._admission_queue[0] is not operation
+        ):
+            return False
+        if self._active_exclusive_operation is not None:
+            return False
+        return operation.is_parallel or self._running_readers == 0
+
+    def _end_operation(self, operation: _ToolOperation) -> None:
+        with self._operation_condition:
+            if operation.is_parallel:
+                self._running_readers -= 1
+            else:
+                if self._active_exclusive_operation is operation:
+                    self._active_exclusive_operation = None
+            self._registered_operations.discard(operation)
+            self._operation_condition.notify_all()
 
     def _publish_step(self, record: StepRecord) -> None:
         """Publish one recorded environment step to the dashboard sink."""
@@ -293,23 +363,40 @@ class Toolkit:
     # ------------------------------------------------------------------
 
     def cancel_active_and_wait(self) -> None:
-        """Request cancellation and wait for the active tool to return."""
-        with self._operation_lock:
-            operation = self._active_operation
-            if operation is None:
+        """Pause admission, cancel queued calls, and drain running calls."""
+        with self._operation_condition:
+            self._admission_paused = True
+            for operation in self._admission_queue:
+                operation.cancelled_before_start = True
+            self._admission_queue.clear()
+            if self._active_exclusive_operation is not None:
+                self._active_exclusive_operation.cancel_event.set()
+            self._operation_condition.notify_all()
+            self._operation_condition.wait_for(
+                lambda: not self._registered_operations
+            )
+
+    def resume_operations(self) -> None:
+        """Resume admission after a successful interrupt of the same run."""
+        with self._operation_condition:
+            if self._closed or not self._admission_paused:
                 return
-            operation.cancel_event.set()
-        operation.done_event.wait()
+            if self._registered_operations:
+                raise RuntimeError("cannot resume toolkit before operations drain")
+            self._admission_paused = False
 
     def raise_if_cancelled(self) -> None:
         """Raise at an environment-defined safe cancellation boundary."""
-        with self._operation_lock:
-            operation = self._active_operation
+        with self._operation_condition:
+            operation = self._active_exclusive_operation
         if operation is not None and operation.cancel_event.is_set():
             raise ToolCancelled("tool operation interrupted")
 
     def close(self) -> None:
-        """Release the env-side primitives / servers at end of run. Default: no-op."""
+        """Permanently stop tool admission and drain this toolkit."""
+        with self._operation_condition:
+            self._closed = True
+        self.cancel_active_and_wait()
 
     def write_recipe(self, recipe_tag: str) -> str | None:
         """Write a replay recipe for this env, if supported."""


### PR DESCRIPTION
## Summary

- Add a `@parallel` decorator to mark read-only tools that are safe to run concurrently. Parallel tools must also use `@readonly`.
- Run consecutive parallel tools concurrently, while keeping robot actions and other tools FIFO-exclusive.
- Reject new calls, cancel queued calls, and drain running calls during interruption or shutdown.
- Mark safe tools in the common, LIBERO, and RoboCasa toolkits as parallel.
- Keep the API-only PNG `read_image` tool on the normal Toolkit scheduling path.
