### PR TITLE
fix(libero): pin mujoco to 3.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ openpi = [
 ]
 libero = [
     "rpent-libero>=0.2.0",
+    "mujoco==3.3.0",
     "h5py",
 ]
 libero-pro = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ openpi = [
 ]
 libero = [
     "rpent-libero>=0.2.0",
+    # MuJoCo 3.4+ changes LIBERO state settling; see https://github.com/RLinf/RLinf/issues/1460.
     "mujoco==3.3.0",
     "h5py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ openpi = [
 ]
 libero = [
     "rpent-libero>=0.2.0",
-    # MuJoCo 3.4+ changes LIBERO state settling; see https://github.com/RLinf/RLinf/issues/1460.
+    # MuJoCo 3.4+ changes LIBERO settling, misplacing objects and reducing task success; see https://github.com/RLinf/RLinf/issues/1460.
     "mujoco==3.3.0",
     "h5py",
 ]


### PR DESCRIPTION
### Description

Pin `mujoco==3.3.0` in RPent's `libero` optional dependency group.

- `rpent[libero]` now installs the MuJoCo version expected by the saved LIBERO initial states and the evaluated checkpoints.
- `rpent[libero-pro]`, `rpent[libero-plus]`, and `rpent[full]` inherit the same pin through their existing dependency on `rpent[libero]`.
- The simulator distributions remain unchanged; RPent owns the compatibility constraint for its evaluation environment.

### Motivation and Context

LIBERO spatial task 5 declares that the black bowl starts on the ramekin, but its serialized initial states are captured before gravity settles the objects. The sampler places the bowl one centimeter above the support surface; because the saved values are object-center coordinates, this appears as an approximately 11 cm bowl-to-ramekin center-height difference. Loading the state is therefore only the first half of reset: the simulator must drop the bowl into the ramekin before the policy receives its first observation.

MuJoCo 3.4 changed that deterministic settling result. The upstream change was a correct [box-box contact-distance fix](https://github.com/google-deepmind/mujoco/commit/883836848a67e06752cde3a4f097c71c79bf4beb): the bowl collision model consists of 40 box geoms and the ramekin of 25, so this task exercises the changed calculation directly. With 3.3.x physics, the bowl seats inside the ramekin. With 3.4 and later, it catches the rim and finishes tilted and overhanging. This is not a MuJoCo regression to revert; the benchmark state depends on the older contact behavior.

The failure happens during reset, before rendering begins, so episode videos start after the premise has already been broken. It is also policy-dependent: the [cross-stack investigation](https://github.com/huggingface/lerobot/issues/4390) reports OpenVLA-OFT GRPO success falling from 98% with MuJoCo 3.3.0 to 12% with 3.8.1, while other policies degrade by different amounts. Allowing the resolver to select a newer MuJoCo version therefore makes results depend on installation date rather than only on the checkpoint and task.

The currently published `rpent-libero==0.2.0` wheel contains the same affected 50-state file (SHA-256 `2d2c50b7dcbf861fffa94d576f217ed34153e57487010d7a109a220d4d97189b`). RPent should consequently constrain its runnable environment until those benchmark states are replaced deliberately and all supported LIBERO variants and checkpoints are revalidated.

Related: [RLinf/RLinf#1460](https://github.com/RLinf/RLinf/issues/1460), [RLinf/RLinf#1496](https://github.com/RLinf/RLinf/pull/1496).

### How has this been tested?

- Ran a CPU-only settle probe for all 50 affected `rpent-libero==0.2.0` states using `/opt/venv/openvla` with a robosuite 1.5.2 overlay. Every state began with an 11.000 cm center-height difference. After 250 simulation steps, the mean bowl-to-ramekin XY offset was 1.453 cm with MuJoCo 3.3.0 and 3.721 cm with 3.8.1.
- Ran `uv pip install --dry-run --python /opt/venv/openvla/bin/python '.[libero]'`, `'.[libero-pro]'`, and `'.[libero-plus]'`. All three resolved MuJoCo 3.3.0 instead of the environment's installed 3.8.1 without modifying the environment.
- Ran `pre-commit run --files pyproject.toml`; the applicable identity checks passed and the Python-only Ruff hooks skipped the TOML file. Repository-wide Ruff still reports unrelated baseline violations on `main`.

### Additional information (optional, e.g., figures and logs):

The pin is intentionally exact rather than `<3.4`: it records the simulator version used for validation and prevents a future 3.3.x patch from silently changing benchmark physics again.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
