### PR TITLE
feat(planner): add configurable SDK agent runtimes

### DIFF
--- a/docs/source-en/rst_source/usage/configure_planner.rst
+++ b/docs/source-en/rst_source/usage/configure_planner.rst
@@ -106,7 +106,11 @@ Notes:
   (defaults to ``MAX_BUDGET_USD`` env or ``10``).
 - RPent already depends on the Claude Agent SDK, which bundles the
   Claude Code binary; no separate CLI installation is required.
-  Authentication normally uses ``ANTHROPIC_API_KEY``. See the
+  Authentication normally uses ``ANTHROPIC_API_KEY``.
+- ``--base-url`` overrides ``ANTHROPIC_BASE_URL`` for this backend and is
+  passed to the SDK subprocess without changing the parent environment. The
+  endpoint must implement the Anthropic protocol; a Responses-only endpoint
+  is not interchangeable. See the
   `Claude Agent SDK docs
   <https://code.claude.com/docs/en/agent-sdk/overview>`_.
 
@@ -124,6 +128,7 @@ server. You do not need to start ``scripts/codex_proxy/`` first.
 
    rpent --robot libero --planner codex \
      --model gpt-5.5 \
+     --reasoning-effort xhigh \
      --suite libero_goal_task --task 1 --seed 0
 
 Notes:
@@ -132,10 +137,32 @@ Notes:
   the model configured as the Codex SDK default.
 - ``--planner-timeout-s`` limits the Codex run. Its default is
   ``CODEX_TIMEOUT_S``, then ``CELL_TIMEOUT_S``, then ``1200`` seconds.
-- By default, the Codex SDK reuses existing Codex authentication. For
-  a custom Responses-compatible endpoint, set ``CODEX_BASE_URL`` and
-  ``CODEX_API_KEY``. This backend does not read ``OPENAI_BASE_URL`` or
-  ``OPENAI_API_KEY``.
+- By default, the Codex SDK reuses existing Codex authentication. For a
+  custom Responses-compatible endpoint, set ``CODEX_BASE_URL`` and either
+  ``CODEX_API_KEY`` or ``CODEX_API_KEY_FILE``. The latter takes precedence
+  and must name a regular, non-symlink file with exact ``0600`` permissions.
+  This backend does not read ``OPENAI_BASE_URL`` or ``OPENAI_API_KEY``.
+- ``--base-url`` is equivalent to ``CODEX_BASE_URL`` for the Codex backend.
+  The API base may omit ``/v1``; RPent adds it and configures the Codex
+  ``responses`` wire API. Do not pass the ``/responses`` operation URL.
+- A GPT-5.5/xhigh run against a Responses-compatible endpoint can be
+  configured without changing or relying on ``~/.codex/config.toml``::
+
+     export CODEX_BASE_URL=https://provider.example/v1
+     export CODEX_API_KEY_FILE=/run/secrets/responses-api-key
+     rpent --robot libero --planner codex --model gpt-5.5 \
+       --reasoning-effort xhigh --suite libero_goal_task --task 1 --seed 0
+
+  Provision the key file through the job's secret manager; never put a key
+  in the command line. Endpoint support for the model and effort must be
+  checked with a small smoke test before a reproduction batch.
+- Programmatic agent launchers may pass
+  ``agent_runtime=AgentRuntimeConfig(repo_root=..., workdir=...)`` to
+  ``build_planner``. The same filesystem context is forwarded to
+  ``claude_code`` and ``codex`` and is the extension point for later
+  SDK-backed agents. Backend-specific permission controls remain on each
+  backend; ordinary Codex runs retain its existing ``full_access`` default.
+
 
 .. _planner-custom:
 

--- a/docs/source-zh/rst_source/usage/configure_planner.rst
+++ b/docs/source-zh/rst_source/usage/configure_planner.rst
@@ -95,7 +95,10 @@ RPent 通过 SDK 创建进程内 MCP 服务，并把 toolkit 的工具注册到
 - 通过 ``--claude-code-max-budget-usd`` 设置美元预算（默认取
   ``MAX_BUDGET_USD`` 环境变量或 ``10``）。
 - RPent 的依赖中已包含 Claude Agent SDK；该 SDK 自带 Claude Code
