### PR TITLE
fix(robocasa): preserve rendered frame orientation

### DIFF
--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -58,7 +58,7 @@ class RoboCasaPrimitives:
                 depth=False,
             )
             img = np.asarray(img, dtype=np.uint8)
-            img = np.ascontiguousarray(img[::-1, ::-1])
+            img = np.ascontiguousarray(img)
         self._frames.append(img)
 
     def recorded_frame_count(self) -> int:

--- a/tests/test_robocasa_camera_compat.py
+++ b/tests/test_robocasa_camera_compat.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from robots.robocasa.primitives import RoboCasaPrimitives
+
+
+class _RenderedEnv:
+    def __init__(self, frame: np.ndarray) -> None:
+        self.frame = frame
+
+    def render_camera(self, **kwargs) -> np.ndarray:
+        return self.frame
+
+
+def test_record_frame_keeps_render_camera_orientation() -> None:
+    frame = np.arange(18, dtype=np.uint8).reshape(2, 3, 3)
+    primitives = RoboCasaPrimitives.__new__(RoboCasaPrimitives)
+    primitives.env = _RenderedEnv(frame)
+    primitives._frames = []
+
+    primitives.record_frame()
+
+    np.testing.assert_array_equal(primitives._frames[0], frame)


### PR DESCRIPTION
## Summary

- stop rotating already top-down `render_camera()` frames a second time when recording
- add focused regression coverage for the recorded-frame orientation

## Why

`RoboCasaEnvClient.render_camera()` already converts MuJoCo output to top-down orientation. `RoboCasaPrimitives.record_frame()` then applies `[::-1, ::-1]`, rotating the frame by 180 degrees before it is written to the episode video.

The change preserves the orientation returned by `render_camera()` while retaining a contiguous `uint8` array for video encoding.

This was also exercised in two GPU RoboCasa runs (`ReheatMeatOnStove`, seed 1001) using RLDX and Xiaomi-MiBot backends. Both videos decoded successfully and an extracted frame was visually verified upright.

## Validation

```text
pytest -q tests/test_robocasa_camera_compat.py
1 passed

git diff --check
passed
```
