### PR TITLE
fix(robotwin): support close-only env teardown

### DIFF
--- a/robots/robotwin/env_server.py
+++ b/robots/robotwin/env_server.py
@@ -34,6 +34,25 @@ from rpent.utils.logging import get_logger
 
 logger = get_logger("robotwin_env_server")
 
+
+def _teardown_env(env: Any) -> None:
+    """Release an environment across RLinf teardown API versions."""
+    offload = getattr(env, "offload", None)
+    if callable(offload):
+        offload(clear_cache=True)
+        return
+
+    close = getattr(env, "close", None)
+    if callable(close):
+        close(clear_cache=True)
+        return
+
+    raise RuntimeError(
+        f"{type(env).__name__} provides neither callable offload() nor close() "
+        "for teardown"
+    )
+
+
 from omegaconf import OmegaConf  # noqa: E402
 from robotwin.assets import validate_root  # noqa: E402
 from robotwin.config import load_task_config  # noqa: E402
@@ -360,7 +379,7 @@ def main() -> None:
             parent_watch=args.parent_watch,
         )
     finally:
-        env.offload(clear_cache=True)
+        _teardown_env(env)
 
 
 if __name__ == "__main__":

--- a/rpent/cli/main.py
+++ b/rpent/cli/main.py
@@ -310,7 +310,9 @@ def main() -> int:
         robot_spec = get_robot_spec(early.robot_name)
         robot_spec.add_cli_args(parser, use_dashboard=early.dashboard)
     parser.add_argument(
-        "-h", "--help", action="help",
+        "-h",
+        "--help",
+        action="help",
         default=argparse.SUPPRESS,
         help="show this help message and exit",
     )


### PR DESCRIPTION
## Summary

Make RoboTwin EnvServer teardown compatible with both RLinf cleanup APIs:

- prefer `offload(clear_cache=True)` when available;
- otherwise call `close(clear_cache=True)`;
- raise a clear error when neither method exists.

## Problem

The current RPent EnvServer unconditionally calls `env.offload(clear_cache=True)`. The currently published `rpent-rlinf==0.3.0` RoboTwin environment does not expose `offload`; its supported cleanup method is `close(clear_cache=True)`, which delegates to the underlying vector environment. As a result, an otherwise successful run can end with an `AttributeError` and EnvServer exit code 1 during shutdown.

The compatibility helper only selects the available teardown API. Exceptions raised inside either cleanup implementation continue to propagate, and no episode, action, prompt, or success-evaluation behavior changes.

## Validation

Local lightweight tests covered offload-only, close-only, both methods (offload preferred), neither method, internal offload failure, and internal close failure.

A RoboTwin Env-only smoke test on the current main base used `beat_block_hammer`, `demo_randomized`, seed `100000`, and called only `healthz`, `env.get_env_meta`, and `shutdown`:

- SAPIEN/RoboTwin initialized successfully;
- metadata matched the requested task and exact seed;
- `rpent-rlinf==0.3.0` selected `close(clear_cache=True)`;
- EnvServer exited with code 0;
- the dynamic port closed and GPU memory returned to baseline;
- no reset, step, VLA inference, planner, MCP, or episode was run.

Pre-commit (`ruff`, `ruff-format`) and `git diff --check` pass.

## Note on the style-only commit

The separate `rpent/cli/main.py` formatting commit is the same pre-existing main formatting issue already fixed in #117. It is included only so the current all-files pre-commit check passes; once #117 lands, that diff can be dropped/rebased away.