-  二进制文件，无需单独安装 CLI。认证通常使用 ``ANTHROPIC_API_KEY``，详见
+  二进制文件，无需单独安装 CLI。认证通常使用 ``ANTHROPIC_API_KEY``。
+- 对该 backend，``--base-url`` 会覆盖 ``ANTHROPIC_BASE_URL``，并只注入
+  SDK 子进程，不修改父进程环境。端点必须实现 Anthropic 协议，不能直接使用
+  仅兼容 Responses API 的端点。详见
   `Claude Agent SDK 文档
   <https://code.claude.com/docs/en/agent-sdk/overview>`_。
 
@@ -112,6 +115,7 @@ RPent 通过 SDK 创建进程内 MCP 服务，并把 toolkit 的工具注册到
 
    rpent --robot libero --planner codex \
      --model gpt-5.5 \
+     --reasoning-effort xhigh \
      --suite libero_goal_task --task 1 --seed 0
 
 注意事项：
@@ -121,9 +125,31 @@ RPent 通过 SDK 创建进程内 MCP 服务，并把 toolkit 的工具注册到
 - ``--planner-timeout-s`` 限制 Codex 运行时间。默认依次读取
   ``CODEX_TIMEOUT_S``、``CELL_TIMEOUT_S``，均未设置时为 ``1200`` 秒。
 - 默认情况下，Codex SDK 会复用已有的 Codex 认证。若要接入自定义的
-  Responses API 兼容端点，请设置 ``CODEX_BASE_URL`` 和
-  ``CODEX_API_KEY``；这里不读取 ``OPENAI_BASE_URL`` 或
-  ``OPENAI_API_KEY``。
+  Responses API 兼容端点，请设置 ``CODEX_BASE_URL``，并设置
+  ``CODEX_API_KEY`` 或 ``CODEX_API_KEY_FILE``。后者优先，且必须指向权限
+  精确为 ``0600`` 的普通文件，不能是符号链接。这里不读取
+  ``OPENAI_BASE_URL`` 或 ``OPENAI_API_KEY``。
+- 对 Codex backend，``--base-url`` 等价于 ``CODEX_BASE_URL``。API base
+  可以省略 ``/v1``，RPent 会自动补齐并使用 Codex ``responses`` wire API；
+  不要传入 ``/responses`` 操作地址。
+- GPT-5.5/xhigh 接入 Responses-compatible endpoint 时，不需要修改或依赖
+  ``~/.codex/config.toml``：
+
+  .. code-block:: bash
+
+     export CODEX_BASE_URL=https://provider.example/v1
+     export CODEX_API_KEY_FILE=/run/secrets/responses-api-key
+     rpent --robot libero --planner codex --model gpt-5.5 \
+       --reasoning-effort xhigh --suite libero_goal_task --task 1 --seed 0
+
+  key 文件应由作业 secret manager 注入，禁止把 key 放在命令行中。正式批量
+  复现前，仍需用小规模 smoke test 验证端点支持该 model 与 effort。
+- 程序化 agent launcher 可以向 ``build_planner`` 传入
+  ``agent_runtime=AgentRuntimeConfig(repo_root=..., workdir=...)``。同一套
+  文件系统上下文会传给 ``claude_code`` 与 ``codex``，后续 SDK agent 也复用
+  这个扩展点。权限控制仍由各 backend 自己负责；普通 Codex 运行保持现有的
+  ``full_access`` 默认值。
+
 
 .. _planner-custom:
 

