### PR TITLE
Refactor: lift RPC dispatch into RpcFacade base

### DIFF
--- a/docs/source-en/rst_source/development/add_primitive.rst
+++ b/docs/source-en/rst_source/development/add_primitive.rst
@@ -139,12 +139,11 @@ primitive requires a few additional components:
 
    .. code-block:: python
 
-      def get_toolkit(*, primitives_kwargs, dashboard_events, video_path=None):
+      def get_toolkit(*, primitives_kwargs, dashboard_events):
           from robots.myrobot.toolkit import MyRobotToolkit
           return MyRobotToolkit(
               primitives_kwargs=primitives_kwargs,
               dashboard_events=dashboard_events,
-              video_path=video_path,
           )
 
    The robot package's ``_init_runtime`` builds

--- a/docs/source-en/rst_source/development/add_primitive.rst
+++ b/docs/source-en/rst_source/development/add_primitive.rst
@@ -134,7 +134,7 @@ primitive requires a few additional components:
    same pattern as for a scripted primitive.
 
 5. **Wire the components together in ``robot_spec.py``.** The
-   environment's ``get_toolkit`` builds the toolkit with
+   robot's ``get_toolkit`` builds the toolkit with
    ``primitives_kwargs``:
 
    .. code-block:: python

--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -157,13 +157,11 @@ the server-side facade registers each name explicitly.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mirror the client's API in a facade class on the server side (e.g.
-``MyEnvFacade``). Subclass
-:class:`rpent.robots.components.env_facade_base.BaseEnvFacade`; it provides the common RPC
-routes and read/write dispatch locking. Implement the common environment
-methods and extend ``_register_rpc`` for environment-specific routes. Methods
-take the same positional / keyword arguments the client sends and return
-transport-supported Python / NumPy values (not torch — the agent side does not
-import torch).
+``MyEnvFacade``). Subclass :class:`~rpent.robots.components.env_facade_base.BaseEnvFacade`,
+register environment-specific methods in ``_register_rpc``, and delegate
+startup to ``self.serve(...)``. Methods take the same positional / keyword
+arguments the client sends and return pickleable values (numpy, not torch —
+the agent side does not import torch).
 
 .. code-block:: python
 
@@ -174,17 +172,19 @@ import torch).
            self._env = env
            self._meta = dict(meta)
            super().__init__()
+           self._env = env
+           self._meta = meta
 
        def _register_rpc(self):
            super()._register_rpc()
-           self._rpc["env.render_camera"] = self.render_camera
+           # Custom methods must be registered explicitly
+           self._rpc["env.custom_method"] = self.custom_method
 
-       def get_env_meta(self): return dict(self._meta)
+       # Abstract methods required by BaseEnvFacade
        def reset(self): ...
        def step(self, action): ...
-       def chunk_step(self, actions, *, return_all_frames=False): ...
-       def render_camera(self, camera_name): ...
-       def close(self): ...
+
+       def custom_method(self, arg): ...
 
    facade = MyEnvFacade(env, meta)
    facade.serve(transport="http", host=host, port=port)

--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -72,12 +72,11 @@ these two functions:
            dashboard=MYROBOT_DASHBOARD_SPEC,
        )
 
-   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink, video_path=None):
+   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink):
        from robots.myrobot.toolkit import MyRobotToolkit
        return MyRobotToolkit(
            primitives_kwargs=primitives_kwargs,
            dashboard_events=dashboard_events,
-           video_path=video_path,
        )
 
    def _add_cli_args(parser, use_dashboard) -> None:
@@ -101,7 +100,7 @@ these two functions:
        ...
 
 ``dashboard`` is optional. Leave it as ``None`` if the environment does not
-support Dashboard control. Otherwise, define the spec in the environment
+support Dashboard control. Otherwise, define the spec in the robot
 package: its ``task`` section describes the command, validated fields, display
 template, and output slug; ``runtime_components`` and ``frame_channels``
 describe the environment-specific rows and camera views rendered by the
@@ -275,7 +274,7 @@ filenames rather than maintaining a parallel observation index.
 **Toolkit class** — subclass ``rpent.tools.toolkit.Toolkit``:
 
 - build the primitives in ``__init__`` through a custom initialization
-  helper (named ``init_primitives_clean`` in LIBERO; it calls
+  helper (named ``init_primitives`` in LIBERO; it calls
   ``EnvState.reset()``, constructs the primitives, and dumps step 0),
 - register each tool with ``self.add_tool(name, spec, handler)`` — stateless
   readers (``view_env_state``, ``finish``, …) bind directly to module-level

--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -103,7 +103,7 @@ these two functions:
 support Dashboard control. Otherwise, define the spec in the robot
 package: its ``task`` section describes the command, validated fields, display
 template, and output slug; ``runtime_components`` and ``frame_channels``
-describe the environment-specific rows and camera views rendered by the
+describe the robot-specific rows and camera views rendered by the
 frontend. See ``robots/libero/robot_spec.py`` for the reference shape.
 
 That's the entire registration step — ``_resolve_robot(name)`` does an
@@ -156,11 +156,13 @@ the server-side facade registers each name explicitly.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mirror the client's API in a facade class on the server side (e.g.
-``MyEnvFacade``). Subclass :class:`~rpent.robots.components.env_facade_base.BaseEnvFacade`,
-register environment-specific methods in ``_register_rpc``, and delegate
-startup to ``self.serve(...)``. Methods take the same positional / keyword
-arguments the client sends and return pickleable values (numpy, not torch —
-the agent side does not import torch).
+``MyEnvFacade``). Subclass
+:class:`rpent.robots.components.env_facade_base.BaseEnvFacade`; it provides the common RPC
+routes and read/write dispatch locking. Implement the common environment
+methods and extend ``_register_rpc`` for environment-specific routes. Methods
+take the same positional / keyword arguments the client sends and return
+transport-supported Python / NumPy values (not torch — the agent side does not
+import torch).
 
 .. code-block:: python
 
@@ -169,10 +171,7 @@ the agent side does not import torch).
    class MyEnvFacade(BaseEnvFacade):
        def __init__(self, env, meta):
            self._env = env
-           self._meta = dict(meta)
            super().__init__()
-           self._env = env
-           self._meta = meta
 
        def _register_rpc(self):
            super()._register_rpc()
@@ -202,7 +201,7 @@ teardown.
 
 Define two prompt factories, ``system_prompt()`` and ``user_prompt()``, and
 build a ``PromptBundle(system=system_prompt, user=user_prompt)`` in the
-environment's ``robot_spec.py`` (see the entry point above). Each factory returns an ordered
+robot's ``robot_spec.py`` (see the entry point above). Each factory returns an ordered
 ``dict[str, PromptNode]`` of titled sections; ``PromptBundle.render`` assembles
 and fills them. One prompt serves every planner (API loop, Claude Code, Codex):
 refer to tools by their bare names (``move_to``, ...) and note once that the
@@ -384,11 +383,11 @@ overlap. See ``robots/libero/robot_spec.py`` for the ordered component registry
 used by the reference implementation.
 
 Endpoint parsing (``--env-endpoint``, ``--vla-endpoint``, and LIBERO's
-``--sam3-endpoint``) and environment-specific server commands belong in the
+``--sam3-endpoint``) and robot-specific server commands belong in the
 hook that owns the corresponding service. Wrap those spawners with
 ``rpent.robots.runtime.try_spawn_server`` and ``try_wait_server`` so status
 events, readiness failures, and owned-daemon cleanup stay consistent across
-environments. The runners do not handle these environment details. See
+robots. The runners do not handle these environment details. See
 ``robots/libero/robot_spec.py`` and ``robots/robocasa/robot_spec.py`` for the
 reference pattern.
 

--- a/docs/source-en/rst_source/development/architecture.rst
+++ b/docs/source-en/rst_source/development/architecture.rst
@@ -155,7 +155,7 @@ two factories exposed by that package:
 
 ``RobotSpec`` gathers the robot's identity, prompt templates, optional
 Dashboard description, and three runner hooks (``add_cli_args`` /
-``parse_config`` / ``init_runtime``),. See :doc:`interfaces` for what each
+``parse_config`` / ``init_runtime``). See :doc:`interfaces` for what each
 field must provide.
 
 The loader itself does not maintain a list of robot names. The

--- a/docs/source-en/rst_source/development/architecture.rst
+++ b/docs/source-en/rst_source/development/architecture.rst
@@ -150,13 +150,13 @@ two factories exposed by that package:
    # robots/myrobot/__init__.py
    def get_robot_spec() -> RobotSpec: ...  # identity, prompt bundle, and runner hooks
    def get_toolkit(
-       *, primitives_kwargs, dashboard_events, video_path=None
+       *, primitives_kwargs, dashboard_events
    ): ...
 
-``RobotSpec`` gathers the environment's identity, prompt templates, optional
-Dashboard description, and three runner hooks: ``add_cli_args`` /
-``parse_config`` / ``init_runtime``. See :doc:`interfaces` for what each field
-must provide.
+``RobotSpec`` gathers the robot's identity, prompt templates, optional
+Dashboard description, and three runner hooks (``add_cli_args`` /
+``parse_config`` / ``init_runtime``),. See :doc:`interfaces` for what each
+field must provide.
 
 The loader itself does not maintain a list of robot names. The
 current CLI restricts ``--robot`` to ``libero`` and ``robocasa``; adding a

--- a/docs/source-en/rst_source/development/interfaces.rst
+++ b/docs/source-en/rst_source/development/interfaces.rst
@@ -124,8 +124,11 @@ for large or history-stacked nested-NumPy observations to move length-prefixed
 pickle frames and skip repeated JSON encoding. Pickle is unsafe on untrusted
 input, so only point ``socket`` at trusted endpoints.
 
-Server: subclass ``rpent.utils.rpc.RpcFacade`` and register business RPC methods
-in ``_register_rpc`` (e.g. ``reset``, ``step``, ``predict``). Do not implement
-``healthz`` or ``shutdown`` in the subclass.
+Environment and VLA clients should normally subclass ``BaseEnvClient`` and
+``BaseVLAClient``; their servers should subclass ``BaseEnvFacade`` and
+``BaseVLAFacade`` and register extension routes through ``_register_rpc``. The
+bases provide common routing and locking on top of ``RpcFacade``. Subclass
+``RpcFacade`` directly only for a service type without a specialized base. Do
+not implement ``healthz`` or ``shutdown`` in application subclasses.
 
 Details are in the env_server / vla_server sections of :doc:`add_robot`.

--- a/docs/source-en/rst_source/development/interfaces.rst
+++ b/docs/source-en/rst_source/development/interfaces.rst
@@ -122,11 +122,8 @@ for large or history-stacked nested-NumPy observations to move length-prefixed
 pickle frames and skip repeated JSON encoding. Pickle is unsafe on untrusted
 input, so only point ``socket`` at trusted endpoints.
 
-Environment and VLA clients should normally subclass ``BaseEnvClient`` and
-``BaseVLAClient``; their servers should subclass ``BaseEnvFacade`` and
-``BaseVLAFacade`` and register extension routes through ``_register_rpc``. The
-bases provide common routing and locking on top of ``RpcFacade``. Subclass
-``RpcFacade`` directly only for a service type without a specialized base. Do
-not implement ``healthz`` or ``shutdown`` in application subclasses.
+Server: subclass ``rpent.utils.rpc.RpcFacade`` and register business RPC methods
+in ``_register_rpc`` (e.g. ``reset``, ``step``, ``predict``). Do not implement
+``healthz`` or ``shutdown`` in the subclass.
 
 Details are in the env_server / vla_server sections of :doc:`add_robot`.

