### PR TITLE
docs: add RoboTwin reproduction guide

### DIFF
--- a/docs/source-en/rst_source/awesome_works/harnessvla.rst
+++ b/docs/source-en/rst_source/awesome_works/harnessvla.rst
@@ -116,6 +116,8 @@ Quick Start
 -----------
 
 * **Tutorial:** :doc:`LIBERO <../usage/libero>`
+* **Tutorial:** :doc:`RoboCasa <../usage/robocasa>`
+* **Tutorial:** :doc:`RoboTwin <../usage/robotwin>`
 
 Citation
 --------

--- a/docs/source-en/rst_source/usage/robotwin.rst
+++ b/docs/source-en/rst_source/usage/robotwin.rst
@@ -187,3 +187,40 @@ An ``evidence_status`` of ``supported`` means the recipe is backed by a
 successful clean trajectory. An ``experimental`` recipe remains a weak prior.
 Start with ``memory/MEMORY.md`` and read only the notes relevant to the current
 task and failure mode.
+
+Reproducing results
+-------------------
+
+The following result reproduces Harness VLA on RoboTwin C2R using ``gpt-5.5``
+with ``xhigh`` reasoning effort:
+
+- ``demo_randomized``: 58.0% (145/250)
+
+The evaluation covers 50 RoboTwin tasks and runs five episodes per task, for a
+total of 250 episodes. For each task, use the five official verified expert
+seeds listed in ``robots/robotwin/eval/demo_randomized.json``. Because the
+solvable seeds can differ across tasks, select each task's corresponding seeds
+from that file rather than applying one fixed seed list to every task.
+
+Reproduction command for one episode:
+
+.. code-block:: bash
+
+   rpent --robot robotwin \
+     --task-name "task" \
+     --task-config demo_randomized \
+     --seed "seed" \
+     --planner codex \
+     --model gpt-5.5 \
+     --reasoning-effort xhigh \
+     --max-turns 100 \
+     --planner-timeout-s 3600 \
+     --max-episode-steps 10000 \
+     --cuda-device 0
+
+Replace ``task`` with a task name from ``demo_randomized.json`` and ``seed``
+with one of that task's verified expert seeds. Before running, configure the
+RoboTwin assets, LingBot-VLA checkpoint, and ``robotwin_eef.yaml`` as described
+earlier on this page. Success is determined by the latest
+``TASK_ENV.eval_success`` value at the end of the episode, not merely by whether
+the planner calls ``finish``.

--- a/docs/source-en/rst_source/usage/robotwin.rst
+++ b/docs/source-en/rst_source/usage/robotwin.rst
@@ -215,12 +215,11 @@ Reproduction command for one episode:
      --reasoning-effort xhigh \
      --max-turns 100 \
      --planner-timeout-s 3600 \
-     --max-episode-steps 10000 \
-     --cuda-device 0
+     --max-episode-steps 10000
 
 Replace ``task`` with a task name from ``demo_randomized.json`` and ``seed``
 with one of that task's verified expert seeds. Before running, configure the
-RoboTwin assets, LingBot-VLA checkpoint, and ``robotwin_eef.yaml`` as described
-earlier on this page. Success is determined by the latest
+RoboTwin assets and LingBot-VLA checkpoint as described earlier on this page.
+Success is determined by the latest
 ``TASK_ENV.eval_success`` value at the end of the episode, not merely by whether
 the planner calls ``finish``.

--- a/docs/source-zh/rst_source/awesome_works/harnessvla.rst
+++ b/docs/source-zh/rst_source/awesome_works/harnessvla.rst
@@ -100,6 +100,8 @@ Analytic Primitives 隔离非接触执行。
 --------
 
 * **教程：** :doc:`LIBERO <../usage/libero>`
+* **教程：** :doc:`RoboCasa <../usage/robocasa>`
+* **教程：** :doc:`RoboTwin <../usage/robotwin>`
 
 引用
 ----

--- a/docs/source-zh/rst_source/usage/robotwin.rst
+++ b/docs/source-zh/rst_source/usage/robotwin.rst
@@ -197,10 +197,9 @@ task language 与最新 observation 始终优先，所有几何信息都必须�
      --reasoning-effort xhigh \
      --max-turns 100 \
      --planner-timeout-s 3600 \
-     --max-episode-steps 10000 \
-     --cuda-device 0
+     --max-episode-steps 10000
 
 其中，``task`` 应替换为 ``demo_randomized.json`` 中的任务名，``seed`` 应替换为
 该任务对应的一个 verified expert seed。运行前还需按照本页前文配置 RoboTwin assets、
-LingBot-VLA checkpoint 和 ``robotwin_eef.yaml``。任务是否成功以 episode 结束时最新的
+LingBot-VLA checkpoint。任务是否成功以 episode 结束时最新的
 ``TASK_ENV.eval_success`` 为准，不能仅根据规划器是否调用 ``finish`` 判断。

--- a/docs/source-zh/rst_source/usage/robotwin.rst
+++ b/docs/source-zh/rst_source/usage/robotwin.rst
@@ -170,3 +170,37 @@ task language 与最新 observation 始终优先，所有几何信息都必须�
 ``evidence_status=supported`` 表示 recipe 有成功 clean 轨迹支持；``experimental``
 仍然只是弱先验。使用时先阅读 ``memory/MEMORY.md``，再只选与当前任务和失败模式相关的
 少量笔记。
+
+结果复现
+--------
+
+以下结果复现了 Harness VLA 在 RoboTwin C2R 上的评测。实验使用 ``gpt-5.5`` 模型和
+``xhigh`` 推理强度：
+
+- ``demo_randomized``：58.0%（145/250）
+
+评测覆盖 RoboTwin 的 50 个任务，每个任务运行 5 个 episode，共计 250 个 episode。
+每个任务使用的 5 个 seed 来自 ``robots/robotwin/eval/demo_randomized.json`` 中的
+官方 verified expert seeds。由于不同任务的可解 seed 可能不同，请根据该文件为每个
+任务选择对应 seed，不要对所有任务统一使用一组固定 seed。
+
+单个 episode 的复现命令如下：
+
+.. code-block:: bash
+
+   rpent --robot robotwin \
+     --task-name "task" \
+     --task-config demo_randomized \
+     --seed "seed" \
+     --planner codex \
+     --model gpt-5.5 \
+     --reasoning-effort xhigh \
+     --max-turns 100 \
+     --planner-timeout-s 3600 \
+     --max-episode-steps 10000 \
+     --cuda-device 0
+
+其中，``task`` 应替换为 ``demo_randomized.json`` 中的任务名，``seed`` 应替换为
+该任务对应的一个 verified expert seed。运行前还需按照本页前文配置 RoboTwin assets、
+LingBot-VLA checkpoint 和 ``robotwin_eef.yaml``。任务是否成功以 episode 结束时最新的
+``TASK_ENV.eval_success`` 为准，不能仅根据规划器是否调用 ``finish`` 判断。


### PR DESCRIPTION
## Summary

- add RoboCasa and RoboTwin tutorial links to the Harness VLA Quick Start
- document the 50-task, 250-episode RoboTwin C2R reproduction setup
- record the gpt-5.5 / xhigh planner configuration and verified expert seed source
- clarify that native TASK_ENV.eval_success is the success criterion

## Validation

- pre-commit run --all-files
- English Sphinx HTML build with warnings treated as errors
- Chinese Sphinx HTML build and link rendering (the build reports one pre-existing warning in usage/configure_primitives.rst)
- git diff --check

Documentation-only change; no runtime or prompt behavior is modified.