### PR TITLE
fix(robotwin): work around place_fan reward construction bug

### DIFF
--- a/robots/robotwin/env_server.py
+++ b/robots/robotwin/env_server.py
@@ -38,6 +38,7 @@ from omegaconf import OmegaConf  # noqa: E402
 from robotwin.assets import validate_root  # noqa: E402
 from robotwin.config import load_task_config  # noqa: E402
 
+from robots.robotwin.reward_compat import install_native_reward_compat  # noqa: E402
 from robots.robotwin.rlinf_env import RoboTwinAgentEnv  # noqa: E402
 from robots.robotwin.robot_spec import RoboTwinActionType  # noqa: E402
 
@@ -284,6 +285,9 @@ def make_env(
     max_episode_steps: int = 10000,
 ) -> RoboTwinAgentEnv:
     """Construct the only simulator owner used by an RPent run."""
+    # Temporary workaround for the pinned RoboTwin place_fan reward-construction
+    # bug. Remove after the RoboTwin dependency includes the upstream fix.
+    install_native_reward_compat(task_name)
     assets_identity = validate_root(assets_path)
     resolved_assets_path = Path(assets_identity["root"])
     os.environ["ROBOTWIN_ASSETS_PATH"] = str(resolved_assets_path)

--- a/robots/robotwin/reward_compat.py
+++ b/robots/robotwin/reward_compat.py
@@ -1,0 +1,54 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Temporary compatibility for a bug in the pinned RoboTwin runtime."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+def install_native_reward_compat(task_name: str) -> bool:
+    """Adapt the legacy ``place_fan`` reward constructor when required."""
+    if task_name != "place_fan":
+        return False
+
+    task_module = importlib.import_module("robotwin.envs.place_fan")
+    reward_factory = task_module.Reward
+    if getattr(reward_factory, "_rpent_place_fan_compat", False):
+        return False
+
+    class PlaceFanRewardCompat(reward_factory):
+        """Build the intended serial reward from the legacy arguments."""
+
+        _rpent_place_fan_compat = True
+
+        def __new__(
+            cls,
+            *,
+            subtasks: list[Any],
+            transition_rewards: list[float],
+        ) -> Any:
+            del cls
+            return reward_factory.build_top(
+                {
+                    "type": "Serial",
+                    "subtasks": subtasks,
+                    "transition_rewards": transition_rewards,
+                }
+            )
+
+    task_module.Reward = PlaceFanRewardCompat
+    return True

--- a/rpent/cli/main.py
+++ b/rpent/cli/main.py
@@ -310,7 +310,9 @@ def main() -> int:
         robot_spec = get_robot_spec(early.robot_name)
         robot_spec.add_cli_args(parser, use_dashboard=early.dashboard)
     parser.add_argument(
-        "-h", "--help", action="help",
+        "-h",
+        "--help",
+        action="help",
         default=argparse.SUPPRESS,
         help="show this help message and exit",
     )


### PR DESCRIPTION
 ## Summary

  Add a temporary compatibility workaround for a reward-construction bug in the
  pinned RoboTwin `place_fan` environment.

  The pinned `place_fan` implementation still constructs `Reward` with the legacy
  `subtasks` and `transition_rewards` keyword arguments, while the corresponding
  `Reward` implementation now expects callers to use `Reward.build_top()`.

  This causes the RoboTwin EnvServer to exit during `place_fan` initialization.
  From RPent, the failure appears as an EnvServer ready timeout.

  ## Fix

  Install a narrowly scoped compatibility adapter at the RPent EnvServer boundary
  before constructing the pinned RoboTwin environment.

  The adapter:

  - applies only to `place_fan`;
  - converts the legacy arguments into the equivalent serial
    `Reward.build_top()` configuration;
  - is idempotent;
  - does not modify RoboTwin source code or dependency pins;
  - can be removed after the pinned RoboTwin dependency includes an upstream fix.

  ## Validation

  - Local focused regression test passed.
  - Integration check against the actual pinned RoboTwin `Reward` implementation
    passed.
  - `place_fan` Env-only initialization passed on the latest RPent `main`:
    - task: `place_fan`
    - task config: `demo_randomized`
    - seed: `100002`
    - EnvServer reached ready in 86.1 seconds
    - `healthz` succeeded
    - `env.get_env_meta` returned the expected task, config, seed, action layouts,
      and step limit
  - No reset, step, VLA inference, planner, MCP server, or episode was run.
  - The validation was limited to `place_fan` environment construction, server
    readiness, and runtime metadata.