--- a/docs/source-en/rst_source/development/interfaces.rst
+++ b/docs/source-en/rst_source/development/interfaces.rst
@@ -13,7 +13,7 @@ functions implemented in ``robot_spec.py`` for ``main.py`` to call:
 .. code-block:: python
 
    def get_robot_spec() -> RobotSpec: ...
-   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink, video_path=None): ...
+   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink): ...
 
 ``get_robot_spec`` returns a ``RobotSpec``. You supply:
 
@@ -45,8 +45,10 @@ functions implemented in ``robot_spec.py`` for ``main.py`` to call:
        reports status.
 
 ``get_toolkit`` usually just passes ``primitives_kwargs`` into your robot subclass;
-``dashboard_events`` and ``video_path`` are supplied by the active runner, so
-you normally do not need to change them.
+``dashboard_events`` is supplied by the active runner. Robots that need extra
+run-context arguments (LIBERO adds ``mode``, ``attempts_per_session``,
+``state_output_dir``) declare them as keyword-only parameters and rely on the
+runner to pass them in the robot's CLI branch.
 
 Reference: ``robots/libero/robot_spec.py``.
 

--- a/docs/source-zh/rst_source/development/add_primitive.rst
+++ b/docs/source-zh/rst_source/development/add_primitive.rst
@@ -124,12 +124,11 @@ primitives 方法，以及调用完成后的状态快照。区别仅在于方法
 
    .. code-block:: python
 
-      def get_toolkit(*, primitives_kwargs, dashboard_events, video_path=None):
+      def get_toolkit(*, primitives_kwargs, dashboard_events):
           from robots.myrobot.toolkit import MyRobotToolkit
           return MyRobotToolkit(
               primitives_kwargs=primitives_kwargs,
               dashboard_events=dashboard_events,
-              video_path=video_path,
           )
 
    机器人包中的 ``_init_runtime`` 则负责构造 ``primitives_kwargs``，例如

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -144,10 +144,11 @@ slug，``runtime_components`` 与 ``frame_channels`` 描述前端展示的环境
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 在 ``env_server`` 中定义与 client API 对应的 facade 类，例如
-``MyEnvFacade``。该类继承 :class:`~rpent.robots.components.env_facade_base.BaseEnvFacade`，
-在 ``_register_rpc`` 中注册环境特有方法，再通过 ``self.serve(...)`` 启动服务。
-方法接收与 client 一致的位置参数和关键字参数，返回可 pickle 的值
-（使用 numpy，不要返回 torch；agent 进程不导入 torch）。
+``MyEnvFacade``。该类继承
+:class:`rpent.robots.components.env_facade_base.BaseEnvFacade`；基类已提供公共 RPC 路由和
+读写分派锁。子类实现公共环境方法，并通过 ``_register_rpc`` 增加环境专用路由。
+方法接收与 client 一致的位置参数和关键字参数，返回传输层支持的 Python / NumPy
+值（不要返回 torch；agent 进程不导入 torch）。
 
 .. code-block:: python
 
@@ -156,10 +157,7 @@ slug，``runtime_components`` 与 ``frame_channels`` 描述前端展示的环境
    class MyEnvFacade(BaseEnvFacade):
        def __init__(self, env, meta):
            self._env = env
-           self._meta = dict(meta)
            super().__init__()
-           self._env = env
-           self._meta = meta
 
        def _register_rpc(self):
            super()._register_rpc()
@@ -185,7 +183,7 @@ socket）、提供 ``healthz`` 和 ``shutdown``、检测父进程退出并执行
 2. ``prompt_bundle.py``
 -----------------------
 
-定义 ``system_prompt()`` 和 ``user_prompt()`` 两个 prompt 工厂，并在环境的
+定义 ``system_prompt()`` 和 ``user_prompt()`` 两个 prompt 工厂，并在机器人的
 ``robot_spec.py`` 中构造
 ``PromptBundle(system=system_prompt, user=user_prompt)``（见上面的“入口”）。
 每个工厂返回一个有序的 ``dict[str, PromptNode]``，其中包含带标题的分节；

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -145,11 +145,10 @@ slug，``runtime_components`` 与 ``frame_channels`` 描述前端展示的环境
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 在 ``env_server`` 中定义与 client API 对应的 facade 类，例如
-``MyEnvFacade``。该类继承
-:class:`rpent.robots.components.env_facade_base.BaseEnvFacade`；基类已提供公共 RPC 路由和
-读写分派锁。子类实现公共环境方法，并通过 ``_register_rpc`` 增加环境专用路由。
-方法接收与 client 一致的位置参数和关键字参数，返回传输层支持的 Python / NumPy
-值（不要返回 torch；agent 进程不导入 torch）。
+``MyEnvFacade``。该类继承 :class:`~rpent.robots.components.env_facade_base.BaseEnvFacade`，
+在 ``_register_rpc`` 中注册环境特有方法，再通过 ``self.serve(...)`` 启动服务。
+方法接收与 client 一致的位置参数和关键字参数，返回可 pickle 的值
+（使用 numpy，不要返回 torch；agent 进程不导入 torch）。
 
 .. code-block:: python
 
@@ -160,17 +159,19 @@ slug，``runtime_components`` 与 ``frame_channels`` 描述前端展示的环境
            self._env = env
            self._meta = dict(meta)
            super().__init__()
+           self._env = env
+           self._meta = meta
 
        def _register_rpc(self):
            super()._register_rpc()
-           self._rpc["env.render_camera"] = self.render_camera
+           # 自定义方法需额外注册
+           self._rpc["env.custom_method"] = self.custom_method
 
-       def get_env_meta(self): return dict(self._meta)
+       # BaseEnvFacade 要求的抽象方法必须实现
        def reset(self): ...
        def step(self, action): ...