--- a/rpent/planner/base.py
+++ b/rpent/planner/base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import queue
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
@@ -33,6 +34,24 @@ from rpent.utils.config import (
 #: Toolkits expose plain tool names; planners add/strip this prefix.
 MCP_TOOL_PREFIX = "mcp__rpent__"
 REASONING_EFFORTS = ("none", "low", "medium", "high", "xhigh")
+
+
+@dataclass(frozen=True)
+class AgentRuntimeConfig:
+    """Filesystem context shared by SDK-backed agent planners.
+
+    Backend-specific controls, such as a Codex sandbox or Claude permission
+    mode, remain owned by that backend. This common context lets launchers
+    select an isolated working tree without coupling themselves to one SDK.
+    """
+
+    repo_root: str | Path | None = None
+    workdir: str | Path | None = None
+
+    def resolved(self) -> tuple[str | Path, str | Path]:
+        """Return the effective repository root and working directory."""
+        repo_root = self.repo_root or get_repo_root()
+        return repo_root, self.workdir or repo_root
 
 
 def add_mcp_prefix(name: str) -> str:
@@ -128,11 +147,11 @@ def build_planner(
     claude_code_max_budget_usd: float | None = None,
     dashboard_events: DashboardEventSink,
     no_images: bool = False,
+    agent_runtime: AgentRuntimeConfig | None = None,
 ):
     """Build a planner for the given backend, resolving credentials from env vars."""
     # Imports are deferred to avoid a circular import: api_loop / claude_code /
     # codex all import from this module (PlannerResult).
-
     if planner_type == "api":
         if not model:
             raise ValueError(
@@ -177,6 +196,8 @@ def build_planner(
             no_images=no_images,
             timeout_s=api_timeout_s,
         )
+
+    repo_root, workdir = (agent_runtime or AgentRuntimeConfig()).resolved()
     if planner_type == "claude_code":
         from rpent.planner.claude_code import ClaudeCodePlanner
 
@@ -188,7 +209,9 @@ def build_planner(
             cc_budget = float(os.environ.get("MAX_BUDGET_USD", "10"))
         return ClaudeCodePlanner(
             output_dir=output_dir,
-            repo_root=get_repo_root(),
+            repo_root=repo_root,
+            workdir=workdir,
+            base_url=base_url,
             model=model or "sonnet",
             timeout_s=cc_timeout_s,
             max_budget_usd=cc_budget,
@@ -210,7 +233,9 @@ def build_planner(
             )
         return CodexPlanner(
             output_dir=output_dir,
-            repo_root=get_repo_root(),
+            repo_root=repo_root,
+            workdir=workdir,
+            base_url=base_url,
             model=model,
             timeout_s=cx_timeout_s,
             extra_dirs=[str(get_memory_dir(robot_name))],

--- a/rpent/planner/claude_code.py
+++ b/rpent/planner/claude_code.py
@@ -27,6 +27,7 @@ import asyncio
 import contextlib
 import dataclasses
 import json
+import os
 import queue
 import tempfile
 import time
@@ -71,6 +72,8 @@ class ClaudeCodePlanner:
         output_dir: str,
         dashboard_events: DashboardEventSink,
         repo_root: str | Path | None = None,
+        workdir: str | Path | None = None,
+        base_url: str | None = None,
         model: str = "sonnet",
         allowed_tools: str = "Bash Read Write Glob Grep",
         timeout_s: int = 600,
@@ -82,6 +85,13 @@ class ClaudeCodePlanner:
         """Initialize the Claude Agent SDK backend."""
         self._output_dir = str(output_dir)
         self._repo_root = str(repo_root) if repo_root else str(get_repo_root())
+        self._workdir = str(workdir) if workdir else self._repo_root
+        configured_base_url = (
+            base_url if base_url is not None else os.environ.get("ANTHROPIC_BASE_URL")
+        )
+        self._base_url = (
+            configured_base_url.rstrip("/") if configured_base_url else None
+        )
         self._model = model
         self._allowed_tools = allowed_tools
         self._timeout_s = timeout_s
@@ -343,7 +353,8 @@ class ClaudeCodePlanner:
         thinking = {"type": "disabled"} if self._reasoning_effort == "none" else None
         effort = None if self._reasoning_effort == "none" else self._reasoning_effort
         return sdk.ClaudeAgentOptions(
-            cwd=self._repo_root,
+            cwd=self._workdir,
+            env=({"ANTHROPIC_BASE_URL": self._base_url} if self._base_url else {}),
             model=self._model,
             max_turns=max_turns,
             max_budget_usd=self._max_budget_usd,

--- a/rpent/planner/codex.py
+++ b/rpent/planner/codex.py
@@ -30,12 +30,14 @@ import contextlib
 import json
 import os
 import queue
+import stat
 import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import openai_codex
 from openai_codex.generated.v2_all import ReasoningEffort
@@ -49,7 +51,6 @@ from rpent.dashboard.events import (
 from rpent.dashboard.interaction import DashboardInteractionPort
 from rpent.dashboard.planner_control import DashboardPlannerControl
 from rpent.planner.base import REASONING_EFFORTS, PlannerResult, strip_mcp_prefix
-from rpent.planner.utils.http_mcp_server import HttpMcpServer
 from rpent.tools.toolkit import Toolkit
 from rpent.utils.config import get_repo_root
 from rpent.utils.logging import get_logger
@@ -58,6 +59,7 @@ logger = get_logger("codex")
 
 PROVIDER_ID = "rpent_proxy"
 PROVIDER_ENV_KEY = "RPENT_CODEX_PROVIDER_KEY"
+_MAX_API_KEY_BYTES = 64 * 1024
 
 # ---------------------------------------------------------------------------
 # Public backend
@@ -78,24 +80,41 @@ class CodexPlanner:
         output_path: str | Path | None = None,
         model: str | None = None,
         reasoning_effort: str = "none",
+        base_url: str | None = None,
+        workdir: str | Path | None = None,
+        sandbox: str | object = "full_access",
     ):
         """Initialize the Codex SDK backend."""
         self._output_dir = str(output_dir)
         self._repo_root = str(repo_root) if repo_root else str(get_repo_root())
+        self._workdir = str(workdir) if workdir else self._repo_root
         self._timeout_s = timeout_s
         self._extra_dirs = extra_dirs or []
         self._output_path = Path(output_path) if output_path else None
         self._model = model or os.environ.get("CODEX_MODEL", None)
-        self._base_url = os.environ.get("CODEX_BASE_URL", None)
-        self._api_key = os.environ.get("CODEX_API_KEY", None)
+        configured_base_url = (
+            base_url if base_url is not None else os.environ.get("CODEX_BASE_URL")
+        )
+        self._base_url = (
+            _normalize_responses_base_url(configured_base_url)
+            if configured_base_url
+            else None
+        )
+        self._api_key = _load_codex_api_key()
+        if self._base_url and not self._api_key:
+            raise ValueError(
+                "CODEX_BASE_URL requires CODEX_API_KEY or CODEX_API_KEY_FILE"
+            )
+        if os.environ.get("CODEX_API_KEY_FILE") and not self._base_url:
+            raise ValueError("CODEX_API_KEY_FILE requires CODEX_BASE_URL")
         self._dashboard_events = dashboard_events
         if reasoning_effort not in REASONING_EFFORTS:
             raise ValueError(f"unsupported reasoning effort: {reasoning_effort}")
         self._thread_options = {
             "approval_mode": openai_codex.ApprovalMode.deny_all,
-            "cwd": self._repo_root,
+            "cwd": self._workdir,
             "model": self._model,
-            "sandbox": openai_codex.Sandbox.full_access,
+            "sandbox": _resolve_sandbox(sandbox),
         }
         self._turn_options = {
             **self._thread_options,
@@ -137,6 +156,8 @@ class CodexPlanner:
 
         # Start the in-thread MCP HTTP server so Codex can reach the
         # shared toolkit without spawning a subprocess.
+        from rpent.planner.utils.http_mcp_server import HttpMcpServer
+
         mcp_server = HttpMcpServer(toolkit)
         mcp_url = mcp_server.start()
         logger.info("mcp http endpoint: %s", mcp_url)
@@ -338,6 +359,8 @@ class CodexPlanner:
         error: str | None = None
         started = time.time()
 
+        from rpent.planner.utils.http_mcp_server import HttpMcpServer
+
         mcp_server = HttpMcpServer(toolkit)
         mcp_url = mcp_server.start()
         try:
@@ -439,7 +462,7 @@ class CodexPlanner:
                     base_url=self._base_url,
                 )
             ),
-            "cwd": self._repo_root,
+            "cwd": self._workdir,
             "env": env,
             # use True to support (namespace tools,
             # web_search, image_generation).
@@ -772,9 +795,7 @@ def _codex_mcp_config_overrides(
         ("mcp_servers.rpent.url", mcp_url),
     ]
     if base_url:
-        normalized = base_url.rstrip("/")
-        if not normalized.endswith("/v1"):
-            normalized = normalized + "/v1"
+        normalized = _normalize_responses_base_url(base_url)
         config.extend(
             [
                 ("model_provider", PROVIDER_ID),
@@ -785,6 +806,82 @@ def _codex_mcp_config_overrides(
             ]
         )
     return [f"{key}={json.dumps(value)}" for key, value in config]
+
+
+def _normalize_responses_base_url(base_url: str) -> str:
+    """Return a validated Responses API base URL ending in ``/v1``."""
+    raw = base_url.strip().rstrip("/")
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("CODEX_BASE_URL must be an absolute http(s) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError(
+            "CODEX_BASE_URL must not contain credentials, a query, or a fragment"
+        )
+    path = parsed.path.rstrip("/")
+    if path.endswith("/responses"):
+        raise ValueError("CODEX_BASE_URL must be the API base, not /responses")
+    if not path.endswith("/v1"):
+        path = f"{path}/v1"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _load_codex_api_key() -> str | None:
+    """Load a custom-provider key without exposing it through config overrides."""
+    key_file = os.environ.get("CODEX_API_KEY_FILE")
+    if not key_file:
+        return os.environ.get("CODEX_API_KEY") or None
+    return _read_codex_api_key_file(Path(key_file).expanduser())
+
+
+def _read_codex_api_key_file(path: Path) -> str:
+    """Read one API key from a policy-compliant, non-symlink 0600 file."""
+    try:
+        before = os.lstat(path)
+    except OSError as exc:
+        raise ValueError(f"cannot inspect CODEX_API_KEY_FILE: {path}") from exc
+    if stat.S_ISLNK(before.st_mode):
+        raise ValueError("CODEX_API_KEY_FILE must not be a symlink")
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"cannot open CODEX_API_KEY_FILE: {path}") from exc
+    try:
+        opened = os.fstat(fd)
+        if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+            raise ValueError("CODEX_API_KEY_FILE changed while it was being opened")
+        if not stat.S_ISREG(opened.st_mode):
+            raise ValueError("CODEX_API_KEY_FILE must be a regular file")
+        if stat.S_IMODE(opened.st_mode) != 0o600:
+            raise ValueError("CODEX_API_KEY_FILE permissions must be 0600")
+        raw = os.read(fd, _MAX_API_KEY_BYTES + 1)
+    finally:
+        os.close(fd)
+
+    if len(raw) > _MAX_API_KEY_BYTES:
+        raise ValueError("CODEX_API_KEY_FILE is unexpectedly large")
+    try:
+        key = raw.decode("utf-8").strip()
+    except UnicodeDecodeError as exc:
+        raise ValueError("CODEX_API_KEY_FILE must contain UTF-8 text") from exc
+    if not key or "\n" in key or "\r" in key:
+        raise ValueError("CODEX_API_KEY_FILE must contain exactly one non-empty line")
+    return key
+
+
+def _resolve_sandbox(sandbox: str | object) -> Any:
+    """Resolve a stable string sandbox name to the SDK enum."""
+    if not isinstance(sandbox, str):
+        return sandbox
+    name = sandbox.replace("-", "_")
+    try:
+        return getattr(openai_codex.Sandbox, name)
+    except AttributeError as exc:
+        raise ValueError(
+            "unsupported Codex sandbox; use read_only, workspace_write, or full_access"
+        ) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_planner_config.py
+++ b/tests/test_agent_planner_config.py
@@ -1,0 +1,272 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: E402, I001
+
+import hashlib
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+if importlib.util.find_spec("openai_codex") is None:
+    sdk = types.ModuleType("openai_codex")
+
+    class _ApprovalMode:
+        deny_all = "deny_all"
+
+    class _Sandbox:
+        read_only = "read_only"
+        workspace_write = "workspace_write"
+        full_access = "full_access"
+
+    class _ReasoningEffort:
+        none = "none"
+        low = "low"
+        medium = "medium"
+        high = "high"
+        xhigh = "xhigh"
+
+    sdk.ApprovalMode = _ApprovalMode
+    sdk.Sandbox = _Sandbox
+    sdk.CodexConfig = lambda **kwargs: kwargs
+    generated = types.ModuleType("openai_codex.generated")
+    generated_v2 = types.ModuleType("openai_codex.generated.v2_all")
+    generated_v2.ReasoningEffort = _ReasoningEffort
+    sys.modules["openai_codex"] = sdk
+    sys.modules["openai_codex.generated"] = generated
+    sys.modules["openai_codex.generated.v2_all"] = generated_v2
+
+from rpent.dashboard.events import NullDashboardEventSink
+from rpent.planner import claude_code as claude_code_module
+from rpent.planner import codex as codex_module
+from rpent.planner.base import AgentRuntimeConfig, build_planner
+from rpent.planner.claude_code import ClaudeCodePlanner
+from rpent.planner.codex import CodexPlanner
+
+
+@pytest.fixture(autouse=True)
+def _clean_planner_environment(monkeypatch):
+    for name in (
+        "ANTHROPIC_BASE_URL",
+        "CODEX_API_KEY",
+        "CODEX_API_KEY_FILE",
+        "CODEX_BASE_URL",
+        "CODEX_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _secure_key_file(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "codex.key"
+    path.write_text(content)
+    path.chmod(0o600)
+    return path
+
+
+def _planner(tmp_path: Path, **kwargs) -> CodexPlanner:
+    return CodexPlanner(
+        output_dir=str(tmp_path / "output"),
+        dashboard_events=NullDashboardEventSink(),
+        **kwargs,
+    )
+
+
+def test_key_file_is_injected_by_env_name_not_config_value(
+    tmp_path, monkeypatch, caplog
+):
+    key = os.urandom(24).hex()
+    key_path = _secure_key_file(tmp_path, key + "\n")
+    monkeypatch.setenv("CODEX_API_KEY_FILE", str(key_path))
+    monkeypatch.setenv("CODEX_API_KEY", "ignored-inline-value")
+    monkeypatch.setenv("CODEX_BASE_URL", "https://provider.example/v1")
+    monkeypatch.setattr(codex_module.openai_codex, "CodexConfig", lambda **kw: kw)
+
+    config = _planner(
+        tmp_path, model="gpt-5.5", reasoning_effort="xhigh"
+    )._build_config("http://127.0.0.1:1234/mcp/")
+
+    injected = config["env"][codex_module.PROVIDER_ENV_KEY]
+    assert (
+        hashlib.sha256(injected.encode()).digest()
+        == hashlib.sha256(key.encode()).digest()
+    )
+    assert all(key not in override for override in config["config_overrides"])
+    assert (
+        'model_providers.rpent_proxy.base_url="https://provider.example/v1"'
+        in config["config_overrides"]
+    )
+    assert (
+        'model_providers.rpent_proxy.wire_api="responses"' in config["config_overrides"]
+    )
+    leaked = key in caplog.text
+    assert leaked is False
+
+
+@pytest.mark.parametrize("mode", [0o400, 0o640, 0o644])
+def test_key_file_requires_exact_0600(tmp_path, monkeypatch, mode):
+    key_path = _secure_key_file(tmp_path, "placeholder")
+    key_path.chmod(mode)
+    monkeypatch.setenv("CODEX_API_KEY_FILE", str(key_path))
+    monkeypatch.setenv("CODEX_BASE_URL", "https://provider.example/v1")
+
+    with pytest.raises(ValueError, match="permissions must be 0600"):
+        _planner(tmp_path)
+
+
+def test_key_file_rejects_symlink(tmp_path, monkeypatch):
+    target = _secure_key_file(tmp_path, "placeholder")
+    link = tmp_path / "linked.key"
+    link.symlink_to(target)
+    monkeypatch.setenv("CODEX_API_KEY_FILE", str(link))
+    monkeypatch.setenv("CODEX_BASE_URL", "https://provider.example/v1")
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        _planner(tmp_path)
+
+
+def test_custom_base_url_requires_a_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_BASE_URL", "https://provider.example/v1")
+
+    with pytest.raises(ValueError, match="requires CODEX_API_KEY"):
+        _planner(tmp_path)
+
+
+def test_responses_url_and_formal_runtime_options(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_API_KEY", "placeholder")
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    planner = _planner(
+        tmp_path,
+        repo_root=tmp_path,
+        workdir=workdir,
+        sandbox="workspace_write",
+        base_url="https://provider.example",
+        model="gpt-5.5",
+        reasoning_effort="xhigh",
+    )
+
+    assert planner._base_url == "https://provider.example/v1"
+    assert planner._turn_options["cwd"] == str(workdir)
+    assert (
+        planner._turn_options["sandbox"]
+        == codex_module.openai_codex.Sandbox.workspace_write
+    )
+    assert planner._turn_options["model"] == "gpt-5.5"
+    assert "effort" not in planner._thread_options
+    assert planner._turn_options["effort"] == codex_module.ReasoningEffort.xhigh
+
+
+def test_operation_url_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_API_KEY", "placeholder")
+
+    with pytest.raises(ValueError, match="API base"):
+        _planner(tmp_path, base_url="https://provider.example/v1/responses")
+
+
+def test_build_planner_forwards_agent_runtime_to_codex(tmp_path, monkeypatch):
+    captured = {}
+
+    class _FakeCodexPlanner:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(codex_module, "CodexPlanner", _FakeCodexPlanner)
+    workdir = tmp_path / "work"
+
+    build_planner(
+        "codex",
+        output_dir=tmp_path / "output",
+        recipe_tag="formal",
+        robot_name="libero",
+        base_url="https://provider.example/v1",
+        model="gpt-5.5",
+        reasoning_effort="xhigh",
+        dashboard_events=NullDashboardEventSink(),
+        agent_runtime=AgentRuntimeConfig(repo_root=tmp_path, workdir=workdir),
+    )
+
+    assert captured["repo_root"] == tmp_path
+    assert captured["workdir"] == workdir
+    assert "sandbox" not in captured
+    assert captured["base_url"] == "https://provider.example/v1"
+
+
+def test_build_planner_forwards_agent_runtime_to_claude_code(tmp_path, monkeypatch):
+    captured = {}
+
+    class _FakeClaudeCodePlanner:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(claude_code_module, "ClaudeCodePlanner", _FakeClaudeCodePlanner)
+    workdir = tmp_path / "claude-work"
+
+    build_planner(
+        "claude_code",
+        output_dir=tmp_path / "output",
+        recipe_tag="formal",
+        robot_name="libero",
+        base_url="https://anthropic-provider.example",
+        model="claude-opus-4-8",
+        reasoning_effort="high",
+        dashboard_events=NullDashboardEventSink(),
+        agent_runtime=AgentRuntimeConfig(repo_root=tmp_path, workdir=workdir),
+    )
+
+    assert captured["repo_root"] == tmp_path
+    assert captured["workdir"] == workdir
+    assert captured["base_url"] == "https://anthropic-provider.example"
+    assert captured["model"] == "claude-opus-4-8"
+    assert captured["reasoning_effort"] == "high"
+
+
+def test_claude_code_options_use_runtime_and_endpoint(tmp_path, monkeypatch):
+    class _FakeSdk:
+        @staticmethod
+        def ClaudeAgentOptions(**kwargs):
+            return kwargs
+
+    toolkit = types.SimpleNamespace(get_tools_spec=lambda: [])
+    monkeypatch.setattr(
+        claude_code_module,
+        "_build_rpent_server",
+        lambda _sdk, *, toolkit: "rpent-server",
+    )
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://ignored.example")
+    workdir = tmp_path / "claude-work"
+    planner = ClaudeCodePlanner(
+        output_dir=str(tmp_path / "output"),
+        dashboard_events=NullDashboardEventSink(),
+        repo_root=tmp_path,
+        workdir=workdir,
+        base_url="https://anthropic-provider.example/",
+        model="claude-opus-4-8",
+        reasoning_effort="high",
+    )
+
+    options = planner._build_options(_FakeSdk, toolkit=toolkit, max_turns=7)
+
+    assert options["cwd"] == str(workdir)
+    assert options["env"] == {
+        "ANTHROPIC_BASE_URL": "https://anthropic-provider.example"
+    }
+    assert options["model"] == "claude-opus-4-8"
+    assert options["effort"] == "high"
+    assert options["max_turns"] == 7


### PR DESCRIPTION
## Summary

- add `AgentRuntimeConfig` so SDK-backed planners can share an explicit repository root and isolated working directory
- forward custom endpoints and runtime context to both Claude Agent SDK and Codex SDK backends, including `claude-opus-4-8` model selection
- harden Codex Responses-compatible endpoint configuration with URL validation, selectable sandboxing, and secure `CODEX_API_KEY_FILE` loading
- document the shared extension point for future SDK-backed agent planners in English and Chinese

## Motivation

Experiment launchers need to provision isolated worktrees without coupling the launcher to one agent SDK. This change keeps backend-specific controls on each planner while giving Claude Code, Codex, and future agent backends a small common filesystem-context contract. It is independently mergeable preparatory work for #21.

## Security and compatibility

- no credentials, provider-specific secrets, or local paths are included
- Codex key files must be regular non-symlink files with exact `0600` permissions; key values are passed through the child environment rather than config overrides or logs
- custom base URLs reject embedded credentials, query strings, fragments, and `/responses` operation URLs
- the existing API planner and default SDK planner behavior remain unchanged when the new options are not supplied

## Verification

- `pytest -q`: 12 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- English Sphinx build with `-W`: passed
- Chinese Sphinx build completed with only the pre-existing upstream warning in `configure_primitives.rst:22`, a file unchanged by this PR

The Claude path is covered by SDK option and forwarding tests. No live Claude provider credential was used or included.