-       def chunk_step(self, actions, *, return_all_frames=False): ...
-       def render_camera(self, camera_name): ...
-       def close(self): ...
+
+       def custom_method(self, arg): ...
 
    facade = MyEnvFacade(env, meta)
    facade.serve(transport="http", host=host, port=port)

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -65,12 +65,11 @@ RPent 的整体进程划分、服务职责和通信方式见 :doc:`系统设计 
            dashboard=MYROBOT_DASHBOARD_SPEC,
        )
 
-   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink, video_path=None):
+   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink):
        from robots.myrobot.toolkit import MyRobotToolkit
        return MyRobotToolkit(
            primitives_kwargs=primitives_kwargs,
            dashboard_events=dashboard_events,
-           video_path=video_path,
        )
 
    def _add_cli_args(parser, use_dashboard) -> None:
@@ -256,7 +255,7 @@ step index；该 ``StepRecord`` 会被立即追加并提交。大型观测通过
 **Toolkit 类** 继承 ``rpent.tools.toolkit.Toolkit``：
 
 - 在 ``__init__`` 中通过自定义的初始化辅助方法构建 primitives（LIBERO
-  中的方法名为 ``init_primitives_clean``；它会调用 ``EnvState.reset()``、构造
+  中的方法名为 ``init_primitives``；它会调用 ``EnvState.reset()``、构造
   原语并 dump 第 0 步）,
 - 用 ``self.add_tool(name, spec, handler)`` 注册每个工具。无状态的读取工具
   （如 ``view_env_state``、``finish``）直接绑定模块级函数；原语工具通过

--- a/docs/source-zh/rst_source/development/architecture.rst
+++ b/docs/source-zh/rst_source/development/architecture.rst
@@ -131,11 +131,11 @@ planner 后端集中在 ``rpent/planner/``，
    # robots/myrobot/__init__.py
    def get_robot_spec() -> RobotSpec: ...  # 机器人标识、提示词模板与 Runner 钩子
    def get_toolkit(
-       *, primitives_kwargs, dashboard_events, video_path=None
+       *, primitives_kwargs, dashboard_events
    ): ...
 
-``RobotSpec`` 汇集了环境标识、prompt 模板、可选的 Dashboard 描述与三个 Runner
-钩子：``add_cli_args`` / ``parse_config`` / ``init_runtime``。各字段要填什么见
+``RobotSpec`` 汇集了机器人标识、prompt 模板、可选的 Dashboard 描述与三个 Runner
+钩子（``add_cli_args`` / ``parse_config`` / ``init_runtime``）。各字段要填什么见
 :doc:`interfaces`。
 
 加载器本身不维护机器人名称列表。当前 CLI 将 ``--robot`` 限定为 ``libero``

--- a/docs/source-zh/rst_source/development/interfaces.rst
+++ b/docs/source-zh/rst_source/development/interfaces.rst
@@ -13,7 +13,7 @@
 .. code-block:: python
 
    def get_robot_spec() -> RobotSpec: ...
-   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink, video_path=None): ...
+   def get_toolkit(*, primitives_kwargs, dashboard_events: DashboardEventSink): ...
 
 ``get_robot_spec`` 返回 ``RobotSpec``，其中你需要提供：
 
@@ -42,7 +42,9 @@
        的 shared 和 unique 子集后分别传入。``DashboardEventSink`` 用于上报运行时状态。
 
 ``get_toolkit`` 一般只需把 ``primitives_kwargs`` 传给机器人子类；
-``dashboard_events``、``video_path`` 由当前 runner 传入，通常不用改。
+``dashboard_events`` 由当前 runner 传入。如果机器人需要额外的运行上下文参数
+（LIBERO 追加了 ``mode``、``attempts_per_session``、``state_output_dir``），以
+keyword-only 参数声明，由 runner 在该机器人的 CLI 分支中显式传入。
 
 参考实现：``robots/libero/robot_spec.py``。
 

--- a/docs/source-zh/rst_source/development/interfaces.rst
+++ b/docs/source-zh/rst_source/development/interfaces.rst
@@ -112,9 +112,7 @@ runtime 钩子中解析）：
 观测数据很大、或是多帧堆叠的嵌套 NumPy 字典时可改 ``socket``，用带长度前缀的
 pickle 数据帧传输，省掉反复的 JSON 编解码。pickle 不适合不可信输入，socket 只应连接可信端点。
 
-环境和 VLA client 通常应分别继承 ``BaseEnvClient``、``BaseVLAClient``；服务端
-分别继承 ``BaseEnvFacade``、``BaseVLAFacade``，并通过 ``_register_rpc`` 注册
-扩展路由。这些基类在 ``RpcFacade`` 之上提供公共路由和锁。只有尚无专用基类的
-服务类型才直接继承 ``RpcFacade``。业务子类不必实现 ``healthz`` / ``shutdown``。
+服务端：继承 ``rpent.utils.rpc.RpcFacade``，在 ``_register_rpc`` 中注册业务 RPC
+方法（如 ``reset``、``step``、``predict``）。``healthz`` / ``shutdown`` 不必在子类里写。
 
 细节见 :doc:`add_robot` 中的 env_server 与 vla_server 章节。

--- a/docs/source-zh/rst_source/development/interfaces.rst
+++ b/docs/source-zh/rst_source/development/interfaces.rst
@@ -114,7 +114,9 @@ runtime 钩子中解析）：
 观测数据很大、或是多帧堆叠的嵌套 NumPy 字典时可改 ``socket``，用带长度前缀的
 pickle 数据帧传输，省掉反复的 JSON 编解码。pickle 不适合不可信输入，socket 只应连接可信端点。
 
-服务端：继承 ``rpent.utils.rpc.RpcFacade``，在 ``_register_rpc`` 中注册业务 RPC
-方法（如 ``reset``、``step``、``predict``）。``healthz`` / ``shutdown`` 不必在子类里写。
+环境和 VLA client 通常应分别继承 ``BaseEnvClient``、``BaseVLAClient``；服务端
+分别继承 ``BaseEnvFacade``、``BaseVLAFacade``，并通过 ``_register_rpc`` 注册
+扩展路由。这些基类在 ``RpcFacade`` 之上提供公共路由和锁。只有尚无专用基类的
+服务类型才直接继承 ``RpcFacade``。业务子类不必实现 ``healthz`` / ``shutdown``。
 
 细节见 :doc:`add_robot` 中的 env_server 与 vla_server 章节。

--- a/robots/libero/env_client.py
+++ b/robots/libero/env_client.py
@@ -55,10 +55,10 @@ class LiberoEnvClient(BaseEnvClient):
         self.truncated |= bool(np.asarray(trunc).any())
 
     def reset(self) -> tuple[dict, Any]:
-        self.last_obs, _ = super().reset()
+        self.last_obs, info = super().reset()
         self.terminated = False
         self.truncated = False
-        return ret
+        return self.last_obs, info
 
     def step(self, action) -> tuple[dict, Any, np.ndarray, Any, Any]:
         assert not (self.terminated or self.truncated), (
@@ -103,15 +103,8 @@ class LiberoEnvClient(BaseEnvClient):
         width: int = 1024,
         depth: bool = False,
     ):
-        return self._client.call(
-            "env.render_camera",
-            kwargs={
-                "camera_name": camera_name,
-                "height": height,
-                "width": width,
-                "depth": depth,
-            },
-            timeout_s=self._TIMEOUT_S["env.render_camera"],
+        return super().render_camera(
+            camera_name, height=height, width=width, depth=depth
         )
 
     def get_camera_meta(
@@ -120,13 +113,4 @@ class LiberoEnvClient(BaseEnvClient):
         height: int = 256,
         width: int = 256,
     ) -> dict | None:
-        return self._client.call(
-            "env.get_camera_meta",
-            kwargs={"camera_name": camera_name, "height": height, "width": width},
-            timeout_s=self._TIMEOUT_S["default"],
-        )
-
-    def get_task_language(self) -> str | None:
-        return self._client.call(
-            "env.get_task_language", timeout_s=self._TIMEOUT_S["default"]
-        )
+        return super().get_camera_meta(camera_name, height=height, width=width)

--- a/robots/libero/env_client.py
+++ b/robots/libero/env_client.py
@@ -55,8 +55,7 @@ class LiberoEnvClient(BaseEnvClient):
         self.truncated |= bool(np.asarray(trunc).any())
 
     def reset(self) -> tuple[dict, Any]:
-        ret = super().reset()
-        self.last_obs = ret[0]
+        self.last_obs, _ = super().reset()
         self.terminated = False
         self.truncated = False
         return ret

--- a/robots/libero/tools.py
+++ b/robots/libero/tools.py
@@ -89,7 +89,7 @@ class LiberoPrimitives:
         return frames
 
     def frame_slice(self, start: int) -> list[np.ndarray]:
-        return list(self._frames[int(start):])
+        return list(self._frames[int(start) :])
 
     def set_obs(self, obs):
         self._last_obs = obs

--- a/robots/libero/tools.py
+++ b/robots/libero/tools.py
@@ -89,7 +89,7 @@ class LiberoPrimitives:
         return frames
 
     def frame_slice(self, start: int) -> list[np.ndarray]:
-        return list(self._frames[int(start) :])
+        return list(self._frames[int(start):])
 
     def set_obs(self, obs):
         self._last_obs = obs

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -42,7 +42,6 @@ CAM_ALIAS = {
 class RoboCasaEnvClient(BaseEnvClient):
     _TIMEOUT_S = {
         **BaseEnvClient._TIMEOUT_S,
-        "env.render_camera": 120.0,
         "env.grasp_contact": 10.0,
     }
 
@@ -124,11 +123,7 @@ class RoboCasaEnvClient(BaseEnvClient):
         cam = self._resolve_cam(camera_name)
         h = height or self.camera_h
         w = width or self.camera_w
-        return self._client.call(
-            "env.get_camera_meta",
-            kwargs={"camera_name": cam, "height": h, "width": w},
-            timeout_s=self._TIMEOUT_S["default"],
-        )
+        return super().get_camera_meta(cam, height=h, width=w)
 
     def world_map(self, camera_name, height=None, width=None):
         """HxWx3 world xyz per pixel, TOP-DOWN (row 0 = image top), pixel-aligned

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -42,24 +42,14 @@ CAM_ALIAS = {
 class RoboCasaEnvClient(BaseEnvClient):
     _TIMEOUT_S = {
         **BaseEnvClient._TIMEOUT_S,
-        "env.render_raw": 120.0,
+        "env.render_camera": 120.0,
         "env.grasp_contact": 10.0,
     }
 
     def __init__(self, client: RpcClient, *, expected_meta: dict):
-        self._client = client
-        server_meta = self._client.call(
-            "env.get_env_meta", timeout_s=self._TIMEOUT_S["default"]
-        )
-        assert server_meta == expected_meta, (
-            f"env_meta mismatch: expected={expected_meta!r} "
-            f"actual={server_meta!r}. The env_server was launched with "
-            "different args than this client expects — kill the stale "
-            "env_server and relaunch."
-        )
-        self.camera_h = server_meta["camera_h"]
-        self.camera_w = server_meta["camera_w"]
-        self.reset()
+        super().__init__(client, expected_meta=expected_meta)
+        self.camera_h = expected_meta["camera_h"]
+        self.camera_w = expected_meta["camera_w"]
 
     def _resolve_cam(self, name):
         return CAM_ALIAS.get(name, name)
@@ -92,12 +82,6 @@ class RoboCasaEnvClient(BaseEnvClient):
         return self.check_success()
 
     @property
-    def action_dim(self):
-        return self._client.call(
-            "env.get_action_dim", timeout_s=self._TIMEOUT_S["default"]
-        )
-
-    @property
     def current_raw_obs(self):
         return self.last_obs
 
@@ -114,11 +98,6 @@ class RoboCasaEnvClient(BaseEnvClient):
         return np.array(self.last_obs.get("robot0_gripper_qpos", []), dtype=np.float64)
 
     # ---- task info ----
-    def get_ep_meta(self):
-        return self._client.call(
-            "env.get_ep_meta", timeout_s=self._TIMEOUT_S["default"]
-        )
-
     def get_success_criteria_text(self):
         return self._client.call(
             "env.get_success_criteria_text", timeout_s=self._TIMEOUT_S["default"]
@@ -130,13 +109,11 @@ class RoboCasaEnvClient(BaseEnvClient):
         )
 
     # ---- rendering / perception ----
-    def render_raw(self, cam, h, w, depth):
+    def render_camera(self, cam, h, w, depth):
         """Low-level render — takes already-resolved cam and actual h/w."""
-        return self._client.call(
-            "env.render_raw",
+        return self._client.call("env.render_camera",
             kwargs={"cam": cam, "h": h, "w": w, "depth": depth},
-            timeout_s=self._TIMEOUT_S["env.render_raw"],
-        )
+            timeout_s=self._TIMEOUT_S["env.render_camera"])
 
     def render_camera(self, camera_name, height=None, width=None, depth=False):
         """Agent-facing: vertically flip to top-down so the rgb reads naturally and
@@ -145,9 +122,9 @@ class RoboCasaEnvClient(BaseEnvClient):
         h = height or self.camera_h
         w = width or self.camera_w
         if depth:
-            rgb, real = self.render_raw(cam, h, w, True)
+            rgb, real = self.render_camera(cam, h, w, True)
             return rgb[::-1], real[::-1]
-        return self.render_raw(cam, h, w, False)[::-1]
+        return self.render_camera(cam, h, w, False)[::-1]
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         cam = self._resolve_cam(camera_name)
@@ -168,8 +145,8 @@ class RoboCasaEnvClient(BaseEnvClient):
         cam = self._resolve_cam(camera_name)
         h = height or self.camera_h
         w = width or self.camera_w
-        _, z_native = self.render_raw(cam, h, w, True)  # metric depth, bottom-up
-        z = z_native[::-1]  # -> top-down
+        _, z_native = self.render_camera(cam, h, w, True)      # metric depth, bottom-up
+        z = z_native[::-1]                                  # -> top-down
         T_p2w = self._client.call(
             "env.get_camera_transform",
             kwargs={"camera_name": cam, "height": h, "width": w},

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -109,12 +109,6 @@ class RoboCasaEnvClient(BaseEnvClient):
         )
 
     # ---- rendering / perception ----
-    def render_camera(self, cam, h, w, depth):
-        """Low-level render — takes already-resolved cam and actual h/w."""
-        return self._client.call("env.render_camera",
-            kwargs={"cam": cam, "h": h, "w": w, "depth": depth},
-            timeout_s=self._TIMEOUT_S["env.render_camera"])
-
     def render_camera(self, camera_name, height=None, width=None, depth=False):
         """Agent-facing: vertically flip to top-down so the rgb reads naturally and
         is pixel-aligned with world_map()."""
@@ -122,9 +116,9 @@ class RoboCasaEnvClient(BaseEnvClient):
         h = height or self.camera_h
         w = width or self.camera_w
         if depth:
-            rgb, real = self.render_camera(cam, h, w, True)
+            rgb, real = super().render_camera((cam, h, w, True)
             return rgb[::-1], real[::-1]
-        return self.render_camera(cam, h, w, False)[::-1]
+        return super().render_camera((cam, h, w, False)[::-1]
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         cam = self._resolve_cam(camera_name)
@@ -145,7 +139,7 @@ class RoboCasaEnvClient(BaseEnvClient):
         cam = self._resolve_cam(camera_name)
         h = height or self.camera_h
         w = width or self.camera_w
-        _, z_native = self.render_camera(cam, h, w, True)      # metric depth, bottom-up
+        _, z_native = super().render_camera((cam, h, w, True)      # metric depth, bottom-up
         z = z_native[::-1]                                  # -> top-down
         T_p2w = self._client.call(
             "env.get_camera_transform",

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -53,10 +53,6 @@ class RoboCasaEnvClient(BaseEnvClient):
     def _resolve_cam(self, name):
         return CAM_ALIAS.get(name, name)
 
-    # ---- lifecycle ----
-    def close(self):
-        self._client.call("env.close", timeout_s=self._TIMEOUT_S["default"])
-
     # ---- state accessors ----
     def reset(self):
         self.last_obs = self._client.call(

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -130,8 +130,10 @@ class RoboCasaEnvClient(BaseEnvClient):
         cam = self._resolve_cam(camera_name)
         h = height or self.camera_h
         w = width or self.camera_w
-        _, z_native = super().render_camera(cam, height=h, width=w, depth=True)      # metric depth, bottom-up
-        z = z_native[::-1]                                  # -> top-down
+        _, z_native = super().render_camera(
+            cam, height=h, width=w, depth=True
+        )  # metric depth, bottom-up
+        z = z_native[::-1]  # -> top-down
         T_p2w = self._client.call(
             "env.get_camera_transform",
             kwargs={"camera_name": cam, "height": h, "width": w},

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -116,9 +116,9 @@ class RoboCasaEnvClient(BaseEnvClient):
         h = height or self.camera_h
         w = width or self.camera_w
         if depth:
-            rgb, real = super().render_camera((cam, h, w, True)
+            rgb, real = super().render_camera(cam, height=h, width=w, depth=True)
             return rgb[::-1], real[::-1]
-        return super().render_camera((cam, h, w, False)[::-1]
+        return super().render_camera(cam, height=h, width=w, depth=False)[::-1]
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         cam = self._resolve_cam(camera_name)
@@ -139,7 +139,7 @@ class RoboCasaEnvClient(BaseEnvClient):
         cam = self._resolve_cam(camera_name)
         h = height or self.camera_h
         w = width or self.camera_w
-        _, z_native = super().render_camera((cam, h, w, True)      # metric depth, bottom-up
+        _, z_native = super().render_camera(cam, height=h, width=w, depth=True)      # metric depth, bottom-up
         z = z_native[::-1]                                  # -> top-down
         T_p2w = self._client.call(
             "env.get_camera_transform",

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -130,28 +130,19 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         """Register all RPC methods."""
         super()._register_rpc()
         self._rpc["env.check_success"] = self.check_success
-        self._rpc["env.render_raw"] = self.render_raw
-        self._rpc["env.get_camera_meta"] = self.get_camera_meta
         self._rpc["env.get_camera_transform"] = self.get_camera_transform
-        self._rpc["env.get_ep_meta"] = self.get_ep_meta
-        self._rpc["env.get_action_dim"] = self.get_action_dim
         self._rpc["env.grasp_contact"] = self.grasp_contact
         self._rpc["env.reassemble_env_action"] = self.reassemble_env_action
         self._rpc["env.get_success_criteria_text"] = self.get_success_criteria_text
         self._rpc["env.get_task_progress"] = self.get_task_progress
         # Read-only methods
-        self._readonly_methods.update(
-            [
-                "env.get_camera_meta",
-                "env.get_camera_transform",
-                "env.get_ep_meta",
-                "env.get_action_dim",
-                "env.check_success",
-                "env.grasp_contact",
-                "env.get_success_criteria_text",
-                "env.get_task_progress",
-            ]
-        )
+        self._readonly_methods.update([
+            "env.check_success",
+            "env.get_camera_transform",
+            "env.grasp_contact",
+            "env.get_success_criteria_text",
+            "env.get_task_progress",
+        ])
 
     def get_env_meta(self):
         return self._meta
@@ -189,7 +180,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
     def check_success(self):
         return bool(self.env._check_success())
 
-    def render_raw(self, cam, h, w, depth):
+    def render_camera(self, cam, h, w, depth):
         """sim.render in ROBOSUITE-NATIVE orientation (matches the camera
         transform matrices). rgb uint8 HxWx3, depth metric HxW."""
         import robosuite.utils.camera_utils as CU
@@ -232,11 +223,8 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         T = CU.get_camera_transform_matrix(self.env.sim, camera_name, height, width)
         return np.linalg.inv(T)  # T_p2w
 
-    def get_ep_meta(self):
-        return self.env.get_ep_meta()
-
-    def get_action_dim(self):
-        return self.env.action_dim
+    def get_task_language(self) -> str | None:
+        return self.env.get_task_language().get("lang")
 
     def grasp_contact(self):
         """Check if the gripper is currently contacting a task object."""
@@ -392,7 +380,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
                 event, req = item
                 try:
                     req["result"] = self._dispatch(
-                        req["method"], req["args"], req["kwargs"]
+                        req["method"], req["args"], req["kwargs"],
                     )
                 except Exception:
                     req["error"] = traceback.format_exc()

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -136,13 +136,15 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         self._rpc["env.get_success_criteria_text"] = self.get_success_criteria_text
         self._rpc["env.get_task_progress"] = self.get_task_progress
         # Read-only methods
-        self._readonly_methods.update([
-            "env.check_success",
-            "env.get_camera_transform",
-            "env.grasp_contact",
-            "env.get_success_criteria_text",
-            "env.get_task_progress",
-        ])
+        self._readonly_methods.update(
+            [
+                "env.check_success",
+                "env.get_camera_transform",
+                "env.grasp_contact",
+                "env.get_success_criteria_text",
+                "env.get_task_progress",
+            ]
+        )
 
     def get_env_meta(self):
         return self._meta
@@ -184,7 +186,10 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         """sim.render in ROBOSUITE-NATIVE orientation (matches the camera
         transform matrices). rgb uint8 HxWx3, depth metric HxW."""
         import robosuite.utils.camera_utils as CU
-        out = self.env.sim.render(width=width, height=height, camera_name=camera_name, depth=depth)
+
+        out = self.env.sim.render(
+            width=width, height=height, camera_name=camera_name, depth=depth
+        )
         if depth:
             rgb, d = out
             # Sanitize the raw OpenGL normalized depth into [0,1]: replace NaN/inf
@@ -379,7 +384,9 @@ class RoboCasaEnvFacade(BaseEnvFacade):
                 event, req = item
                 try:
                     req["result"] = self._dispatch(
-                        req["method"], req["args"], req["kwargs"],
+                        req["method"],
+                        req["args"],
+                        req["kwargs"],
                     )
                 except Exception:
                     req["error"] = traceback.format_exc()

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -180,12 +180,11 @@ class RoboCasaEnvFacade(BaseEnvFacade):
     def check_success(self):
         return bool(self.env._check_success())
 
-    def render_camera(self, cam, h, w, depth):
+    def render_camera(self, camera_name, height, width, depth):
         """sim.render in ROBOSUITE-NATIVE orientation (matches the camera
         transform matrices). rgb uint8 HxWx3, depth metric HxW."""
         import robosuite.utils.camera_utils as CU
-
-        out = self.env.sim.render(width=w, height=h, camera_name=cam, depth=depth)
+        out = self.env.sim.render(width=width, height=height, camera_name=camera_name, depth=depth)
         if depth:
             rgb, d = out
             # Sanitize the raw OpenGL normalized depth into [0,1]: replace NaN/inf

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -228,7 +228,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         return np.linalg.inv(T)  # T_p2w
 
     def get_task_language(self) -> str | None:
-        return self.env.get_task_language().get("lang")
+        return self.env.get_ep_meta().get("lang")
 
     def grasp_contact(self):
         """Check if the gripper is currently contacting a task object."""

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -425,6 +425,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             work_queue.put(None)
             server.shutdown()
             server.server_close()
+            self.close()
 
 
 def main():

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -426,8 +426,9 @@ class RoboCasaPrimitives:
         if use_prompt:
             task_lang = prompt
         else:
-            task_lang = (self.env.current_raw_obs.get("language")
-                         or self.env.get_task_language()) or prompt
+            task_lang = (
+                self.env.current_raw_obs.get("language") or self.env.get_task_language()
+            ) or prompt
         # Auto-reseed history if a non-VLA primitive ran since the last VLA call
         # (read _vla_desync BEFORE clearing it)
         fr = bool(force_reset) or self._vla_desync

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -394,7 +394,7 @@ class RoboCasaPrimitives:
         """
         o = self.env.current_raw_obs
         return {
-            "task_language": o.get("language", self.env.get_ep_meta().get("lang", "")),
+            "task_language": o.get("language", self.env.get_task_language()),
             "success": self.env.check_success(),
             # NUMERIC progress toward success (counters/sub-predicates the env's own
             # _check_success computes) so the agent has a feedback loop, not just a bool.
@@ -426,10 +426,8 @@ class RoboCasaPrimitives:
         if use_prompt:
             task_lang = prompt
         else:
-            task_lang = (
-                self.env.current_raw_obs.get("language")
-                or self.env.get_ep_meta().get("lang", "")
-            ) or prompt
+            task_lang = (self.env.current_raw_obs.get("language")
+                         or self.env.get_task_language()) or prompt
         # Auto-reseed history if a non-VLA primitive ran since the last VLA call
         # (read _vla_desync BEFORE clearing it)
         fr = bool(force_reset) or self._vla_desync

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -394,7 +394,7 @@ class RoboCasaPrimitives:
         """
         o = self.env.current_raw_obs
         return {
-            "task_language": o.get("language", self.env.get_task_language()),
+            "task_language": o.get("language", self.env.get_task_language()) or "",
             "success": self.env.check_success(),
             # NUMERIC progress toward success (counters/sub-predicates the env's own
             # _check_success computes) so the agent has a feedback loop, not just a bool.

--- a/robots/robocasa/rldx_skill.py
+++ b/robots/robocasa/rldx_skill.py
@@ -334,7 +334,7 @@ class RLDXSkill:
             grip_prev = grip_now
         grip = float(self.env.gripper_qpos[0])
         base1 = np.asarray(self.env.current_raw_obs["robot0_base_pos"], np.float64)[:2]
-        # ── ROBUST, DIRECTION-AGNOSTIC GRASP DETERMINATION ──────────────────────────
+        # ---- ROBUST, DIRECTION-AGNOSTIC GRASP DETERMINATION ----
         # Primary (gold): fingerpad↔object CONTACT now (works for any grasp orientation,
         # incl. sideways; does NOT depend on Z-lift). Secondary: the commanded-close-but-
         # held-apart signal — the gripper was told to CLOSE but the fingers stopped before

--- a/robots/robocasa/vla_client.py
+++ b/robots/robocasa/vla_client.py
@@ -20,16 +20,15 @@ from rpent.robots.components.vla_client_base import BaseVLAClient
 
 
 class RoboCasaVLAClient(BaseVLAClient):
-    _TIMEOUT_S = {
-        **BaseVLAClient._TIMEOUT_S,
-    }
+    _TIMEOUT_S = BaseVLAClient._TIMEOUT_S
 
     def __init__(self, client):
         super().__init__(client)
 
     def get_modality_config(self) -> dict:
         return self._client.call(
-            "vla.get_modality_config", timeout_s=self._TIMEOUT_S["default"]
+            "vla.get_modality_config",
+            timeout_s=self._TIMEOUT_S["default"],
         )
 
     def predict(self, obs_dict: dict, options: dict) -> dict:

--- a/robots/robotwin/env_client.py
+++ b/robots/robotwin/env_client.py
@@ -228,13 +228,6 @@ class RoboTwinEnvClient(BaseEnvClient):
             raise TypeError(f"RoboTwin camera metadata must be a mapping: {result!r}")
         return result
 
-    def get_task_language(self) -> str:
-        """Return the current RoboTwin task instruction."""
-        result = self._read("get_task_language")
-        if not isinstance(result, str):
-            raise TypeError(f"RoboTwin task language must be a string: {result!r}")
-        return result
-
     def plan_arm_path(self, arm: str, target_pose) -> dict[str, Any]:
         """Plan a native arm path to the target end-effector pose."""
         return self._read(

--- a/robots/robotwin/env_client.py
+++ b/robots/robotwin/env_client.py
@@ -53,18 +53,6 @@ class RoboTwinEnvClient(BaseEnvClient):
             raise TypeError(f"{method} must return a {size}-item tuple, got {result!r}")
         return tuple(result)
 
-    def _read(
-        self,
-        method: str,
-        *,
-        kwargs: dict[str, Any] | None = None,
-    ) -> Any:
-        return self._client.call(
-            f"env.{method}",
-            kwargs=kwargs,
-            timeout_s=ROBOTWIN_READ_TIMEOUT_S,
-        )
-
     def _require_common_active(self) -> None:
         if self.terminated or self.truncated:
             raise RuntimeError("RoboTwin common episode is terminal; reset is required")
@@ -208,10 +196,7 @@ class RoboTwinEnvClient(BaseEnvClient):
             )
         if not isinstance(depth, bool):
             raise TypeError("RoboTwin camera depth flag must be bool")
-        return self._read(
-            "render_camera",
-            kwargs={"camera_name": camera_name, "depth": depth},
-        )
+        return super().render_camera(camera_name, depth=depth)
 
     def get_camera_meta(self, camera_name: str) -> dict[str, Any]:
         """Return calibration metadata for one RoboTwin camera."""
@@ -220,17 +205,12 @@ class RoboTwinEnvClient(BaseEnvClient):
                 f"unknown RoboTwin camera {camera_name!r}; "
                 f"available={list(ROBOTWIN_CAMERA_NAMES)}"
             )
-        result = self._read(
-            "get_camera_meta",
-            kwargs={"camera_name": camera_name},
-        )
-        if not isinstance(result, dict):
-            raise TypeError(f"RoboTwin camera metadata must be a mapping: {result!r}")
-        return result
+        return super().get_camera_meta(camera_name)
 
     def plan_arm_path(self, arm: str, target_pose) -> dict[str, Any]:
         """Plan a native arm path to the target end-effector pose."""
-        return self._read(
-            "plan_arm_path",
+        return self._client.call(
+            "env.plan_arm_path",
             kwargs={"arm": arm, "target_pose": target_pose},
+            timeout_s=ROBOTWIN_READ_TIMEOUT_S,
         )

--- a/robots/robotwin/env_client.py
+++ b/robots/robotwin/env_client.py
@@ -207,6 +207,13 @@ class RoboTwinEnvClient(BaseEnvClient):
             )
         return super().get_camera_meta(camera_name)
 
+    def get_task_language(self) -> str:
+        """Return the current RoboTwin task instruction."""
+        result = super().get_task_language()
+        if not isinstance(result, str):
+            raise TypeError(f"RoboTwin task language must be a string: {result!r}")
+        return result
+
     def plan_arm_path(self, arm: str, target_pose) -> dict[str, Any]:
         """Plan a native arm path to the target end-effector pose."""
         return self._client.call(

--- a/robots/robotwin/env_server.py
+++ b/robots/robotwin/env_server.py
@@ -136,6 +136,9 @@ class RoboTwinEnvFacade(BaseEnvFacade):
         """Return immutable identity for endpoint compatibility checks."""
         return dict(self._metadata)
 
+    def close(self):
+        _teardown_env(self._env)
+
     def reset(self) -> tuple[dict[str, Any], dict[str, Any]]:
         seed = int(self._metadata["seed"])
         observation, info = self._env.reset(env_idx=[0], env_seeds=[seed])
@@ -357,15 +360,12 @@ def main() -> None:
             max_episode_steps=args.max_episode_steps,
         ),
     )
-    try:
-        facade.serve(
-            transport=args.transport,
-            host=args.host,
-            port=args.port,
-            parent_watch=args.parent_watch,
-        )
-    finally:
-        _teardown_env(env)
+    facade.serve(
+        transport=args.transport,
+        host=args.host,
+        port=args.port,
+        parent_watch=args.parent_watch,
+    )
 
 
 if __name__ == "__main__":

--- a/robots/robotwin/env_server.py
+++ b/robots/robotwin/env_server.py
@@ -129,26 +129,8 @@ class RoboTwinEnvFacade(BaseEnvFacade):
         return array[0].item()
 
     def _register_rpc(self) -> None:
-        self._rpc.update(
-            {
-                "env.get_env_meta": self.get_env_meta,
-                "env.reset": self.reset,
-                "env.step": self.step,
-                "env.chunk_step": self.chunk_step,
-                "env.render_camera": self.render_camera,
-                "env.get_camera_meta": self.get_camera_meta,
-                "env.get_task_language": self.get_task_language,
-                "env.plan_arm_path": self.plan_arm_path,
-            }
-        )
-        self._readonly_methods.update(
-            {
-                "env.get_env_meta",
-                "env.render_camera",
-                "env.get_camera_meta",
-                "env.get_task_language",
-            }
-        )
+        super()._register_rpc()
+        self._rpc["env.plan_arm_path"] = self.plan_arm_path
 
     def get_env_meta(self) -> dict[str, Any]:
         """Return immutable identity for endpoint compatibility checks."""

--- a/rpent/robots/components/env_client_base.py
+++ b/rpent/robots/components/env_client_base.py
@@ -27,6 +27,7 @@ class BaseEnvClient:
         "env.reset": 120.0,
         "env.step": 60.0,
         "env.chunk_step": 120.0,
+        "env.render_camera": 120.0,
     }
 
     def __init__(self, client, *, expected_meta: dict):
@@ -92,3 +93,23 @@ class BaseEnvClient:
         else:
             self.last_obs = obs_field
         return result
+
+    def get_camera_meta(self, camera_name, **kwargs):
+        return self._client.call(
+            "env.get_camera_meta",
+            kwargs={"camera_name": camera_name, **kwargs},
+            timeout_s=self._TIMEOUT_S["default"],
+        )
+
+    def render_camera(self, camera_name, **kwargs):
+        return self._client.call(
+            "env.render_camera",
+            kwargs={"camera_name": camera_name, **kwargs},
+            timeout_s=self._TIMEOUT_S["env.render_camera"],
+        )
+
+    def get_task_language(self) -> str | None:
+        """Return the language description of the current task."""
+        return self._client.call(
+            "env.get_task_language", timeout_s=self._TIMEOUT_S["default"]
+        )

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -65,16 +65,28 @@ class BaseEnvFacade(RpcFacade):
         raise NotImplementedError
 
     def close(self):
-        raise NotImplementedError
+        pass
 
     def _register_rpc(self):
         """Can be overridden to register more RPC methods."""
-        self._rpc["env.reset"] = self.reset
         self._rpc["env.get_env_meta"] = self.get_env_meta
         self._rpc["env.close"] = self.close
+
+        self._rpc["env.reset"] = self.reset
         self._rpc["env.step"] = self.step
         self._rpc["env.chunk_step"] = self.chunk_step
-        self._readonly_methods.add("env.get_env_meta")
+
+        self._rpc["env.get_task_language"] = self.get_task_language
+        self._rpc["env.get_camera_meta"] = self.get_camera_meta
+        self._rpc["env.render_camera"] = self.render_camera
+
+        # Read-only methods that can run parallel
+        self._readonly_methods.update([
+            "env.get_env_meta",
+            "env.get_task_language",
+            "env.get_camera_meta",
+            "env.render_camera",
+        ])
 
     def _dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
         handler = self._rpc.get(method)

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -83,23 +83,23 @@ class BaseEnvFacade(RpcFacade):
         ])
 
     # ---- abstract methods (subclasses must override) ----
-    def reset(self):
+    def reset(self, *args, **kwargs):
         """Reset the env and return ``(initial_obs, info)``."""
         raise NotImplementedError
 
-    def step(self):
+    def step(self, *args, **kwargs):
         """Execute one env action. Returns the gym tuple result."""
         raise NotImplementedError
 
-    def chunk_step(self):
+    def chunk_step(self, *args, **kwargs):
         """Execute N actions in one batch. Returns the gym tuple result."""
         raise NotImplementedError
 
-    def get_camera_meta(self):
+    def get_camera_meta(self, *args, **kwargs):
         raise NotImplementedError
 
-    def render_camera(self):
+    def render_camera(self, *args, **kwargs):
         raise NotImplementedError
 
-    def get_task_language(self):
+    def get_task_language(self, *args, **kwargs):
         raise NotImplementedError

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -71,12 +71,14 @@ class BaseEnvFacade(RpcFacade):
         self._rpc["env.render_camera"] = self.render_camera
 
         # Read-only methods that can run parallel
-        self._readonly_methods.update([
-            "env.get_env_meta",
-            "env.get_task_language",
-            "env.get_camera_meta",
-            "env.render_camera",
-        ])
+        self._readonly_methods.update(
+            [
+                "env.get_env_meta",
+                "env.get_task_language",
+                "env.get_camera_meta",
+                "env.render_camera",
+            ]
+        )
 
     # ---- abstract methods (subclasses must override) ----
     def reset(self, *args, **kwargs):

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -118,3 +118,12 @@ class BaseEnvFacade(RpcFacade):
           it before executing any action.
         """
         raise NotImplementedError
+
+    def get_camera_meta(self):
+        raise NotImplementedError
+
+    def render_camera(self):
+        raise NotImplementedError
+
+    def get_task_language(self):
+        raise NotImplementedError

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -87,20 +87,12 @@ class BaseEnvFacade(RpcFacade):
         """Reset the env and return ``(initial_obs, info)``."""
         raise NotImplementedError
 
-    def step(self, flat_action):
-        """Execute one env action. Returns the gym 5-tuple result."""
+    def step(self):
+        """Execute one env action. Returns the gym tuple result."""
         raise NotImplementedError
 
-    def chunk_step(self, flat_actions, *, return_all_frames: bool = False):
-        """Execute N actions in one batch. Returns the 5-tuple result.
-
-        - ``obs_or_list``: ``list[Obs]`` when ``return_all_frames=True`` (one
-          per step, carrying the per-step render); the final obs dict when
-          ``False``.
-        - ``return_all_frames``: optional capability for backends that can
-          return one observation per action. Unsupported backends must reject
-          it before executing any action.
-        """
+    def chunk_step(self):
+        """Execute N actions in one batch. Returns the gym tuple result."""
         raise NotImplementedError
 
     def get_camera_meta(self):

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -18,10 +18,7 @@ backend: ``docs/source-zh/rst_source/development/add_env.rst``.
 
 from __future__ import annotations
 
-from typing import Any, Callable
-
 from rpent.utils.rpc import RpcFacade
-from rpent.utils.rwlock import RWLock
 
 
 class BaseEnvFacade(RpcFacade):
@@ -40,9 +37,9 @@ class BaseEnvFacade(RpcFacade):
            client owns the caching policy.
 
     RPC routing:
-        ``_dispatch`` uses a registration dict (``self._rpc``) instead of
-        dynamic ``getattr`` routing. Subclasses register their own methods in
-        ``_register_rpc``.
+        ``_dispatch`` (inherited from :class:`RpcFacade`) uses a
+        registration dict (``self._rpc``) instead of dynamic ``getattr``
+        routing. Subclasses register their own methods in ``_register_rpc``.
 
     EGL single-thread:
         Subclasses that must keep EGL single-threaded must override ``serve``
@@ -51,11 +48,8 @@ class BaseEnvFacade(RpcFacade):
     """
 
     def __init__(self):
-        super().__init__()
-        self._dispatch_lock = RWLock()
         # server side does not cache obs / terminated — only the client caches
-        self._rpc: dict[str, Callable] = {}
-        self._readonly_methods: set[str] = set()
+        super().__init__()
         self._register_rpc()
 
     # ---- framework ----
@@ -87,16 +81,6 @@ class BaseEnvFacade(RpcFacade):
             "env.get_camera_meta",
             "env.render_camera",
         ])
-
-    def _dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
-        handler = self._rpc.get(method)
-        if handler is None:
-            raise ValueError(f"unknown RPC method: {method!r}")
-        if method in self._readonly_methods:
-            with self._dispatch_lock.read():
-                return handler(*args, **kwargs)
-        with self._dispatch_lock.write():
-            return handler(*args, **kwargs)
 
     # ---- abstract methods (subclasses must override) ----
     def reset(self):

--- a/rpent/robots/components/env_facade_base.py
+++ b/rpent/robots/components/env_facade_base.py
@@ -37,9 +37,9 @@ class BaseEnvFacade(RpcFacade):
            client owns the caching policy.
 
     RPC routing:
-        ``_dispatch`` (inherited from :class:`RpcFacade`) uses a
-        registration dict (``self._rpc``) instead of dynamic ``getattr``
-        routing. Subclasses register their own methods in ``_register_rpc``.
+        ``_dispatch`` uses a registration dict (``self._rpc``) instead of
+        dynamic ``getattr`` routing. Subclasses register their own methods in
+        ``_register_rpc``.
 
     EGL single-thread:
         Subclasses that must keep EGL single-threaded must override ``serve``
@@ -58,13 +58,9 @@ class BaseEnvFacade(RpcFacade):
         verify config consistency after startup."""
         raise NotImplementedError
 
-    def close(self):
-        pass
-
     def _register_rpc(self):
         """Can be overridden to register more RPC methods."""
         self._rpc["env.get_env_meta"] = self.get_env_meta
-        self._rpc["env.close"] = self.close
 
         self._rpc["env.reset"] = self.reset
         self._rpc["env.step"] = self.step

--- a/rpent/robots/components/pi05_vla_client.py
+++ b/rpent/robots/components/pi05_vla_client.py
@@ -14,6 +14,26 @@
 
 """Pi0.5 VLA client for LIBERO."""
 
+"""Thin client wrapping the Pi0.5 VLA RPC server.
+
+The server lifecycle is the caller's responsibility: bring up
+``rpent.robots.components.pi05_vla_server`` (or any compatible ``predict`` /
+``healthz`` implementation) before constructing this client.
+
+Wire schema (see also ``pi05_vla_server``):
+
+    call("predict", kwargs={
+        "instruction": "<task_descriptions>",
+        "images": {
+            "main":  {"format": "png", "data": "<base64>"},
+            "wrist": {"format": "png", "data": "<base64>"},  # optional
+            "extra": {"format": "png", "data": "<base64>"},  # optional
+        },
+        "state": [[s0..sN]],           # shape [B, state_dim]
+        "mode":  "eval",
+    })
+    -> {"actions": [[[a0..a6], ...]], "shape": [B, chunk, action_dim], "dtype": "float32"}
+"""
 from __future__ import annotations
 
 from typing import Any

--- a/rpent/robots/components/pi05_vla_client.py
+++ b/rpent/robots/components/pi05_vla_client.py
@@ -12,26 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Thin client wrapping the Pi0.5 VLA RPC server.
-
-The server lifecycle is the caller's responsibility: bring up
-``rpent.robots.components.pi05_vla_server`` (or any compatible ``predict`` /
-``healthz`` implementation) before constructing this client.
-
-Wire schema (see also ``pi05_vla_server``):
-
-    call("predict", kwargs={
-        "instruction": "<task_descriptions>",
-        "images": {
-            "main":  {"format": "png", "data": "<base64>"},
-            "wrist": {"format": "png", "data": "<base64>"},  # optional
-            "extra": {"format": "png", "data": "<base64>"},  # optional
-        },
-        "state": [[s0..sN]],           # shape [B, state_dim]
-        "mode":  "eval",
-    })
-    -> {"actions": [[[a0..a6], ...]], "shape": [B, chunk, action_dim], "dtype": "float32"}
-"""
+"""Pi0.5 VLA client for LIBERO."""
 
 from __future__ import annotations
 

--- a/rpent/robots/components/pi05_vla_client.py
+++ b/rpent/robots/components/pi05_vla_client.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pi0.5 VLA client for LIBERO."""
-
 """Thin client wrapping the Pi0.5 VLA RPC server.
 
 The server lifecycle is the caller's responsibility: bring up
@@ -34,6 +32,7 @@ Wire schema (see also ``pi05_vla_server``):
     })
     -> {"actions": [[[a0..a6], ...]], "shape": [B, chunk, action_dim], "dtype": "float32"}
 """
+
 from __future__ import annotations
 
 from typing import Any

--- a/rpent/robots/components/vla_facade_base.py
+++ b/rpent/robots/components/vla_facade_base.py
@@ -51,5 +51,5 @@ class BaseVLAFacade(RpcFacade):
         self._rpc["vla.predict"] = self.predict
 
     # ---- abstract methods (subclasses must override) ----
-    def predict(self):
+    def predict(self, *args, **kwargs):
         raise NotImplementedError

--- a/rpent/robots/components/vla_facade_base.py
+++ b/rpent/robots/components/vla_facade_base.py
@@ -29,8 +29,7 @@ class BaseVLAFacade(RpcFacade):
         ``__init__`` —  the subclass loads the model itself.
 
     RPC routing:
-        ``_dispatch`` (inherited from :class:`RpcFacade`) uses a
-        registration dict (``self._rpc``) instead of a dynamic
+        ``_dispatch`` uses a registration dict (``self._rpc``) instead of an
         ``if method == "predict"`` chain. Subclasses register their own methods
         in ``_register_rpc``.
 

--- a/rpent/robots/components/vla_facade_base.py
+++ b/rpent/robots/components/vla_facade_base.py
@@ -51,5 +51,5 @@ class BaseVLAFacade(RpcFacade):
         self._rpc["vla.predict"] = self.predict
 
     # ---- abstract methods (subclasses must override) ----
-    def predict(self, obs, options):
+    def predict(self):
         raise NotImplementedError

--- a/rpent/robots/components/vla_facade_base.py
+++ b/rpent/robots/components/vla_facade_base.py
@@ -18,10 +18,7 @@ Design reference: ``docs/source-zh/rst_source/development/add_vla.rst``.
 
 from __future__ import annotations
 
-from typing import Any
-
 from rpent.utils.rpc import RpcFacade
-from rpent.utils.rwlock import RWLock
 
 
 class BaseVLAFacade(RpcFacade):
@@ -32,7 +29,8 @@ class BaseVLAFacade(RpcFacade):
         ``__init__`` —  the subclass loads the model itself.
 
     RPC routing:
-        ``_dispatch`` uses a registration dict (``self._rpc``) instead of an
+        ``_dispatch`` (inherited from :class:`RpcFacade`) uses a
+        registration dict (``self._rpc``) instead of a dynamic
         ``if method == "predict"`` chain. Subclasses register their own methods
         in ``_register_rpc``.
 
@@ -46,27 +44,11 @@ class BaseVLAFacade(RpcFacade):
 
     def __init__(self):
         super().__init__()
-        # Serializes ``predict`` execution: the model is not thread-safe and
-        # concurrent RPC requests must not interleave. Kept at the facade level
-        # so it still applies when a subclass overrides ``serve``.
-        self._dispatch_lock = RWLock()
-        self._rpc: dict[str, Any] = {}
-        self._readonly_methods: set[str] = set()
         self._register_rpc()
 
     # ---- framework ----
     def _register_rpc(self):
         self._rpc["vla.predict"] = self.predict
-
-    def _dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
-        handler = self._rpc.get(method)
-        if handler is None:
-            raise ValueError(f"unknown RPC method: {method!r}")
-        if method in self._readonly_methods:
-            with self._dispatch_lock.read():
-                return handler(*args, **kwargs)
-        with self._dispatch_lock.write():
-            return handler(*args, **kwargs)
 
     # ---- abstract methods (subclasses must override) ----
     def predict(self, obs, options):

--- a/rpent/utils/rpc/__init__.py
+++ b/rpent/utils/rpc/__init__.py
@@ -14,17 +14,17 @@
 
 """rpc utils and implementations"""
 
+from rpent.utils.rpc.client_utils import (
+    make_rpc_client,
+    parse_endpoint,
+    wait_for_ready,
+)
 from rpent.utils.rpc.rpc_client import (
     RpcClient,
     RpcError,
 )
 from rpent.utils.rpc.rpc_facade import (
     RpcFacade,
-)
-from rpent.utils.rpc.client_utils import (
-    make_rpc_client,
-    parse_endpoint,
-    wait_for_ready,
 )
 from rpent.utils.rpc.socket_rpc import SocketRpcClient, SocketRpcServer
 

--- a/rpent/utils/rpc/__init__.py
+++ b/rpent/utils/rpc/__init__.py
@@ -14,9 +14,11 @@
 
 """rpc utils and implementations"""
 
-from rpent.utils.rpc.rpc import (
+from rpent.utils.rpc.rpc_client import (
     RpcClient,
     RpcError,
+)
+from rpent.utils.rpc.rpc_facade import (
     RpcFacade,
 )
 from rpent.utils.rpc.client_utils import (

--- a/rpent/utils/rpc/__init__.py
+++ b/rpent/utils/rpc/__init__.py
@@ -18,8 +18,8 @@ from rpent.utils.rpc.rpc import (
     RpcClient,
     RpcError,
     RpcFacade,
-    check_response,
-    make_error_response,
+)
+from rpent.utils.rpc.client_utils import (
     make_rpc_client,
     parse_endpoint,
     wait_for_ready,
@@ -32,8 +32,6 @@ __all__ = [
     "RpcFacade",
     "SocketRpcClient",
     "SocketRpcServer",
-    "check_response",
-    "make_error_response",
     "make_rpc_client",
     "parse_endpoint",
     "wait_for_ready",

--- a/rpent/utils/rpc/client_utils.py
+++ b/rpent/utils/rpc/client_utils.py
@@ -1,0 +1,77 @@
+"""Client utility functions: endpoint parsing, server discovery, and readiness polling."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from rpent.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from rpent.utils.daemon import ProcessDaemon
+    from rpent.utils.rpc.rpc import RpcClient
+
+logger = get_logger("client_utils")
+
+
+def parse_endpoint(endpoint: str) -> tuple[str, str, int]:
+    """Parse ``[protocol://]host:port`` into ``(protocol, host, port)``.
+
+    Protocol defaults to ``http`` when the prefix is omitted.
+    """
+    if "://" in endpoint:
+        protocol, _, rest = endpoint.partition("://")
+    else:
+        protocol, rest = "http", endpoint
+    host, _, port = rest.partition(":")
+    if not host or not port:
+        raise ValueError(f"endpoint must be [protocol://]host:port, got {endpoint!r}")
+    return protocol, host, int(port)
+
+
+def make_rpc_client(endpoint: str) -> "RpcClient":
+    """Build an HTTP or socket client for ``endpoint``."""
+    from rpent.utils.rpc.http_rpc import HttpRpcClient
+    from rpent.utils.rpc.socket_rpc import SocketRpcClient
+
+    protocol, host, port = parse_endpoint(endpoint)
+    if protocol == "http":
+        return HttpRpcClient(f"http://{host}:{port}")
+    if protocol == "socket":
+        return SocketRpcClient(host, port)
+    raise ValueError(f"endpoint protocol must be http or socket, got {protocol!r}")
+
+
+def wait_for_ready(
+    client: "RpcClient",
+    *,
+    timeout_s: float = 300.0,
+    poll_interval_s: float = 0.5,
+    daemon: "ProcessDaemon | None" = None,
+) -> None:
+    """Poll ``client.call("healthz")`` until it succeeds or ``timeout_s`` elapses.
+
+    If ``daemon`` is given and its subprocess exits before becoming ready,
+    fail fast with ``RuntimeError`` (carrying the exit code) instead of
+    blocking until ``timeout_s``.
+    """
+    deadline = time.time() + timeout_s
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        if daemon is not None:
+            rc = daemon.poll()
+            if rc is not None:
+                detail = last_err if last_err is not None else "no healthz attempt yet"
+                raise RuntimeError(
+                    f"{daemon.name} exited with code {rc} before becoming "
+                    f"ready; check its log. last healthz error: {detail}"
+                )
+        try:
+            client.call("healthz", timeout_s=1.0)
+            return
+        except Exception as exc:
+            last_err = exc
+            time.sleep(poll_interval_s)
+    raise TimeoutError(
+        f"server did not become ready within {timeout_s:.0f}s: {last_err}"
+    )

--- a/rpent/utils/rpc/client_utils.py
+++ b/rpent/utils/rpc/client_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Client utility functions: endpoint parsing, server discovery, and readiness polling."""
 
 from __future__ import annotations

--- a/rpent/utils/rpc/client_utils.py
+++ b/rpent/utils/rpc/client_utils.py
@@ -9,7 +9,7 @@ from rpent.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from rpent.utils.daemon import ProcessDaemon
-    from rpent.utils.rpc.rpc import RpcClient
+    from rpent.utils.rpc.rpc_client import RpcClient
 
 logger = get_logger("client_utils")
 

--- a/rpent/utils/rpc/http_rpc.py
+++ b/rpent/utils/rpc/http_rpc.py
@@ -37,7 +37,7 @@ from rpent.utils.rpc import RpcError, check_response, make_error_response
 
 DEFAULT_TIMEOUT_S = 30.0
 
-logger = get_logger("rpc")
+logger = get_logger("http_rpc")
 
 
 def _from_json(obj: Any) -> Any:

--- a/rpent/utils/rpc/http_rpc.py
+++ b/rpent/utils/rpc/http_rpc.py
@@ -33,7 +33,8 @@ from typing import Any, Callable
 import numpy as np
 
 from rpent.utils.logging import get_logger
-from rpent.utils.rpc.rpc import RpcClient, RpcError, check_response, make_error_response
+from rpent.utils.rpc.rpc_client import RpcClient, RpcError, check_response
+from rpent.utils.rpc.rpc_facade import make_error_response
 
 DEFAULT_TIMEOUT_S = 30.0
 

--- a/rpent/utils/rpc/http_rpc.py
+++ b/rpent/utils/rpc/http_rpc.py
@@ -33,7 +33,7 @@ from typing import Any, Callable
 import numpy as np
 
 from rpent.utils.logging import get_logger
-from rpent.utils.rpc import RpcError, check_response, make_error_response
+from rpent.utils.rpc.rpc import RpcClient, RpcError, check_response, make_error_response
 
 DEFAULT_TIMEOUT_S = 30.0
 
@@ -58,7 +58,7 @@ def _from_json(obj: Any) -> Any:
     return obj
 
 
-class HttpRpcClient:
+class HttpRpcClient(RpcClient):
     """RPC client that talks to an RPC server via HTTP POST.
 
     Parameters

--- a/rpent/utils/rpc/rpc.py
+++ b/rpent/utils/rpc/rpc.py
@@ -104,6 +104,10 @@ class RpcFacade:
         self._rpc: dict[str, Any] = {}
         self._readonly_methods: set[str] = set()
 
+    def close(self) -> None:
+        """Clean up resources. Override in subclasses that hold resources."""
+        pass
+
     def _builtin_dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
         """Handle framework methods (healthz, shutdown).
 
@@ -171,6 +175,7 @@ class RpcFacade:
         finally:
             server.shutdown()
             server.server_close()
+            self.close()
 
 
 __all__ = [

--- a/rpent/utils/rpc/rpc.py
+++ b/rpent/utils/rpc/rpc.py
@@ -17,13 +17,10 @@
 from __future__ import annotations
 
 import threading
-import time
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import Any, Literal
 
 from rpent.utils.logging import get_logger
-
-if TYPE_CHECKING:
-    from rpent.utils.daemon import ProcessDaemon
+from rpent.utils.rwlock import RWLock
 
 logger = get_logger("rpc")
 
@@ -37,8 +34,12 @@ class RpcError(RuntimeError):
         self.server_traceback = traceback
 
 
-class RpcClient(Protocol):
-    """Generic method-call RPC transport (agent → out-of-process server)."""
+class RpcClient:
+    """Base for transport-specific RPC clients."""
+
+    def close(self) -> None:
+        """Close the client connection."""
+        pass
 
     def call(
         self,
@@ -48,7 +49,8 @@ class RpcClient(Protocol):
         *,
         timeout_s: float | None = None,
     ) -> Any:
-        """Invoke a remote method and return its result."""
+        """Invoke a remote method and return its result. Override in subclasses."""
+        raise NotImplementedError
 
 
 def make_error_response(exc: Exception) -> dict:
@@ -71,55 +73,26 @@ def check_response(response: Any, method: str) -> Any:
     return response.get("result")
 
 
-def wait_for_ready(
-    client: RpcClient,
-    *,
-    timeout_s: float = 300.0,
-    poll_interval_s: float = 0.5,
-    daemon: "ProcessDaemon | None" = None,
-) -> None:
-    """Poll ``client.call("healthz")`` until it succeeds or ``timeout_s`` elapses.
-
-    If ``daemon`` is given and its subprocess exits before becoming ready,
-    fail fast with ``RuntimeError`` (carrying the exit code) instead of
-    blocking until ``timeout_s``.
-    """
-    deadline = time.time() + timeout_s
-    last_err: Exception | None = None
-    while time.time() < deadline:
-        if daemon is not None:
-            rc = daemon.poll()
-            if rc is not None:
-                detail = last_err if last_err is not None else "no healthz attempt yet"
-                raise RuntimeError(
-                    f"{daemon.name} exited with code {rc} before becoming "
-                    f"ready; check its log. last healthz error: {detail}"
-                )
-        try:
-            client.call("healthz", timeout_s=1.0)
-            return
-        except Exception as exc:
-            last_err = exc
-            time.sleep(poll_interval_s)
-    raise TimeoutError(
-        f"server did not become ready within {timeout_s:.0f}s: {last_err}"
-    )
-
-
 class RpcFacade:
     """Base class for subprocess RPC servers.
 
-    Subclasses implement :meth:`_dispatch`; the base owns the shutdown
-    event, the ``shutdown`` / ``healthz`` RPC methods, transport binding,
-    parent-watch, and clean teardown.
+    Subclasses register methods in ``self._rpc`` (typically in ``__init__``
+    or a ``_register_rpc`` hook). Read-only methods listed in
+    ``self._readonly_methods`` run under a shared read lock; mutating
+    methods acquire an exclusive write lock.
+
+    The base owns the shutdown event, the ``shutdown`` / ``healthz`` RPC
+    methods, transport binding, parent-watch, and clean teardown.
 
     Usage::
 
         class MyFacade(RpcFacade):
-            def _dispatch(self, method, args, kwargs):
-                if method == "hello":
-                    return "world"
-                raise ValueError(f"unknown RPC method: {method!r}")
+            def __init__(self):
+                super().__init__()
+                self._rpc["hello"] = self.say_hello
+
+            def say_hello(self):
+                return "world"
 
 
         MyFacade().serve(transport="http", host="127.0.0.1", port=0)
@@ -127,14 +100,25 @@ class RpcFacade:
 
     def __init__(self) -> None:
         self._shutdown_event = threading.Event()
+        self._dispatch_lock = RWLock()
+        self._rpc: dict[str, Any] = {}
+        self._readonly_methods: set[str] = set()
 
     def _dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
-        """Business RPC dispatch. Override in subclasses.
+        """Business RPC dispatch using a registration dict.
 
-        Do not handle ``shutdown`` or ``healthz`` here — the base takes care
-        of them.
+        Subclasses register handlers in ``_register_rpc``. Read-only methods
+        (registered in ``_readonly_methods``) run under a shared read lock;
+        mutating methods acquire an exclusive write lock.
         """
-        raise NotImplementedError
+        handler = self._rpc.get(method)
+        if handler is None:
+            raise ValueError(f"unknown RPC method: {method!r}")
+        if method in self._readonly_methods:
+            with self._dispatch_lock.read():
+                return handler(*args, **kwargs)
+        with self._dispatch_lock.write():
+            return handler(*args, **kwargs)
 
     def serve(
         self,
@@ -184,41 +168,10 @@ class RpcFacade:
             server.server_close()
 
 
-def parse_endpoint(endpoint: str) -> tuple[str, str, int]:
-    """Parse ``[protocol://]host:port`` into ``(protocol, host, port)``.
-
-    Protocol defaults to ``http`` when the prefix is omitted.
-    """
-    if "://" in endpoint:
-        protocol, _, rest = endpoint.partition("://")
-    else:
-        protocol, rest = "http", endpoint
-    host, _, port = rest.partition(":")
-    if not host or not port:
-        raise ValueError(f"endpoint must be [protocol://]host:port, got {endpoint!r}")
-    return protocol, host, int(port)
-
-
-def make_rpc_client(endpoint: str) -> RpcClient:
-    """Build an HTTP or socket client for ``endpoint``."""
-    from rpent.utils.rpc.http_rpc import HttpRpcClient
-    from rpent.utils.rpc.socket_rpc import SocketRpcClient
-
-    protocol, host, port = parse_endpoint(endpoint)
-    if protocol == "http":
-        return HttpRpcClient(f"http://{host}:{port}")
-    if protocol == "socket":
-        return SocketRpcClient(host, port)
-    raise ValueError(f"endpoint protocol must be http or socket, got {protocol!r}")
-
-
 __all__ = [
     "RpcClient",
     "RpcError",
     "RpcFacade",
     "check_response",
     "make_error_response",
-    "make_rpc_client",
-    "parse_endpoint",
-    "wait_for_ready",
 ]

--- a/rpent/utils/rpc/rpc.py
+++ b/rpent/utils/rpc/rpc.py
@@ -104,6 +104,20 @@ class RpcFacade:
         self._rpc: dict[str, Any] = {}
         self._readonly_methods: set[str] = set()
 
+    def _builtin_dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
+        """Handle framework methods (healthz, shutdown).
+
+        Returns ``None`` for business methods so that :meth:`_dispatch`
+        can fall through to RWLock-based routing.
+        """
+        if method == "healthz":
+            return {"status": "ok"}
+        if method == "shutdown":
+            with self._dispatch_lock.write():
+                self._shutdown_event.set()
+            return {"ok": True}
+        return None
+
     def _dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
         """Business RPC dispatch using a registration dict.
 
@@ -111,6 +125,9 @@ class RpcFacade:
         (registered in ``_readonly_methods``) run under a shared read lock;
         mutating methods acquire an exclusive write lock.
         """
+        result = self._builtin_dispatch(method, args, kwargs)
+        if result is not None:
+            return result
         handler = self._rpc.get(method)
         if handler is None:
             raise ValueError(f"unknown RPC method: {method!r}")
@@ -138,20 +155,8 @@ class RpcFacade:
         from rpent.utils.rpc.http_rpc import HttpRpcServer
         from rpent.utils.rpc.socket_rpc import SocketRpcServer
 
-        _lock = threading.Lock()
-
-        def dispatch(method: str, args: tuple, kwargs: dict) -> Any:
-            if method == "healthz":
-                return {"status": "ok"}
-            if method == "shutdown":
-                with _lock:
-                    self._shutdown_event.set()
-                return {"ok": True}
-            with _lock:
-                return self._dispatch(method, args, kwargs)
-
         server_cls = HttpRpcServer if transport == "http" else SocketRpcServer
-        server = server_cls((host, port), dispatch)
+        server = server_cls((host, port), self._dispatch)
         bound_host, bound_port = server.server_address
         client_host = "127.0.0.1" if bound_host == "0.0.0.0" else bound_host
         url = f"{transport}://{client_host}:{bound_port}"

--- a/rpent/utils/rpc/rpc_client.py
+++ b/rpent/utils/rpc/rpc_client.py
@@ -1,9 +1,24 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """RPC client protocol: error type, transport-agnostic client base, response
 envelope validation.
 
 Server-side counterparts live in :mod:`rpent.utils.rpc.rpc_facade` (the
 ``RpcFacade`` base and the ``make_error_response`` envelope builder).
 """
+
 from __future__ import annotations
 
 from typing import Any

--- a/rpent/utils/rpc/rpc_client.py
+++ b/rpent/utils/rpc/rpc_client.py
@@ -1,0 +1,53 @@
+"""RPC client protocol: error type, transport-agnostic client base, response
+envelope validation.
+
+Server-side counterparts live in :mod:`rpent.utils.rpc.rpc_facade` (the
+``RpcFacade`` base and the ``make_error_response`` envelope builder).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class RpcError(RuntimeError):
+    """Raised when a remote method call returns an error."""
+
+    def __init__(self, method: str, message: str, *, traceback: str | None = None):
+        super().__init__(f"{method}: {message}")
+        self.method = method
+        self.server_traceback = traceback
+
+
+class RpcClient:
+    """Base for transport-specific RPC clients."""
+
+    def close(self) -> None:
+        """Close the client connection."""
+        pass
+
+    def call(
+        self,
+        method: str,
+        args: tuple = (),
+        kwargs: dict | None = None,
+        *,
+        timeout_s: float | None = None,
+    ) -> Any:
+        """Invoke a remote method and return its result. Override in subclasses."""
+        raise NotImplementedError
+
+
+def check_response(response: Any, method: str) -> Any:
+    """Validate RPC response envelope; raise ``RpcError`` on failure, return result."""
+    if not isinstance(response, dict):
+        raise RpcError(method, f"bad response type: {type(response).__name__}")
+    if not response.get("ok"):
+        raise RpcError(
+            method,
+            str(response.get("error", "<no error message>")),
+            traceback=response.get("traceback"),
+        )
+    return response.get("result")
+
+
+__all__ = ["RpcClient", "RpcError", "check_response"]

--- a/rpent/utils/rpc/rpc_facade.py
+++ b/rpent/utils/rpc/rpc_facade.py
@@ -32,6 +32,7 @@ Usage::
         def say_hello(self):
             return "world"
 
+
     MyFacade().serve(transport="http", host="127.0.0.1", port=0)
 """
 

--- a/rpent/utils/rpc/rpc_facade.py
+++ b/rpent/utils/rpc/rpc_facade.py
@@ -12,7 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""RPC client protocol and Facade base for subprocess RPC servers."""
+"""Base class for subprocess RPC servers.
+
+``RpcFacade`` owns the shutdown event, the ``healthz`` / ``shutdown`` RPC
+methods, transport binding, parent-watch, and clean teardown. Subclasses
+register business methods in ``_register_rpc`` (called from ``__init__``);
+read-only methods listed in ``self._readonly_methods`` run under a shared
+read lock, mutating methods acquire an exclusive write lock.
+
+Client-side counterparts live in :mod:`rpent.utils.rpc.rpc_client`.
+
+Usage::
+
+    class MyFacade(RpcFacade):
+        def __init__(self):
+            super().__init__()
+            self._rpc["hello"] = self.say_hello
+
+        def say_hello(self):
+            return "world"
+
+    MyFacade().serve(transport="http", host="127.0.0.1", port=0)
+"""
 
 from __future__ import annotations
 
@@ -25,52 +46,11 @@ from rpent.utils.rwlock import RWLock
 logger = get_logger("rpc")
 
 
-class RpcError(RuntimeError):
-    """Raised when a remote method call returns an error."""
-
-    def __init__(self, method: str, message: str, *, traceback: str | None = None):
-        super().__init__(f"{method}: {message}")
-        self.method = method
-        self.server_traceback = traceback
-
-
-class RpcClient:
-    """Base for transport-specific RPC clients."""
-
-    def close(self) -> None:
-        """Close the client connection."""
-        pass
-
-    def call(
-        self,
-        method: str,
-        args: tuple = (),
-        kwargs: dict | None = None,
-        *,
-        timeout_s: float | None = None,
-    ) -> Any:
-        """Invoke a remote method and return its result. Override in subclasses."""
-        raise NotImplementedError
-
-
 def make_error_response(exc: Exception) -> dict:
     """Build the error envelope for a caught exception."""
     import traceback as _tb
 
     return {"ok": False, "error": str(exc), "traceback": _tb.format_exc()}
-
-
-def check_response(response: Any, method: str) -> Any:
-    """Validate RPC response envelope; raise ``RpcError`` on failure, return result."""
-    if not isinstance(response, dict):
-        raise RpcError(method, f"bad response type: {type(response).__name__}")
-    if not response.get("ok"):
-        raise RpcError(
-            method,
-            str(response.get("error", "<no error message>")),
-            traceback=response.get("traceback"),
-        )
-    return response.get("result")
 
 
 class RpcFacade:
@@ -83,19 +63,6 @@ class RpcFacade:
 
     The base owns the shutdown event, the ``shutdown`` / ``healthz`` RPC
     methods, transport binding, parent-watch, and clean teardown.
-
-    Usage::
-
-        class MyFacade(RpcFacade):
-            def __init__(self):
-                super().__init__()
-                self._rpc["hello"] = self.say_hello
-
-            def say_hello(self):
-                return "world"
-
-
-        MyFacade().serve(transport="http", host="127.0.0.1", port=0)
     """
 
     def __init__(self) -> None:
@@ -178,10 +145,4 @@ class RpcFacade:
             self.close()
 
 
-__all__ = [
-    "RpcClient",
-    "RpcError",
-    "RpcFacade",
-    "check_response",
-    "make_error_response",
-]
+__all__ = ["RpcFacade", "make_error_response"]

--- a/rpent/utils/rpc/socket_rpc.py
+++ b/rpent/utils/rpc/socket_rpc.py
@@ -31,7 +31,10 @@ import socketserver
 import struct
 from typing import Any, Callable
 
-from rpent.utils.rpc import check_response, make_error_response
+from rpent.utils.logging import get_logger
+from rpent.utils.rpc.rpc import RpcClient, check_response, make_error_response
+
+logger = get_logger("socket_rpc")
 
 DEFAULT_CONNECT_TIMEOUT_S = 10.0
 DEFAULT_REQUEST_TIMEOUT_S = 30.0
@@ -62,7 +65,7 @@ def _write_frame(writer, obj: Any) -> None:
     writer.flush()
 
 
-class SocketRpcClient:
+class SocketRpcClient(RpcClient):
     """One-request-per-connection pickle-framed RPC client."""
 
     def __init__(
@@ -106,7 +109,8 @@ class _RequestHandler(socketserver.StreamRequestHandler):
     def handle(self) -> None:
         try:
             payload = _read_frame(self.rfile)
-        except Exception:
+        except Exception as exc:
+            logger.debug("rpc read failed: %s", exc)
             return
         try:
             method = payload["method"]
@@ -118,8 +122,8 @@ class _RequestHandler(socketserver.StreamRequestHandler):
             response = make_error_response(exc)
         try:
             _write_frame(self.wfile, response)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("rpc write failed: %s", exc)
 
 
 class SocketRpcServer(socketserver.ThreadingTCPServer):

--- a/rpent/utils/rpc/socket_rpc.py
+++ b/rpent/utils/rpc/socket_rpc.py
@@ -29,8 +29,7 @@ import pickle
 import socket
 import socketserver
 import struct
-from collections.abc import Callable
-from typing import Any
+from typing import Any, Callable
 
 from rpent.utils.rpc import check_response, make_error_response
 

--- a/rpent/utils/rpc/socket_rpc.py
+++ b/rpent/utils/rpc/socket_rpc.py
@@ -32,7 +32,8 @@ import struct
 from typing import Any, Callable
 
 from rpent.utils.logging import get_logger
-from rpent.utils.rpc.rpc import RpcClient, check_response, make_error_response
+from rpent.utils.rpc.rpc_client import RpcClient, check_response
+from rpent.utils.rpc.rpc_facade import make_error_response
 
 logger = get_logger("socket_rpc")
 


### PR DESCRIPTION
**Summary**: Lifts dispatch, locking, and method registration into the `RpcFacade` base; subclasses only register handlers in `_register_rpc`.

**Main changes**:
1. RpcFacade owns dispatch & lock: `_dispatch`, `_dispatch_lock`, and `_rpc` registry moved into `RpcFacade`; subclasses register handlers in `_register_rpc`.
2. RpcClient becomes a base: `RpcClient` changed from `Protocol` to a base class; transports must inherit from it.
3. Env client shares helpers: `BaseEnvClient` gains `get_camera_meta`, `render_camera`, `get_task_language`; robocasa/robotwin delegate via `super()`.

**Minor changes**:
- `check_response` / `make_error_response` no longer exported from `rpent.utils.rpc`; use `rpent.utils.rpc.rpc`.
- `parse_endpoint`, `make_rpc_client`, `wait_for_ready` split into `rpent/utils/rpc/client_utils.py`.
- `RpcFacade.close()` base added; `serve()` calls it in `finally`; `RoboTwinEnvFacade.close()` implements `self._env.offload(clear_cache=True)`.
- `RoboCasaEnvClient` reads `camera_h` / `camera_w` from `expected_meta` (was: server-returned `env_meta`).
- `get_task_language()` returns `str | None` (was: `ep_meta.get("lang", "")`); downstream uses `... or prompt`, unaffected.
- `RoboCasaEnvClient` drops redundant `env.render_camera` timeout override; `get_camera_meta` delegates via `super()`.
- `robots/robocasa/primitives.py` / `rldx_skill.py`: switch to `self.env.get_task_language()`.
- `robots/robocasa/env_server.py`: pure format adjustments in dispatch call site.
- Docs: `add_robot.rst` / `interfaces.rst` updated to `_register_rpc` pattern.
