### PR TITLE
fix(robocasa): harden environment and VLA contracts

### DIFF
--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -38,6 +39,46 @@ CAM_ALIAS = {
     "mobilebase0_navview": "mobilebase0_navview",
 }
 
+ENV_PROTOCOL_VERSION = 1
+EXPECTED_ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
+EXPECTED_ACTION_DIM = sum(EXPECTED_ACTION_FIELDS.values())
+EXPECTED_CAMERAS = {
+    "robot0_agentview_left",
+    "robot0_agentview_right",
+    "robot0_eye_in_hand",
+}
+MAX_RENDER_DIM = 4096
+MAX_ACTION_CHUNK = 512
+
+
+def _positive_int(value, name, *, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be in [1, {maximum}], got {value}")
+    return value
+
+
+def _finite_array(value, name, *, shape):
+    array = np.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(np.float64, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
 
 class RoboCasaEnvClient(BaseEnvClient):
     _TIMEOUT_S = {
@@ -46,80 +87,369 @@ class RoboCasaEnvClient(BaseEnvClient):
     }
 
     def __init__(self, client: RpcClient, *, expected_meta: dict):
-        super().__init__(client, expected_meta=expected_meta)
-        self.camera_h = expected_meta["camera_h"]
-        self.camera_w = expected_meta["camera_w"]
+        self._client = client
+        server_meta = self._client.call(
+            "env.get_env_meta", timeout_s=self._TIMEOUT_S["default"]
+        )
+        if server_meta != expected_meta:
+            raise RuntimeError(
+                f"env_meta mismatch: expected={expected_meta!r} "
+                f"actual={server_meta!r}. The env_server was launched with "
+                "different args than this client expects — kill the stale "
+                "env_server and relaunch."
+            )
+        self.camera_h = server_meta["camera_h"]
+        self.camera_w = server_meta["camera_w"]
+        self.runtime_info = self._client.call(
+            "env.get_runtime_info", timeout_s=self._TIMEOUT_S["default"]
+        )
+        self._validate_runtime_info(self.runtime_info)
+        self.runtime_id = self.runtime_info["runtime_id"]
+        self._action_dim = int(self.runtime_info["action_schema"]["flat_dim"])
+        self._episode_id = int(self.runtime_info["episode_id"])
+        self._sim_step = int(self.runtime_info["sim_step"])
+        self._success_latched = bool(self.runtime_info["success_latched"])
+        self.last_obs = None
+        self.reset()
+
+    @staticmethod
+    def _validate_runtime_info(info):
+        if not isinstance(info, Mapping):
+            raise TypeError("env runtime handshake must return a mapping")
+        if info.get("protocol_version") != ENV_PROTOCOL_VERSION:
+            raise RuntimeError(
+                f"unsupported env protocol_version={info.get('protocol_version')!r}; "
+                f"expected {ENV_PROTOCOL_VERSION}"
+            )
+        runtime_id = info.get("runtime_id")
+        if not isinstance(runtime_id, str) or not runtime_id:
+            raise RuntimeError("env runtime handshake is missing runtime_id")
+        schema = info.get("action_schema")
+        if (
+            not isinstance(schema, Mapping)
+            or schema.get("flat_dim") != EXPECTED_ACTION_DIM
+        ):
+            raise RuntimeError(f"incompatible env action schema: {schema!r}")
+        fields = schema.get("fields")
+        if not isinstance(fields, list):
+            raise RuntimeError("env action schema fields must be a list")
+        actual_fields = {
+            field.get("name"): field.get("size")
+            for field in fields
+            if isinstance(field, Mapping)
+        }
+        if actual_fields != EXPECTED_ACTION_FIELDS:
+            raise RuntimeError(
+                f"incompatible env action fields: expected={EXPECTED_ACTION_FIELDS!r}, "
+                f"actual={actual_fields!r}"
+            )
+        cameras = info.get("cameras")
+        if not isinstance(cameras, list):
+            raise RuntimeError("env runtime cameras must be a list")
+        perception_isolation = info.get("perception_isolation", False)
+        if not isinstance(perception_isolation, bool):
+            raise RuntimeError("invalid env runtime perception_isolation flag")
+        required_cameras = set(EXPECTED_CAMERAS)
+        if perception_isolation:
+            required_cameras.add("mobilebase0_navview")
+        missing_cameras = required_cameras.difference(cameras)
+        if missing_cameras:
+            raise RuntimeError(
+                f"env runtime is missing required cameras {sorted(missing_cameras)}"
+            )
+        for key in ("episode_id", "sim_step"):
+            value = info.get(key)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise RuntimeError(f"invalid env runtime {key}={value!r}")
+        if not isinstance(info.get("success_latched"), bool):
+            raise RuntimeError("invalid env runtime success_latched flag")
 
     def _resolve_cam(self, name):
+        if not isinstance(name, str) or not name:
+            raise TypeError("camera name must be a non-empty string")
         return CAM_ALIAS.get(name, name)
 
+    def _resolve_size(self, height, width):
+        height = self.camera_h if height is None else height
+        width = self.camera_w if width is None else width
+        return (
+            _positive_int(height, "height", maximum=MAX_RENDER_DIM),
+            _positive_int(width, "width", maximum=MAX_RENDER_DIM),
+        )
+
+    # ---- lifecycle ----
     # ---- state accessors ----
     def reset(self):
-        self.last_obs = self._client.call(
-            "env.reset", timeout_s=self._TIMEOUT_S["env.reset"]
+        obs = self._client.call("env.reset", timeout_s=self._TIMEOUT_S["env.reset"])
+        if not isinstance(obs, Mapping):
+            raise TypeError(
+                f"env.reset returned {type(obs).__name__}, expected mapping"
+            )
+        previous_episode = self._episode_id
+        runtime_info = self._client.call(
+            "env.get_runtime_info", timeout_s=self._TIMEOUT_S["default"]
         )
+        self._validate_runtime_info(runtime_info)
+        if runtime_info["runtime_id"] != self.runtime_id:
+            raise RuntimeError("env runtime changed during reset")
+        if runtime_info["episode_id"] != previous_episode + 1:
+            raise RuntimeError(
+                "env reset did not advance exactly one episode: "
+                f"before={previous_episode}, after={runtime_info['episode_id']!r}"
+            )
+        if runtime_info["sim_step"] != 0:
+            raise RuntimeError("env reset returned a nonzero simulator step")
+        self.last_obs = obs
+        self.runtime_info = runtime_info
+        self._episode_id = runtime_info["episode_id"]
+        self._sim_step = 0
+        self._success_latched = runtime_info["success_latched"]
         return self.last_obs
 
     def step(self, flat_action):
+        action = _finite_array(flat_action, "flat_action", shape=(self._action_dim,))
         result = self._client.call(
-            "env.step", args=(flat_action,), timeout_s=self._TIMEOUT_S["env.step"]
+            "env.step", args=(action,), timeout_s=self._TIMEOUT_S["env.step"]
         )
-        self.last_obs = result[0]
+        if not isinstance(result, (list, tuple)) or len(result) != 4:
+            raise RuntimeError("env.step must return (obs, reward, done, info)")
+        obs, reward, done, info = result
+        if not isinstance(obs, Mapping):
+            raise TypeError("env.step observation must be a mapping")
+        if isinstance(reward, bool) or not isinstance(reward, (int, float, np.number)):
+            raise TypeError("env.step reward must be numeric")
+        if not np.isfinite(float(reward)):
+            raise ValueError("env.step reward must be finite")
+        if not isinstance(done, (bool, np.bool_)):
+            raise TypeError("env.step done must be boolean")
+        if not isinstance(info, Mapping):
+            raise TypeError("env.step info must be a mapping")
+        if info.get("rpent_runtime_id") != self.runtime_id:
+            raise RuntimeError("env.step response came from a different runtime")
+        if info.get("rpent_episode_id") != self._episode_id:
+            raise RuntimeError("env.step response episode identity mismatch")
+        sim_step = info.get("rpent_sim_step")
+        if (
+            isinstance(sim_step, bool)
+            or not isinstance(sim_step, int)
+            or sim_step != self._sim_step + 1
+        ):
+            raise RuntimeError(
+                f"env.step sequence mismatch: expected {self._sim_step + 1}, got {sim_step!r}"
+            )
+        success_latched = info.get("rpent_success_latched")
+        if not isinstance(success_latched, bool):
+            raise RuntimeError("env.step response is missing the success latch")
+        self._sim_step = sim_step
+        self._success_latched = self._success_latched or success_latched
+        self.last_obs = obs
         return result
 
+    def chunk_step(self, flat_actions, *, return_all_frames=False):
+        """Apply a bounded chunk and verify the server's per-action identities."""
+        actions = np.asarray(flat_actions)
+        if actions.ndim != 2 or actions.shape[1:] != (self._action_dim,):
+            raise ValueError(
+                f"flat_actions must have shape (steps, {self._action_dim}), "
+                f"got {actions.shape}"
+            )
+        if not 1 <= actions.shape[0] <= MAX_ACTION_CHUNK:
+            raise ValueError(
+                f"action chunk length must be in [1, {MAX_ACTION_CHUNK}], "
+                f"got {actions.shape[0]}"
+            )
+        if not np.issubdtype(actions.dtype, np.number) or np.issubdtype(
+            actions.dtype, np.bool_
+        ):
+            raise TypeError("flat_actions must contain numeric values")
+        if not np.isfinite(actions).all():
+            raise ValueError("flat_actions must contain only finite values")
+        if not isinstance(return_all_frames, (bool, np.bool_)):
+            raise TypeError("return_all_frames must be boolean")
+        result = self._client.call(
+            "env.chunk_step",
+            args=(actions,),
+            kwargs={"return_all_frames": bool(return_all_frames)},
+            timeout_s=self._TIMEOUT_S["env.chunk_step"],
+        )
+        if not isinstance(result, (list, tuple)) or len(result) != 4:
+            raise RuntimeError(
+                "env.chunk_step must return (obs, rewards, dones, infos)"
+            )
+        obs_field, rewards, dones, infos = result
+        observations = obs_field if return_all_frames else [obs_field]
+        if not isinstance(observations, list) or not observations:
+            raise RuntimeError("env.chunk_step returned no observations")
+        if any(not isinstance(obs, Mapping) for obs in observations):
+            raise TypeError("env.chunk_step observations must be mappings")
+        if not isinstance(infos, list) or not 1 <= len(infos) <= actions.shape[0]:
+            raise RuntimeError("env.chunk_step returned an invalid info sequence")
+        rewards = _finite_array(rewards, "chunk rewards", shape=(len(infos),))
+        dones = np.asarray(dones)
+        if dones.shape != (len(infos),) or dones.dtype != np.bool_:
+            raise ValueError(
+                f"chunk dones must be boolean with shape {(len(infos),)}, "
+                f"got dtype={dones.dtype}, shape={dones.shape}"
+            )
+        if return_all_frames and len(observations) != len(infos):
+            raise RuntimeError("env.chunk_step observation/info lengths differ")
+        for info in infos:
+            if not isinstance(info, Mapping):
+                raise TypeError("env.chunk_step infos must be mappings")
+            expected_step = self._sim_step + 1
+            if (
+                info.get("rpent_runtime_id") != self.runtime_id
+                or info.get("rpent_episode_id") != self._episode_id
+                or info.get("rpent_sim_step") != expected_step
+            ):
+                raise RuntimeError("env.chunk_step response identity/sequence mismatch")
+            latched = info.get("rpent_success_latched")
+            if not isinstance(latched, bool):
+                raise RuntimeError(
+                    "env.chunk_step response is missing the success latch"
+                )
+            self._sim_step = expected_step
+            self._success_latched = self._success_latched or latched
+        if self._success_latched and len(infos) > 1:
+            first_success = next(
+                (i for i, info in enumerate(infos) if info["rpent_success_latched"]),
+                None,
+            )
+            if first_success is not None and first_success != len(infos) - 1:
+                raise RuntimeError("env.chunk_step did not stop at the first success")
+        self.last_obs = observations[-1]
+        return obs_field, rewards, dones, infos
+
     def check_success(self):
-        return self._client.call(
+        if self._success_latched:
+            return True
+        value = self._client.call(
             "env.check_success", timeout_s=self._TIMEOUT_S["default"]
         )
+        if not isinstance(value, (bool, np.bool_)):
+            raise TypeError("env.check_success must return a boolean")
+        self._success_latched = bool(value)
+        return self._success_latched
+
+    @property
+    def success_latched(self):
+        """Return the authoritative latch carried by reset and step responses."""
+        return self._success_latched
 
     @property
     def terminated(self):
         return self.check_success()
 
     @property
+    def action_dim(self):
+        return self._action_dim
+
+    @property
     def current_raw_obs(self):
+        if self.last_obs is None:
+            raise RuntimeError("environment has not been reset")
         return self.last_obs
 
     @property
     def eef_pos(self):
-        return np.array(self.last_obs["robot0_eef_pos"], dtype=np.float64)
+        return _finite_array(
+            self.current_raw_obs["robot0_eef_pos"],
+            "robot0_eef_pos",
+            shape=(3,),
+        )
 
     @property
     def eef_quat(self):
-        return np.array(self.last_obs["robot0_eef_quat"], dtype=np.float64)
+        return _finite_array(
+            self.current_raw_obs["robot0_eef_quat"],
+            "robot0_eef_quat",
+            shape=(4,),
+        )
 
     @property
     def gripper_qpos(self):
-        return np.array(self.last_obs.get("robot0_gripper_qpos", []), dtype=np.float64)
+        return _finite_array(
+            self.current_raw_obs.get("robot0_gripper_qpos"),
+            "robot0_gripper_qpos",
+            shape=(2,),
+        )
 
     # ---- task info ----
+    def get_task_language(self) -> str | None:
+        value = super().get_task_language()
+        if value is not None and not isinstance(value, str):
+            raise TypeError("env.get_task_language must return a string or null")
+        return value
+
     def get_success_criteria_text(self):
         return self._client.call(
             "env.get_success_criteria_text", timeout_s=self._TIMEOUT_S["default"]
         )
 
     def get_task_progress(self):
-        return self._client.call(
+        progress = self._client.call(
             "env.get_task_progress", timeout_s=self._TIMEOUT_S["default"]
         )
+        if not isinstance(progress, Mapping):
+            raise TypeError("env.get_task_progress must return a mapping")
+        return dict(progress)
 
     # ---- rendering / perception ----
+    def _render_native(self, camera_name, height, width, depth):
+        """Render through the shared RPC contract and validate its payload."""
+        camera_name = self._resolve_cam(camera_name)
+        height, width = self._resolve_size(height, width)
+        if not isinstance(depth, (bool, np.bool_)):
+            raise TypeError("depth must be a boolean")
+        result = super().render_camera(
+            camera_name,
+            height=height,
+            width=width,
+            depth=bool(depth),
+        )
+        if depth:
+            if not isinstance(result, (list, tuple)) or len(result) != 2:
+                raise RuntimeError("depth render must return (rgb, depth)")
+            rgb = np.asarray(result[0])
+            real = _finite_array(result[1], "depth", shape=(height, width))
+            if rgb.shape != (height, width, 3) or rgb.dtype != np.uint8:
+                raise ValueError(
+                    f"RGB render must be uint8 with shape {(height, width, 3)}, "
+                    f"got dtype={rgb.dtype}, shape={rgb.shape}"
+                )
+            return rgb, real
+        rgb = np.asarray(result)
+        if rgb.shape != (height, width, 3) or rgb.dtype != np.uint8:
+            raise ValueError(
+                f"RGB render must be uint8 with shape {(height, width, 3)}, "
+                f"got dtype={rgb.dtype}, shape={rgb.shape}"
+            )
+        return rgb
+
     def render_camera(self, camera_name, height=None, width=None, depth=False):
         """Agent-facing: vertically flip to top-down so the rgb reads naturally and
         is pixel-aligned with world_map()."""
         cam = self._resolve_cam(camera_name)
-        h = height or self.camera_h
-        w = width or self.camera_w
+        h, w = self._resolve_size(height, width)
         if depth:
-            rgb, real = super().render_camera(cam, height=h, width=w, depth=True)
+            rgb, real = self._render_native(cam, h, w, True)
             return rgb[::-1], real[::-1]
-        return super().render_camera(cam, height=h, width=w, depth=False)[::-1]
+        return self._render_native(cam, h, w, False)[::-1]
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         cam = self._resolve_cam(camera_name)
-        h = height or self.camera_h
-        w = width or self.camera_w
-        return super().get_camera_meta(cam, height=h, width=w)
+        h, w = self._resolve_size(height, width)
+        meta = super().get_camera_meta(cam, height=h, width=w)
+        if not isinstance(meta, Mapping):
+            raise TypeError("camera metadata must be a mapping")
+        if (
+            meta.get("runtime_id") != self.runtime_id
+            or meta.get("episode_id") != self._episode_id
+        ):
+            raise RuntimeError("camera metadata identity mismatch")
+        _finite_array(meta.get("intrinsic"), "camera intrinsic", shape=(3, 3))
+        _finite_array(meta.get("extrinsic_cam2world"), "camera extrinsic", shape=(4, 4))
+        return dict(meta)
 
     def world_map(self, camera_name, height=None, width=None):
         """HxWx3 world xyz per pixel, TOP-DOWN (row 0 = image top), pixel-aligned
@@ -128,34 +458,53 @@ class RoboCasaEnvClient(BaseEnvClient):
         transform's top-down convention (VERIFIED: GT object back-projects within
         ~2cm). Dense vectorized: world = T_p2w @ [col*z, row*z, z, 1]."""
         cam = self._resolve_cam(camera_name)
-        h = height or self.camera_h
-        w = width or self.camera_w
-        _, z_native = super().render_camera(
-            cam, height=h, width=w, depth=True
-        )  # metric depth, bottom-up
+        h, w = self._resolve_size(height, width)
+        _, z_native = self._render_native(cam, h, w, True)  # metric depth, bottom-up
         z = z_native[::-1]  # -> top-down
         T_p2w = self._client.call(
             "env.get_camera_transform",
             kwargs={"camera_name": cam, "height": h, "width": w},
             timeout_s=self._TIMEOUT_S["default"],
         )
+        T_p2w = _finite_array(T_p2w, "pixel-to-world transform", shape=(4, 4))
         rows, cols = np.meshgrid(np.arange(h), np.arange(w), indexing="ij")
         homog = np.stack([cols * z, rows * z, z, np.ones_like(z)], axis=-1)  # HxWx4
         world = homog @ T_p2w.T  # HxWx4
         return world[..., :3]  # top-down, aligned with rgb
 
     def world_xyz_at(self, camera_name, row, col, height=None, width=None):
-        return self.world_map(camera_name, height, width)[row, col]
+        if isinstance(row, (bool, np.bool_)) or not isinstance(row, (int, np.integer)):
+            raise TypeError("row must be an integer")
+        if isinstance(col, (bool, np.bool_)) or not isinstance(col, (int, np.integer)):
+            raise TypeError("col must be an integer")
+        world = self.world_map(camera_name, height, width)
+        row, col = int(row), int(col)
+        if not (0 <= row < world.shape[0] and 0 <= col < world.shape[1]):
+            raise IndexError(f"pixel ({row}, {col}) is outside {world.shape[:2]}")
+        return world[row, col]
 
     # ---- other ----
     def grasp_contact(self):
-        return self._client.call(
+        result = self._client.call(
             "env.grasp_contact", timeout_s=self._TIMEOUT_S["env.grasp_contact"]
         )
+        if not isinstance(result, (list, tuple)) or len(result) != 2:
+            raise RuntimeError("env.grasp_contact must return (bool, object_name)")
+        grasping, object_name = result
+        if not isinstance(grasping, (bool, np.bool_)):
+            raise TypeError("env.grasp_contact flag must be boolean")
+        if object_name is not None and not isinstance(object_name, str):
+            raise TypeError("env.grasp_contact object name must be a string or null")
+        return bool(grasping), object_name
 
     def reassemble_env_action(self, unmap_result):
-        return self._client.call(
+        if not isinstance(unmap_result, Mapping):
+            raise TypeError("unmap_result must be a mapping")
+        action = self._client.call(
             "env.reassemble_env_action",
-            args=(unmap_result,),
+            args=(dict(unmap_result),),
             timeout_s=self._TIMEOUT_S["default"],
+        )
+        return _finite_array(
+            action, "reassembled env action", shape=(self._action_dim,)
         )

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -22,6 +22,8 @@ import re
 import sys
 import threading
 import traceback
+import uuid
+from collections.abc import Mapping
 
 import numpy as np
 
@@ -39,6 +41,57 @@ DEFAULT_CAMS = [
     "robot0_agentview_right",
     "robot0_eye_in_hand",
 ]
+
+ENV_PROTOCOL_VERSION = 1
+NAV_CAMERA = "mobilebase0_navview"
+RLDX_ACTION_FIELDS = (
+    ("action.end_effector_position", 3),
+    ("action.end_effector_rotation", 3),
+    ("action.gripper_close", 1),
+    ("action.base_motion", 4),
+    ("action.control_mode", 1),
+)
+RLDX_ACTION_DIM = sum(size for _, size in RLDX_ACTION_FIELDS)
+MAX_RENDER_DIM = 4096
+MAX_RENDER_PIXELS = MAX_RENDER_DIM * MAX_RENDER_DIM
+MAX_ACTION_CHUNK = 512
+
+
+def _env_flag(name, default):
+    raw = os.environ.get(name, default)
+    if raw not in {"0", "1"}:
+        raise ValueError(f"{name} must be 0 or 1, got {raw!r}")
+    return raw == "1"
+
+
+def _positive_int(value, name, *, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be in [1, {maximum}], got {value}")
+    return value
+
+
+def _finite_array(value, name, *, shape):
+    array = np.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(np.float64, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _finite_action_part(value, name, size):
+    array = np.asarray(value)
+    if size == 1 and array.shape == ():
+        array = array.reshape(1)
+    return _finite_array(array, name, shape=(size,))
 
 
 def _split_kwargs(split):
@@ -87,6 +140,9 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         cameras=None,
         use_camera_obs=False,
     ):
+        self._perception_isolation = _env_flag("RLDX_PERCEPTION_ISOLATION", "0")
+        self._allow_reset = _env_flag("RLDX_ALLOW_RESET", "0")
+        self._initial_reset_consumed = False
         super().__init__()
         import robocasa  # noqa: F401 — registers robocasa envs
         import robosuite
@@ -118,6 +174,26 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             **_split_kwargs(split),
         )
         self.env = robosuite.make(**env_kwargs)
+        self._runtime_id = uuid.uuid4().hex
+        self._episode_id = 0
+        self._sim_step = 0
+        self._success_latched = False
+        self._camera_names = self._discover_camera_names()
+        required_cameras = set(DEFAULT_CAMS)
+        if self._perception_isolation:
+            required_cameras.add(NAV_CAMERA)
+        missing_cameras = required_cameras.difference(self._camera_names)
+        if missing_cameras:
+            raise RuntimeError(
+                "RoboCasa camera contract is not satisfied; missing "
+                f"{sorted(missing_cameras)}. {NAV_CAMERA!r} requires the PandaOmron "
+                "navview XML patch on robosuite commit 85abee228d1c43ab1939bce33028099945d453b4."
+            )
+        if int(self.env.action_dim) != RLDX_ACTION_DIM:
+            raise RuntimeError(
+                f"RLDX/RoboCasa action schema requires {RLDX_ACTION_DIM} values, "
+                f"but env.action_dim={self.env.action_dim}"
+            )
         self._meta = {
             "task_name": self.task_name,
             "split": self.split,
@@ -133,24 +209,75 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         self._rpc["env.get_camera_transform"] = self.get_camera_transform
         self._rpc["env.grasp_contact"] = self.grasp_contact
         self._rpc["env.reassemble_env_action"] = self.reassemble_env_action
-        self._rpc["env.get_success_criteria_text"] = self.get_success_criteria_text
-        self._rpc["env.get_task_progress"] = self.get_task_progress
+        if not self._perception_isolation:
+            self._rpc["env.get_success_criteria_text"] = self.get_success_criteria_text
+            self._rpc["env.get_task_progress"] = self.get_task_progress
+        self._rpc["env.get_runtime_info"] = self.get_runtime_info
         # Read-only methods
         self._readonly_methods.update(
             [
-                "env.check_success",
                 "env.get_camera_transform",
+                "env.check_success",
                 "env.grasp_contact",
-                "env.get_success_criteria_text",
-                "env.get_task_progress",
+                "env.get_runtime_info",
             ]
         )
+        if not self._perception_isolation:
+            self._readonly_methods.update(
+                {
+                    "env.get_success_criteria_text",
+                    "env.get_task_progress",
+                }
+            )
 
     def get_env_meta(self):
         return self._meta
 
+    def _discover_camera_names(self):
+        model = self.env.sim.model
+        raw_names = getattr(model, "camera_names", ())
+        names = (
+            {str(name) for name in raw_names if name}
+            if raw_names is not None
+            else set()
+        )
+        for name in DEFAULT_CAMS + [NAV_CAMERA]:
+            try:
+                model.camera_name2id(name)
+            except Exception:
+                continue
+            names.add(name)
+        return names
+
+    def get_runtime_info(self):
+        return {
+            "protocol_version": ENV_PROTOCOL_VERSION,
+            "runtime_id": self._runtime_id,
+            "episode_id": self._episode_id,
+            "sim_step": self._sim_step,
+            "success_latched": self._success_latched,
+            "perception_isolation": self._perception_isolation,
+            "robot": "PandaOmron",
+            "action_schema": {
+                "name": "robocasa.panda_omron.flat.v1",
+                "flat_dim": RLDX_ACTION_DIM,
+                "fields": [
+                    {"name": name, "size": size} for name, size in RLDX_ACTION_FIELDS
+                ],
+            },
+            "cameras": sorted(self._camera_names),
+        }
+
     # ---- lifecycle ----
     def reset(self):
+        if (
+            getattr(self, "_perception_isolation", False)
+            and not getattr(self, "_allow_reset", False)
+            and getattr(self, "_initial_reset_consumed", False)
+        ):
+            raise PermissionError(
+                "reset is disabled after formal episode initialization"
+            )
         # RLDX_RESET_SEED=<episode_seed> -> reproduce the EXACT scene the fullshot eval
         # generated for that episode, seeded the SAME way as the eval's VideoRecordingWrapper
         # (random.seed + np.random.seed + robosuite env.rng/seed) BEFORE reset. Lets the
@@ -160,72 +287,219 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         if rs_env:
             import random
 
-            sd = int(rs_env)
+            try:
+                sd = int(rs_env)
+            except ValueError as exc:
+                raise ValueError("RLDX_RESET_SEED must be an integer") from exc
+            if sd < 0 or sd > np.iinfo(np.uint32).max:
+                raise ValueError("RLDX_RESET_SEED must be in [0, 2**32 - 1]")
             random.seed(sd)
             np.random.seed(sd)
             if hasattr(self.env, "seed"):
                 self.env.seed = sd
             if hasattr(self.env, "rng"):
                 self.env.rng = np.random.default_rng(sd)
-        return self.env.reset()
+        obs = self.env.reset()
+        if not isinstance(obs, dict):
+            raise TypeError(
+                f"env.reset must return an observation dict, got {type(obs).__name__}"
+            )
+        self._episode_id += 1
+        self._sim_step = 0
+        self._success_latched = bool(self.env._check_success())
+        self._initial_reset_consumed = True
+        return obs
 
     def step(self, flat_action):
         """flat_action: np.ndarray[12] = [eef_pos(3), eef_rot(3), gripper(1),
         base_motion(4), control_mode(1)] in the PandaOmron composite layout."""
-        a = np.asarray(flat_action, dtype=np.float64).reshape(-1)
-        assert a.shape[0] == self.env.action_dim, (
-            f"action dim {a.shape[0]} != env.action_dim {self.env.action_dim}"
+        a = _finite_array(
+            flat_action,
+            "flat_action",
+            shape=(int(self.env.action_dim),),
         )
+        if self._success_latched:
+            raise RuntimeError(
+                "episode success is already latched; further motion is disabled"
+            )
         obs, reward, done, info = self.env.step(a)
+        if not isinstance(obs, dict):
+            raise TypeError(
+                f"env.step must return an observation dict, got {type(obs).__name__}"
+            )
+        self._sim_step += 1
+        success_now = bool(self.env._check_success())
+        self._success_latched = self._success_latched or success_now
+        info = dict(info) if isinstance(info, dict) else {"env_info": info}
+        info.update(
+            {
+                "rpent_runtime_id": self._runtime_id,
+                "rpent_episode_id": self._episode_id,
+                "rpent_sim_step": self._sim_step,
+                "rpent_success_now": success_now,
+                "rpent_success_latched": self._success_latched,
+            }
+        )
         return obs, reward, done, info
 
+    def chunk_step(self, flat_actions, *, return_all_frames=False):
+        """Apply a bounded action chunk, stopping at the first latched success."""
+        actions = np.asarray(flat_actions)
+        if actions.ndim != 2 or actions.shape[1:] != (int(self.env.action_dim),):
+            raise ValueError(
+                "flat_actions must have shape "
+                f"(steps, {self.env.action_dim}), got {actions.shape}"
+            )
+        if not 1 <= actions.shape[0] <= MAX_ACTION_CHUNK:
+            raise ValueError(
+                f"action chunk length must be in [1, {MAX_ACTION_CHUNK}], "
+                f"got {actions.shape[0]}"
+            )
+        if not np.issubdtype(actions.dtype, np.number) or np.issubdtype(
+            actions.dtype, np.bool_
+        ):
+            raise TypeError("flat_actions must contain numeric values")
+        if not np.isfinite(actions).all():
+            raise ValueError("flat_actions must contain only finite values")
+        if not isinstance(return_all_frames, (bool, np.bool_)):
+            raise TypeError("return_all_frames must be boolean")
+
+        observations = []
+        rewards = []
+        dones = []
+        infos = []
+        for action in actions:
+            obs, reward, done, info = self.step(action)
+            observations.append(obs)
+            rewards.append(reward)
+            dones.append(done)
+            infos.append(info)
+            if self._success_latched:
+                break
+        obs_field = observations if return_all_frames else observations[-1]
+        return (
+            obs_field,
+            np.asarray(rewards, dtype=np.float64),
+            np.asarray(dones, dtype=np.bool_),
+            infos,
+        )
+
     def check_success(self):
-        return bool(self.env._check_success())
+        return self._success_latched
+
+    def _validate_camera_request(self, camera_name, height, width):
+        if not isinstance(camera_name, str) or not camera_name:
+            raise TypeError("camera_name must be a non-empty string")
+        if camera_name not in self._camera_names:
+            raise ValueError(
+                f"unknown camera {camera_name!r}; available={sorted(self._camera_names)}"
+            )
+        height = self.camera_h if height is None else height
+        width = self.camera_w if width is None else width
+        height = _positive_int(height, "height", maximum=MAX_RENDER_DIM)
+        width = _positive_int(width, "width", maximum=MAX_RENDER_DIM)
+        if height * width > MAX_RENDER_PIXELS:
+            raise ValueError(f"render size {height}x{width} exceeds pixel budget")
+        return camera_name, height, width
 
     def render_camera(self, camera_name, height, width, depth):
-        """sim.render in ROBOSUITE-NATIVE orientation (matches the camera
-        transform matrices). rgb uint8 HxWx3, depth metric HxW."""
+        """Render one validated camera in robosuite-native orientation."""
         import robosuite.utils.camera_utils as CU
 
+        camera_name, height, width = self._validate_camera_request(
+            camera_name, height, width
+        )
+        if not isinstance(depth, (bool, np.bool_)):
+            raise TypeError("depth must be a boolean")
         out = self.env.sim.render(
-            width=width, height=height, camera_name=camera_name, depth=depth
+            width=width,
+            height=height,
+            camera_name=camera_name,
+            depth=depth,
         )
         if depth:
-            rgb, d = out
-            # Sanitize the raw OpenGL normalized depth into [0,1]: replace NaN/inf
-            # (degenerate camera pose) then clip numerical overshoot. Otherwise an
-            # assertion inside get_real_depth_map crashes the whole env server process.
-            d = np.nan_to_num(d, nan=1.0, posinf=1.0, neginf=0.0)
-            d = np.clip(d, 0.0, 1.0)
-            if d.ndim == 3:
-                depth = CU.get_real_depth_map(self.env.sim, d)[..., 0]
+            rgb, normalized_depth = out
+            rgb = np.asarray(rgb)
+            normalized_depth = np.asarray(normalized_depth)
+            if rgb.shape != (height, width, 3):
+                raise ValueError(
+                    "rendered RGB must have shape "
+                    f"{(height, width, 3)}, got {rgb.shape}"
+                )
+            if normalized_depth.shape not in {
+                (height, width),
+                (height, width, 1),
+            }:
+                raise ValueError(
+                    "rendered depth must have shape "
+                    f"{(height, width)} or {(height, width, 1)}, "
+                    f"got {normalized_depth.shape}"
+                )
+            normalized_depth = np.nan_to_num(
+                normalized_depth,
+                nan=1.0,
+                posinf=1.0,
+                neginf=0.0,
+            )
+            normalized_depth = np.clip(normalized_depth, 0.0, 1.0)
+            if normalized_depth.ndim == 3:
+                real_depth = CU.get_real_depth_map(self.env.sim, normalized_depth)[
+                    ..., 0
+                ]
             else:
-                depth = CU.get_real_depth_map(self.env.sim, d[..., None])[..., 0]
-            return rgb, depth
-        return out
+                real_depth = CU.get_real_depth_map(
+                    self.env.sim, normalized_depth[..., None]
+                )[..., 0]
+            return rgb, real_depth
+        rgb = np.asarray(out)
+        if rgb.shape != (height, width, 3):
+            raise ValueError(
+                f"rendered RGB must have shape {(height, width, 3)}, got {rgb.shape}"
+            )
+        return rgb
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         import robosuite.utils.camera_utils as CU
 
+        camera_name, height, width = self._validate_camera_request(
+            camera_name, height, width
+        )
         K = CU.get_camera_intrinsic_matrix(self.env.sim, camera_name, height, width)
         Ext = CU.get_camera_extrinsic_matrix(self.env.sim, camera_name)  # cam->world
+        K = _finite_array(K, "camera intrinsic", shape=(3, 3))
+        Ext = _finite_array(Ext, "camera extrinsic", shape=(4, 4))
         m = self.env.sim.model
         extent = m.stat.extent
+        near = float(m.vis.map.znear * extent)
+        far = float(m.vis.map.zfar * extent)
+        if not np.isfinite([near, far]).all() or not (0 < near < far):
+            raise ValueError(f"invalid camera depth range near={near}, far={far}")
         return {
             "camera_name": camera_name,
             "height": height,
             "width": width,
-            "intrinsic": np.asarray(K, dtype=np.float64).tolist(),
-            "extrinsic_cam2world": np.asarray(Ext, dtype=np.float64).tolist(),
-            "depth_near": float(m.vis.map.znear * extent),
-            "depth_far": float(m.vis.map.zfar * extent),
+            "intrinsic": K.tolist(),
+            "extrinsic_cam2world": Ext.tolist(),
+            "depth_near": near,
+            "depth_far": far,
+            "runtime_id": self._runtime_id,
+            "episode_id": self._episode_id,
+            "sim_step": self._sim_step,
         }
 
     def get_camera_transform(self, camera_name, height=None, width=None):
         import robosuite.utils.camera_utils as CU
 
+        camera_name, height, width = self._validate_camera_request(
+            camera_name, height, width
+        )
         T = CU.get_camera_transform_matrix(self.env.sim, camera_name, height, width)
-        return np.linalg.inv(T)  # T_p2w
+        T = _finite_array(T, "camera transform", shape=(4, 4))
+        try:
+            inverse = np.linalg.inv(T)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError("camera transform is singular") from exc
+        return inverse  # T_p2w
 
     def get_task_language(self) -> str | None:
         return self.env.get_ep_meta().get("lang")
@@ -251,6 +525,9 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             HybridMobileBase,
         )
 
+        if not isinstance(unmap_result, Mapping):
+            raise TypeError("unmap_result must be a mapping")
+        parts = dict(unmap_result)
         env_action = []
         for robot in self.env.robots:
             cc = robot.composite_controller
@@ -258,14 +535,30 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             a = np.zeros(cc.action_limits[0].shape)
             for part_name in cc.part_controllers:
                 s, e = cc._action_split_indexes[part_name]
-                a[s:e] = unmap_result.pop(f"{pf}{part_name}")
+                key = f"{pf}{part_name}"
+                if key not in parts:
+                    raise ValueError(f"unmap_result is missing {key!r}")
+                a[s:e] = _finite_action_part(parts.pop(key), key, e - s)
             if isinstance(cc, HybridMobileBase):
-                a[-1] = unmap_result.pop(f"{pf}base_mode")
+                key = f"{pf}base_mode"
+                if key not in parts:
+                    raise ValueError(f"unmap_result is missing {key!r}")
+                a[-1] = _finite_action_part(parts.pop(key), key, 1)[0]
             env_action.append(a)
-        return np.concatenate(env_action)
+        if parts:
+            raise ValueError(f"unmap_result has unexpected keys: {sorted(parts)}")
+        return _finite_array(
+            np.concatenate(env_action),
+            "reassembled env action",
+            shape=(int(self.env.action_dim),),
+        )
 
     def get_success_criteria_text(self):
         """Return the success_criteria.md text for this task."""
+        if self._perception_isolation:
+            raise PermissionError(
+                "success criteria are unavailable in perception-isolated evaluation"
+            )
         env = self.env
         out = []
         try:
@@ -306,6 +599,10 @@ class RoboCasaEnvFacade(BaseEnvFacade):
 
     def get_task_progress(self):
         """Return the progress dict for this task."""
+        if self._perception_isolation:
+            raise PermissionError(
+                "task progress is unavailable in perception-isolated evaluation"
+            )
         env = self.env
         prog = {}
         code = type(env)._check_success.__code__
@@ -384,9 +681,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
                 event, req = item
                 try:
                     req["result"] = self._dispatch(
-                        req["method"],
-                        req["args"],
-                        req["kwargs"],
+                        req["method"], req["args"], req["kwargs"]
                     )
                 except Exception:
                     req["error"] = traceback.format_exc()

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -22,13 +22,66 @@ from robots.robocasa.rldx_skill import RLDXSkill
 
 OSC_POS_SCALE = 0.05  # action 1.0 -> 0.05 m target delta
 OSC_ROT_SCALE = 0.5  # action 1.0 -> 0.5 rad
+MAX_ENV_STEPS = 10_000
+MAX_VLA_CHUNKS = 1_000
+MAX_VLA_ACTION_STEPS = 512
+MAX_HI_RES = 4096
+
+
+def _bounded_int(value, name, *, minimum=1, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be in [{minimum}, {maximum}], got {value}")
+    return value
+
+
+def _finite_scalar(value, name, *, minimum=None, maximum=None):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.number)
+    ):
+        raise TypeError(f"{name} must be numeric")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value}")
+    return value
+
+
+def _finite_vector(value, name, size):
+    array = np.asarray(value)
+    if array.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},), got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(np.float64, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _env_flag(name, default):
+    raw = os.environ.get(name, default)
+    if raw not in {"0", "1"}:
+        raise ValueError(f"{name} must be 0 or 1, got {raw!r}")
+    return raw == "1"
 
 
 class RoboCasaPrimitives:
     def __init__(self, env_client, workdir, hi_res, vla_client, check_cancelled=None):
         self.env = env_client
         self.workdir = workdir
-        self.hi_res = hi_res
+        self.hi_res = (
+            None
+            if hi_res is None
+            else _bounded_int(hi_res, "hi_res", maximum=MAX_HI_RES)
+        )
         # Cancellation checkpoint callback (e.g. Toolkit.raise_if_cancelled),
         # invoked before long-running env.step loops so an interrupted tool
         # operation stops promptly instead of draining the whole episode.
@@ -37,13 +90,23 @@ class RoboCasaPrimitives:
         # localizes every object, so they are never optional. Disk is bounded by keeping only
         # the last `_keep_heavy` steps' heavy npy on disk (pruned in dump_state) + each
         # launcher's per-cell workdir cleanup.
-        self._keep_heavy = int(os.environ.get("RLDX_KEEP_HEAVY_NPY", "25"))
+        try:
+            keep_heavy = int(os.environ.get("RLDX_KEEP_HEAVY_NPY", "25"))
+        except ValueError as exc:
+            raise ValueError("RLDX_KEEP_HEAVY_NPY must be an integer") from exc
+        self._keep_heavy = _bounded_int(
+            keep_heavy, "RLDX_KEEP_HEAVY_NPY", maximum=10_000
+        )
         # reset (restart the episode) is ONLY legitimate in EXPLORE mode (reset-based recipe
         # search). It is FORBIDDEN in multi-seed / matched-scene evaluation (a give-up-and-
         # restart). Gated by RLDX_ALLOW_RESET (default 0 = off); explore runs opt in.
-        self._allow_reset = bool(int(os.environ.get("RLDX_ALLOW_RESET", "0")))
+        self._allow_reset = _env_flag("RLDX_ALLOW_RESET", "0")
+        self._perception_isolation = _env_flag("RLDX_PERCEPTION_ISOLATION", "0")
         os.makedirs(workdir, exist_ok=True)
-        self.env.reset()
+        if self.env.current_raw_obs is None:
+            raise RuntimeError(
+                "RoboCasaEnvClient must complete its initial reset first"
+            )
         self._pos_jac = None  # 3x3 action(arm xyz) -> world dpos
         self._fwd_offset = None  # world_forward_heading = base_yaw + offset
         self._cam_meta_cache = {}
@@ -59,6 +122,16 @@ class RoboCasaPrimitives:
         # Recording (off by default — zero overhead when not recording)
         self._recording = False
         self._frames = []
+
+    def _invalidate_geometry(self, *, base_moved=False, vla_moved=False):
+        """Drop pose-dependent calibration after motions outside the OSC servo."""
+        if base_moved or vla_moved:
+            self._pos_jac = None
+            self._cam_meta_cache.pop("agentview", None)
+            self._cam_meta_cache.pop("navview", None)
+        if vla_moved:
+            self._fwd_offset = None
+            self._cam_meta_cache.pop("wrist", None)
 
     # ---- recording methods ----
     def start_recording(self):
@@ -98,7 +171,18 @@ class RoboCasaPrimitives:
 
     def _hold_gripper_val(self, g):
         # +1 close/hold, -1 open
+        g = _finite_scalar(g, "gripper")
         return float(np.clip(g, -1, 1))
+
+    @staticmethod
+    def _validate_gripper(gripper):
+        if gripper is None:
+            return gripper
+        if isinstance(gripper, str):
+            if gripper == "hold":
+                return gripper
+            raise ValueError("gripper string must be 'hold'")
+        return _finite_scalar(gripper, "gripper")
 
     def _resolve_grip(self, gripper, target_q):
         """Return the a[6] gripper command for a motion step.
@@ -109,6 +193,7 @@ class RoboCasaPrimitives:
         during a +1 carry). Servoing to the grasped width holds the object without crushing
         it and without letting it drift open. A numeric gripper (+1 close / -1 open) is an
         EXPLICIT override and passes through unchanged."""
+        gripper = self._validate_gripper(gripper)
         if isinstance(gripper, str) or gripper is None:
             cur = float(self.env.gripper_qpos[0])
             return float(
@@ -116,17 +201,35 @@ class RoboCasaPrimitives:
             )  # +a[6] closes (qpos↓)
         return self._hold_gripper_val(gripper)
 
+    def _success_latched(self):
+        value = getattr(self.env, "success_latched", None)
+        if value is not None:
+            return bool(value)
+        return bool(self.env.check_success())
+
+    def _apply_step(self, action, *, record=False):
+        """Apply at most one physical step and stop permanently on first success."""
+        if self._success_latched():
+            return False
+        if self._check_cancelled is not None:
+            self._check_cancelled()
+        self.env.step(action)
+        if record and self._recording:
+            self.record_frame()
+        return not self._success_latched()
+
     def _step_arm(self, dpos=(0, 0, 0), drot=(0, 0, 0), gripper=-1.0, n=1):
+        dpos = _finite_vector(dpos, "dpos", 3)
+        drot = _finite_vector(drot, "drot", 3)
+        gripper = _finite_scalar(gripper, "gripper")
+        n = _bounded_int(n, "n", maximum=MAX_ENV_STEPS)
         a = self._zero(base_mode=-1.0)
         a[0:3] = np.clip(np.asarray(dpos) / OSC_POS_SCALE, -1, 1)
         a[3:6] = np.clip(np.asarray(drot) / OSC_ROT_SCALE, -1, 1)
         a[6] = self._hold_gripper_val(gripper)
         for _ in range(n):
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
-            if self._recording:
-                self.record_frame()
+            if not self._apply_step(a, record=True):
+                break
         return self.env.eef_pos
 
     # ---- Phase 2: online jacobian + move_to ----
@@ -135,18 +238,29 @@ class RoboCasaPrimitives:
         world_dpos ~= J @ action_xyz. move_to inverts J to map desired world delta."""
         cols = []
         for axis in range(3):
+            if self._success_latched():
+                return None
             p0 = self.env.eef_pos.copy()
             a = self._zero()
             a[axis] = 0.4
             a[6] = gripper
+            applied = 0
             for _ in range(3):
-                if self._check_cancelled is not None:
-                    self._check_cancelled()
-                self.env.step(a)
-            d = (self.env.eef_pos - p0) / (0.4 * 3)  # world dpos per unit action
+                applied += 1
+                if not self._apply_step(a):
+                    return None
+            d = (self.env.eef_pos - p0) / (0.4 * applied)
             cols.append(d)
             # settle back is not needed (closed-loop re-reads); keep going
         self._pos_jac = np.stack(cols, axis=1)  # 3x3: world_dpos = J @ a_xyz
+        if (
+            not np.isfinite(self._pos_jac).all()
+            or np.linalg.matrix_rank(self._pos_jac) < 3
+        ):
+            self._pos_jac = None
+            raise RuntimeError(
+                "arm position Jacobian calibration is singular or non-finite"
+            )
         return self._pos_jac
 
     def move_to(self, xyz, gripper="hold", step_clip=0.02, max_steps=200, tol=0.012):
@@ -155,10 +269,38 @@ class RoboCasaPrimitives:
         object WITHOUT crushing it (a sustained +1 squeezes small objects out) or letting
         it drop. Pass +1 to actively CLOSE, -1 to actively OPEN."""
         self._vla_desync = True
-        target = np.asarray(xyz, dtype=np.float64)
+        target = _finite_vector(xyz, "xyz", 3)
+        gripper = self._validate_gripper(gripper)
+        step_clip = _finite_scalar(
+            step_clip, "step_clip", minimum=np.finfo(float).eps, maximum=0.30
+        )
+        max_steps = _bounded_int(max_steps, "max_steps", maximum=MAX_ENV_STEPS)
+        tol = _finite_scalar(tol, "tol", minimum=np.finfo(float).eps, maximum=1.0)
         target_q = float(self.env.gripper_qpos[0])  # finger width to hold
+        if self._success_latched():
+            cur = self.env.eef_pos
+            return {
+                "ok": True,
+                "status": "task_success",
+                "steps": 0,
+                "final_dist": float(np.linalg.norm(target - cur)),
+                "eef": cur.tolist(),
+                "gripper_qpos": round(float(self.env.gripper_qpos[0]), 4),
+            }
         if self._pos_jac is None:
-            self._calibrate_pos_jacobian(gripper=self._resolve_grip(gripper, target_q))
+            calibrated = self._calibrate_pos_jacobian(
+                gripper=self._resolve_grip(gripper, target_q)
+            )
+            if calibrated is None:
+                cur = self.env.eef_pos
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": 0,
+                    "final_dist": float(np.linalg.norm(target - cur)),
+                    "eef": cur.tolist(),
+                    "gripper_qpos": round(float(self.env.gripper_qpos[0]), 4),
+                }
         Jinv = np.linalg.pinv(self._pos_jac)
         for i in range(max_steps):
             cur = self.env.eef_pos
@@ -177,11 +319,16 @@ class RoboCasaPrimitives:
             a = self._zero()
             a[0:3] = a_xyz
             a[6] = self._resolve_grip(gripper, target_q)
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
-            if self._recording:
-                self.record_frame()
+            if not self._apply_step(a, record=True):
+                cur = self.env.eef_pos
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": i + 1,
+                    "final_dist": float(np.linalg.norm(target - cur)),
+                    "eef": cur.tolist(),
+                    "gripper_qpos": round(float(self.env.gripper_qpos[0]), 4),
+                }
         cur = self.env.eef_pos
         return {
             "ok": False,
@@ -193,27 +340,35 @@ class RoboCasaPrimitives:
 
     def move_delta(self, dxyz, gripper="hold", step_clip=0.02, max_steps=80):
         self._vla_desync = True
-        return self.move_to(
-            self.env.eef_pos + np.asarray(dxyz), gripper, step_clip, max_steps
-        )
+        dxyz = _finite_vector(dxyz, "dxyz", 3)
+        gripper = self._validate_gripper(gripper)
+        return self.move_to(self.env.eef_pos + dxyz, gripper, step_clip, max_steps)
 
     def rotate_pitch(self, target_pitch=0.6, gripper=1, n=12):
         """Tilt the wrist forward (axis-angle about control-x). Reuses arm drot."""
         self._vla_desync = True
-        per = float(np.clip(target_pitch, -1.5, 1.5)) / n
+        target_pitch = _finite_scalar(
+            target_pitch, "target_pitch", minimum=-1.5, maximum=1.5
+        )
+        gripper = _finite_scalar(gripper, "gripper")
+        n = _bounded_int(n, "n", maximum=MAX_ENV_STEPS)
+        per = target_pitch / n
         for _ in range(n):
             self._step_arm(drot=(per, 0, 0), gripper=gripper, n=1)
+            if self._success_latched():
+                break
         return {"ok": True, "eef": self.env.eef_pos.tolist()}
 
     def set_gripper(self, gripper=1, steps=10):
         self._vla_desync = True
+        gripper = _finite_scalar(gripper, "gripper")
+        steps = _bounded_int(steps, "steps", maximum=MAX_ENV_STEPS)
         g = self._hold_gripper_val(gripper)
         a = self._zero()
         a[6] = g
         for _ in range(steps):
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                break
         return {"ok": True, "gripper_qpos": self.env.gripper_qpos.tolist()}
 
     def release(self, steps=10):
@@ -223,7 +378,14 @@ class RoboCasaPrimitives:
     def scripted_grasp(self, xyz, approach_z=0.10, grasp_z_offset=0.0, step_clip=0.02):
         """Open -> hover above target -> descend -> close -> lift. Coarse; replace
         with RLDX closed-loop grasp for hard objects."""
-        t = np.asarray(xyz, dtype=np.float64)
+        t = _finite_vector(xyz, "xyz", 3)
+        approach_z = _finite_scalar(approach_z, "approach_z", minimum=0.0, maximum=1.0)
+        grasp_z_offset = _finite_scalar(
+            grasp_z_offset, "grasp_z_offset", minimum=-1.0, maximum=1.0
+        )
+        step_clip = _finite_scalar(
+            step_clip, "step_clip", minimum=np.finfo(float).eps, maximum=0.30
+        )
         self.set_gripper(-1.0, steps=4)
         r = self.move_to(t + [0, 0, approach_z], gripper=-1.0, step_clip=step_clip)
         if not r["ok"]:
@@ -247,14 +409,20 @@ class RoboCasaPrimitives:
     def _base_pose(self):
         o = self.env.current_raw_obs
         return (
-            np.asarray(o["robot0_base_pos"], dtype=np.float64),
-            np.asarray(o["robot0_base_quat"], dtype=np.float64),
+            _finite_vector(o["robot0_base_pos"], "robot0_base_pos", 3),
+            _finite_vector(o["robot0_base_quat"], "robot0_base_quat", 4),
         )
 
     def move_base(self, forward=0, lateral=0, turn=0, steps=10, gripper="hold"):
         """Raw base velocity command (robot-local: +fwd, +lateral, +turn yaw).
         gripper="hold" (DEFAULT) maintains the finger width while driving (carry-safe)."""
         self._vla_desync = True
+        forward = _finite_scalar(forward, "forward")
+        lateral = _finite_scalar(lateral, "lateral")
+        turn = _finite_scalar(turn, "turn")
+        steps = _bounded_int(steps, "steps", maximum=MAX_ENV_STEPS)
+        gripper = self._validate_gripper(gripper)
+        self._invalidate_geometry(base_moved=True)
         target_q = float(self.env.gripper_qpos[0])
         a = self._zero(base_mode=1.0)
         a[7:10] = [
@@ -265,9 +433,8 @@ class RoboCasaPrimitives:
         bp0, _ = self._base_pose()
         for _ in range(steps):
             a[6] = self._resolve_grip(gripper, target_q)
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                break
         bp1, _ = self._base_pose()
         return {
             "ok": True,
@@ -278,24 +445,26 @@ class RoboCasaPrimitives:
     def _yaw(self):
         from scipy.spatial.transform import Rotation as R
 
-        return float(
-            R.from_quat(
-                np.asarray(self.env.current_raw_obs["robot0_base_quat"])
-            ).as_euler("xyz")[2]
+        quat = _finite_vector(
+            self.env.current_raw_obs["robot0_base_quat"], "robot0_base_quat", 4
         )
+        if float(np.linalg.norm(quat)) <= np.finfo(float).eps:
+            raise ValueError("robot0_base_quat must be nonzero")
+        return float(R.from_quat(quat).as_euler("xyz")[2])
 
     def _calibrate_forward(self, gripper=1.0):
         """Drive forward briefly, measure the WORLD direction the base actually goes,
         so navigate_to can steer regardless of the base->world frame offset."""
+        gripper = _finite_scalar(gripper, "gripper")
+        self._invalidate_geometry(base_moved=True)
         p0, _ = self._base_pose()
         y0 = self._yaw()
         a = self._zero(base_mode=1.0)
         a[6] = self._hold_gripper_val(gripper)
         a[7] = 1.0
         for _ in range(6):
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                break
         p1, _ = self._base_pose()
         disp = (p1 - p0)[:2]
         if np.linalg.norm(disp) > 0.005:
@@ -310,17 +479,30 @@ class RoboCasaPrimitives:
         speed (closed-loop). Holds the arm (base_mode>0). Base ~2.3mm/step.
         gripper="hold" (DEFAULT) maintains the finger width while driving (carry-safe)."""
         self._vla_desync = True
-        target = np.asarray(xy[:2], dtype=np.float64)
+        target = _finite_vector(xy, "xy", 2)
+        tol = _finite_scalar(tol, "tol", minimum=np.finfo(float).eps, maximum=5.0)
+        max_steps = _bounded_int(max_steps, "max_steps", maximum=MAX_ENV_STEPS)
+        gripper = self._validate_gripper(gripper)
+        self._invalidate_geometry(base_moved=True)
         target_q = float(self.env.gripper_qpos[0])
         if self._fwd_offset is None:
             self._calibrate_forward(self._resolve_grip(gripper, target_q))
         start = self._base_pose()[0][:2].copy()
         for i in range(max_steps):
             bp, _ = self._base_pose()
+            if self._success_latched():
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": i,
+                    "final_dist": float(np.linalg.norm(target - bp[:2])),
+                    "moved": float(np.linalg.norm(bp[:2] - start)),
+                    "start_pos": start.tolist(),
+                    "base_pos": bp.tolist(),
+                }
             to = target - bp[:2]
             dist = float(np.linalg.norm(to))
             if dist < tol:
-                self._pos_jac = None  # base moved -> recalibrate arm
                 moved = float(np.linalg.norm(bp[:2] - start))
                 return {
                     "ok": True,
@@ -340,11 +522,18 @@ class RoboCasaPrimitives:
             else:  # drive forward + small steer
                 a[7] = 1.0
                 a[9] = float(np.clip(dyaw * 1.5, -0.4, 0.4))
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                bp = self._base_pose()[0]
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": i + 1,
+                    "final_dist": float(np.linalg.norm(target - bp[:2])),
+                    "moved": float(np.linalg.norm(bp[:2] - start)),
+                    "start_pos": start.tolist(),
+                    "base_pos": bp.tolist(),
+                }
         bp, _ = self._base_pose()
-        self._pos_jac = None
         moved = float(np.linalg.norm(bp[:2] - start))
         # stuck = ran out of steps having barely moved (rammed a fixture, no path-planning)
         return {
@@ -363,6 +552,10 @@ class RoboCasaPrimitives:
         This is the success LOGIC (conditions on named objects/fixtures + thresholds) —
         it does NOT reveal GT object COORDINATES (the agent still localizes every object
         from perception). The caller writes it to the run's EnvState."""
+        if self._perception_isolation:
+            raise PermissionError(
+                "success criteria are unavailable in perception-isolated evaluation"
+            )
         return self.env.get_success_criteria_text()
 
     def task_progress(self):
@@ -379,6 +572,8 @@ class RoboCasaPrimitives:
              read-only call of _check_success.
         This is the success CRITERION's current value — NOT ground-truth object coords
         (the agent still localizes objects from perception)."""
+        if self._perception_isolation:
+            return {}
         try:
             return self.env.get_task_progress()
         except Exception:
@@ -393,21 +588,31 @@ class RoboCasaPrimitives:
         object stays free of any output-dir / file-IO concern).
         """
         o = self.env.current_raw_obs
-        return {
-            "task_language": o.get("language", self.env.get_task_language()) or "",
-            "success": self.env.check_success(),
-            # NUMERIC progress toward success (counters/sub-predicates the env's own
-            # _check_success computes) so the agent has a feedback loop, not just a bool.
-            "task_progress": self.task_progress(),
-            "robocasa_terminated": self.env.terminated,
+        if not isinstance(o, dict):
+            raise TypeError("current_raw_obs must be a dict")
+        task_language = o.get("language") or self.env.get_task_language() or ""
+        if not isinstance(task_language, str):
+            raise TypeError("task language must be a string")
+        success = self.env.check_success()
+        base_pos = _finite_vector(o["robot0_base_pos"], "robot0_base_pos", 3)
+        base_quat = _finite_vector(o["robot0_base_quat"], "robot0_base_quat", 4)
+        result = {
+            "task_language": task_language,
+            "success": success,
             "state": {
                 "robot0_eef_pos": self.env.eef_pos.tolist(),
                 "robot0_eef_quat": self.env.eef_quat.tolist(),
                 "robot0_gripper_qpos": self.env.gripper_qpos.tolist(),
-                "robot0_base_pos": np.asarray(o["robot0_base_pos"]).tolist(),
-                "robot0_base_quat": np.asarray(o["robot0_base_quat"]).tolist(),
+                "robot0_base_pos": base_pos.tolist(),
+                "robot0_base_quat": base_quat.tolist(),
             },
         }
+        if not self._perception_isolation:
+            # Exploratory runs may opt into predicate progress. Formal evaluation
+            # omits both fields entirely and never invokes the progress RPC.
+            result["task_progress"] = self.task_progress()
+            result["robocasa_terminated"] = success
+        return result
 
     # ---- VLA execution ----
     def run_rldx_skill(
@@ -423,6 +628,24 @@ class RoboCasaPrimitives:
     ):
         """Execute a VLA skill (RLDX). Resolves task_lang, computes force_reset with
         _vla_desync, clears _vla_desync."""
+        if not isinstance(prompt, str):
+            raise TypeError("prompt must be a string")
+        if use_prompt not in (None, True, False):
+            raise TypeError("use_prompt must be true, false, or null")
+        if not isinstance(force_reset, (bool, np.bool_)):
+            raise TypeError("force_reset must be a boolean")
+        if base_clip is not None:
+            base_clip = _finite_scalar(base_clip, "base_clip", minimum=0.0, maximum=1.0)
+        max_chunks = _bounded_int(max_chunks, "max_chunks", maximum=MAX_VLA_CHUNKS)
+        n_action_steps = _bounded_int(
+            n_action_steps, "n_action_steps", maximum=MAX_VLA_ACTION_STEPS
+        )
+        settle_patience = _bounded_int(
+            settle_patience, "settle_patience", maximum=MAX_VLA_CHUNKS
+        )
+        settle_eps = _finite_scalar(
+            settle_eps, "settle_eps", minimum=np.finfo(float).eps, maximum=1.0
+        )
         if use_prompt:
             task_lang = prompt
         else:
@@ -433,17 +656,73 @@ class RoboCasaPrimitives:
         # (read _vla_desync BEFORE clearing it)
         fr = bool(force_reset) or self._vla_desync
         self._vla_desync = False
-        return self._rldx.run(
-            task_lang,
-            max_chunks,
-            n_action_steps,
-            base_clip=base_clip,
-            settle_patience=settle_patience,
-            settle_eps=settle_eps,
-            force_reset=fr,
-            recording=self._recording,
-            record_frame=self.record_frame,
+        try:
+            return self._rldx.run(
+                task_lang,
+                max_chunks,
+                n_action_steps,
+                base_clip=base_clip,
+                settle_patience=settle_patience,
+                settle_eps=settle_eps,
+                force_reset=fr,
+                recording=self._recording,
+                record_frame=self.record_frame,
+            )
+        except Exception:
+            self._vla_desync = True
+            raise
+        finally:
+            self._invalidate_geometry(vla_moved=True)
+
+    def vla_act(self, prompt):
+        """Run the frozen formal VLA primitive on the benchmark instruction."""
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise TypeError("prompt must be a non-empty string")
+        observation = self.env.current_raw_obs
+        if not isinstance(observation, dict):
+            raise TypeError("current_raw_obs must be a dict")
+        task_language = (
+            observation.get("language") or self.env.get_task_language() or ""
         )
+        if not isinstance(task_language, str) or not task_language.strip():
+            raise RuntimeError("environment task language is unavailable")
+        if prompt != task_language:
+            raise ValueError("vla_act prompt must equal state.task_language verbatim")
+        try:
+            max_chunks = int(os.environ.get("RLDX_MAX_CHUNKS", "40"))
+            settle_patience = int(os.environ.get("RLDX_SETTLE_PATIENCE", "999"))
+        except ValueError as exc:
+            raise ValueError(
+                "RLDX_MAX_CHUNKS and RLDX_SETTLE_PATIENCE must be integers"
+            ) from exc
+        max_chunks = _bounded_int(max_chunks, "RLDX_MAX_CHUNKS", maximum=MAX_VLA_CHUNKS)
+        settle_patience = _bounded_int(
+            settle_patience,
+            "RLDX_SETTLE_PATIENCE",
+            maximum=MAX_VLA_CHUNKS,
+        )
+        result = self.run_rldx_skill(
+            None,
+            max_chunks,
+            True,
+            prompt,
+            False,
+            8,
+            settle_patience,
+            0.012,
+        )
+        if not self._perception_isolation:
+            return result
+        if not isinstance(result, dict):
+            raise TypeError("VLA result must be a dict")
+        return {
+            "ok": bool(result.get("ok")),
+            "status": result.get("status"),
+            "chunks": result.get("chunks"),
+            "steps_applied": result.get("steps_applied"),
+            "contact_made": bool(result.get("grasp_detected")),
+            "holding": bool(result.get("grasped")),
+        }
 
     # ---- reset ----
     def reset(self):
@@ -462,6 +741,7 @@ class RoboCasaPrimitives:
         self.env.reset()
         self._pos_jac = None
         self._fwd_offset = None
+        self._cam_meta_cache.clear()
         self._rldx.reset_session()
         return {"ok": True, "reset": True, "eef": self.env.eef_pos.tolist()}
 

--- a/robots/robocasa/prompts/__init__.py
+++ b/robots/robocasa/prompts/__init__.py
@@ -14,4 +14,32 @@
 
 """RoboCasa prompt sections."""
 
-from robots.robocasa.prompts.system import *  # noqa: F403
+from robots.robocasa.prompts.system import (
+    ENVIRONMENT,
+    GOAL,
+    GRIPPER_RULES,
+    LOCALIZATION,
+    NAVIGATION,
+    NEXT,
+    PREAMBLE,
+    PRIMITIVES,
+    RULES,
+    USER_MODE,
+    VLA_RULES,
+    WORKFLOW,
+)
+
+__all__ = [
+    "ENVIRONMENT",
+    "GOAL",
+    "GRIPPER_RULES",
+    "LOCALIZATION",
+    "NAVIGATION",
+    "NEXT",
+    "PREAMBLE",
+    "PRIMITIVES",
+    "RULES",
+    "USER_MODE",
+    "VLA_RULES",
+    "WORKFLOW",
+]

--- a/robots/robocasa/rldx_skill.py
+++ b/robots/robocasa/rldx_skill.py
@@ -24,12 +24,73 @@ with a per-call session id + reset_memory for the RLDX memory module.
 """
 
 import os
+import uuid
 from collections import deque
+from collections.abc import Mapping
 
 import imageio.v2 as imageio
 import numpy as np
 
 from robots.robocasa.env_client import RoboCasaEnvClient
+
+ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
+STATE_FIELDS = {
+    "state.gripper_qpos": ("robot0_gripper_qpos", 2),
+    "state.base_position": ("robot0_base_pos", 3),
+    "state.base_rotation": ("robot0_base_quat", 4),
+    "state.end_effector_position_relative": ("robot0_base_to_eef_pos", 3),
+    "state.end_effector_rotation_relative": ("robot0_base_to_eef_quat", 4),
+}
+MAX_VLA_CHUNKS = 1_000
+MAX_ACTION_STEPS = 512
+
+
+def _bounded_int(value, name, *, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be in [1, {maximum}], got {value}")
+    return value
+
+
+def _finite_scalar(value, name, *, minimum=None, maximum=None):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.number)
+    ):
+        raise TypeError(f"{name} must be numeric")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value}")
+    return value
+
+
+def _numeric_vector(value, name, size, *, dtype=np.float64):
+    array = np.asarray(value)
+    if array.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},), got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(dtype, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _identity_token(value):
+    return "".join(ch for ch in str(value) if ch.isalnum())[:16] or "unknown"
 
 
 class RLDXSkill:
@@ -43,7 +104,9 @@ class RLDXSkill:
         )
         self._vdi = None  # video delta indices, e.g. [-6,-4,-2,0]
         self._hist = None  # deque of raw frame dicts
-        self._sid = "rc_agent_rldx_0"  # TODO: fix for vla, single server multi client
+        env_runtime = _identity_token(getattr(env_client, "runtime_id", "env"))
+        vla_runtime = _identity_token(getattr(vla_client, "runtime_id", "vla"))
+        self._sid = f"rc:{env_runtime}:{vla_runtime}:{uuid.uuid4().hex}"
         self._unmap = None  # lazy: eval's PandaOmronKeyConverter.unmap_action
         # OPTIONAL per-sim-step video capture. OFF by default (env RLDX_VIDEO_DIR unset):
         # the VLA rollout is closed-loop over 100s of sim-steps but the primitives only dump
@@ -51,16 +114,57 @@ class RLDXSkill:
         # When RLDX_VIDEO_DIR is set, we collect the 3 VLA camera frames (already rendered
         # for the obs — ZERO extra render cost) per step and write one mp4 per run() call.
         self._video_dir = os.environ.get("RLDX_VIDEO_DIR") or None
-        self._video_fps = int(os.environ.get("RLDX_VIDEO_FPS", "20"))
+        try:
+            video_fps = int(os.environ.get("RLDX_VIDEO_FPS", "20"))
+        except ValueError as exc:
+            raise ValueError("RLDX_VIDEO_FPS must be an integer") from exc
+        self._video_fps = _bounded_int(video_fps, "RLDX_VIDEO_FPS", maximum=240)
         self._video_idx = 0  # cmd counter for cmd_NN.mp4 naming
         self._frames = None  # list of HxWx3 uint8 for the current run() call
 
     def _load(self):
         if self._vdi is not None:
             return
+        if self._vla_client is None:
+            raise RuntimeError("RLDXSkill requires a RoboCasaVLAClient")
+        action_schema = getattr(self._vla_client, "action_schema", None)
+        if not isinstance(action_schema, Mapping):
+            raise RuntimeError(
+                "VLA client has not completed its action-schema handshake"
+            )
+        if action_schema.get("flat_dim") != self.env.action_dim:
+            raise RuntimeError(
+                f"VLA/env action dimension mismatch: VLA={action_schema.get('flat_dim')!r}, "
+                f"env={self.env.action_dim}"
+            )
+        fields = action_schema.get("fields")
+        actual_fields = {
+            item.get("name"): item.get("size")
+            for item in fields or []
+            if isinstance(item, Mapping)
+        }
+        if actual_fields != ACTION_FIELDS:
+            raise RuntimeError(
+                f"VLA action fields mismatch: expected={ACTION_FIELDS!r}, "
+                f"actual={actual_fields!r}"
+            )
         mod = self._vla_client.get_modality_config()
         self._vdi = np.asarray(mod["video_delta_indices"])
-        self._hist = deque(maxlen=mod["hist_maxlen"])
+        if (
+            self._vdi.ndim != 1
+            or self._vdi.size == 0
+            or not np.issubdtype(self._vdi.dtype, np.integer)
+            or np.any(np.diff(self._vdi) <= 0)
+            or int(self._vdi[-1]) != 0
+        ):
+            raise RuntimeError(f"invalid video_delta_indices={self._vdi!r}")
+        self._vdi = self._vdi.astype(np.int64, copy=False)
+        expected_hist = int(self._vdi.max() - self._vdi.min()) + 2
+        if mod["hist_maxlen"] != expected_hist:
+            raise RuntimeError(
+                f"hist_maxlen={mod['hist_maxlen']!r}, expected {expected_hist}"
+            )
+        self._hist = deque(maxlen=expected_hist)
         print(
             f"[rldx_skill] modality loaded via RPC; video_delta_indices={self._vdi.tolist()} "
             f"hist_maxlen={self._hist.maxlen}",
@@ -68,12 +172,15 @@ class RLDXSkill:
         )
 
     # ---- obs construction (mirror robocasa gym get_observation) ----
-    # RoboCasa365 evaluation renders the three VLA cameras at 256 instead of
-    # create_env's 128 default. Evaluation observations and primitive output
-    # are byte-identical at this resolution.
-    VLA_OBS_RES = 256
+    VLA_OBS_RES = (
+        256  # matches the eval: robocasa365 gym_wrapper get_camera_config renders
+    )
+    # the 3 VLA cameras at 256 (overriding create_env's 128 DEFAULT).
+    # Verified: eval gym obs are (256,256,3) and primitives@256 is byte-identical.
 
     def _raw_frame(self, task_text):
+        if not isinstance(task_text, str) or not task_text.strip():
+            raise ValueError("task_text must be a non-empty string")
         e = self.env
         o = e.current_raw_obs
         # render the 3 VLA cameras at the eval's resolution (256)
@@ -81,21 +188,26 @@ class RLDXSkill:
         vL = e.render_camera("robot0_agentview_left", height=r, width=r)
         vR = e.render_camera("robot0_agentview_right", height=r, width=r)
         vW = e.render_camera("robot0_eye_in_hand", height=r, width=r)
-        return {
-            "state.gripper_qpos": np.asarray(o["robot0_gripper_qpos"], np.float32),
-            "state.base_position": np.asarray(o["robot0_base_pos"], np.float32),
-            "state.base_rotation": np.asarray(o["robot0_base_quat"], np.float32),
-            "state.end_effector_position_relative": np.asarray(
-                o["robot0_base_to_eef_pos"], np.float32
-            ),
-            "state.end_effector_rotation_relative": np.asarray(
-                o["robot0_base_to_eef_quat"], np.float32
-            ),
-            "video.robot0_agentview_left": vL.astype(np.uint8),
-            "video.robot0_agentview_right": vR.astype(np.uint8),
-            "video.robot0_eye_in_hand": vW.astype(np.uint8),
-            "annotation.human.task_description": task_text,
+        frame = {
+            output_name: _numeric_vector(
+                o[input_name], input_name, size, dtype=np.float32
+            )
+            for output_name, (input_name, size) in STATE_FIELDS.items()
         }
+        for name, image in (
+            ("video.robot0_agentview_left", vL),
+            ("video.robot0_agentview_right", vR),
+            ("video.robot0_eye_in_hand", vW),
+        ):
+            image = np.asarray(image)
+            if image.shape != (r, r, 3) or image.dtype != np.uint8:
+                raise ValueError(
+                    f"{name} must be uint8 with shape {(r, r, 3)}, "
+                    f"got dtype={image.dtype}, shape={image.shape}"
+                )
+            frame[name] = image
+        frame["annotation.human.task_description"] = task_text
+        return frame
 
     def _seed_hist(self, task_text):
         """Pad the per-sim-step history with copies of the CURRENT frame, mirroring the
@@ -155,6 +267,8 @@ class RLDXSkill:
         """Build the batched (n_envs=1), history-stacked obs by indexing the per-sim-step
         history at vdi-1 = [-7,-5,-3,-1], EXACTLY like the eval MultiStepWrapper._get_obs
         (delta_indices = video_delta_indices - 1, over self.obs[i])."""
+        if self._hist is None or not self._hist:
+            raise RuntimeError("VLA observation history has not been seeded")
         buf = list(self._hist)
         idx = [len(buf) + (int(d) - 1) for d in self._vdi]  # vdi-1 offset from end
         idx = [max(0, min(len(buf) - 1, k)) for k in idx]
@@ -186,20 +300,53 @@ class RLDXSkill:
             self._unmap = PandaOmronKeyConverter.unmap_action
         ad = self._unmap(
             {
-                "action.end_effector_position": np.asarray(eef_pos, np.float64).reshape(
-                    -1
+                "action.end_effector_position": _numeric_vector(
+                    eef_pos, "action.end_effector_position", 3
                 ),
-                "action.end_effector_rotation": np.asarray(eef_rot, np.float64).reshape(
-                    -1
+                "action.end_effector_rotation": _numeric_vector(
+                    eef_rot, "action.end_effector_rotation", 3
                 ),
-                "action.gripper_close": np.asarray(gripper_close, np.float64).reshape(
-                    -1
+                "action.gripper_close": _numeric_vector(
+                    gripper_close, "action.gripper_close", 1
                 ),
-                "action.base_motion": np.asarray(base_motion, np.float64).reshape(-1),
-                "action.control_mode": np.asarray(control_mode, np.float64).reshape(-1),
+                "action.base_motion": _numeric_vector(
+                    base_motion, "action.base_motion", 4
+                ),
+                "action.control_mode": _numeric_vector(
+                    control_mode, "action.control_mode", 1
+                ),
             }
         )
         return self.env.reassemble_env_action(ad)
+
+    @staticmethod
+    def _validate_actions(actions):
+        if not isinstance(actions, Mapping):
+            raise TypeError("VLA predict must return an action mapping")
+        normalized = {}
+        horizon = None
+        for name, size in ACTION_FIELDS.items():
+            if name not in actions:
+                raise ValueError(f"VLA action output is missing {name!r}")
+            array = np.asarray(actions[name])
+            if array.ndim != 3 or array.shape[0] != 1 or array.shape[2] != size:
+                raise ValueError(
+                    f"{name} must have shape (1, horizon, {size}), got {array.shape}"
+                )
+            if not 0 < array.shape[1] <= MAX_ACTION_STEPS:
+                raise ValueError(f"{name} has invalid horizon {array.shape[1]}")
+            if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+                array.dtype, np.bool_
+            ):
+                raise TypeError(f"{name} must contain numeric values")
+            if not np.isfinite(array).all():
+                raise ValueError(f"{name} must contain only finite values")
+            if horizon is None:
+                horizon = array.shape[1]
+            elif array.shape[1] != horizon:
+                raise ValueError("VLA action fields have inconsistent horizons")
+            normalized[name] = array
+        return normalized, horizon
 
     def _grasp_contact(self):
         """Direction-AGNOSTIC grasp check: True iff BOTH gripper fingerpads are in
@@ -232,6 +379,26 @@ class RLDXSkill:
         base_clip=None -> full base motion; base_clip=v -> clamp base_motion to [-v,v]
         (whole-body policy: never zero it). Returns status + grasp signals so the LLM
         decides: continue (call again) vs done vs genuinely-failed."""
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+        max_chunks = _bounded_int(max_chunks, "max_chunks", maximum=MAX_VLA_CHUNKS)
+        n_action_steps = _bounded_int(
+            n_action_steps, "n_action_steps", maximum=MAX_ACTION_STEPS
+        )
+        settle_patience = _bounded_int(
+            settle_patience, "settle_patience", maximum=MAX_VLA_CHUNKS
+        )
+        settle_eps = _finite_scalar(
+            settle_eps, "settle_eps", minimum=np.finfo(float).eps, maximum=1.0
+        )
+        if base_clip is not None:
+            base_clip = _finite_scalar(base_clip, "base_clip", minimum=0.0, maximum=1.0)
+        if not isinstance(force_reset, (bool, np.bool_)):
+            raise TypeError("force_reset must be boolean")
+        if not isinstance(recording, (bool, np.bool_)):
+            raise TypeError("recording must be boolean")
+        if recording and not callable(record_frame):
+            raise TypeError("record_frame must be callable when recording=True")
         self._load()
         # Start a fresh video buffer for this run() call (no-op if RLDX_VIDEO_DIR unset).
         self._frames = [] if self._video_dir is not None else None
@@ -263,18 +430,23 @@ class RLDXSkill:
         applied = 0
         settled = 0
         status = "cap"
+        chunks_executed = 0
+        success_latched = bool(self.env.check_success())
+        if success_latched:
+            status = "success"
         grasp_ever = False
         grasp_obj = None
         last_cmd_close = False
-        for c in range(max_chunks):
+        for _ in range(max_chunks if not success_latched else 0):
+            chunks_executed += 1
             obs = self._build_obs(prompt)
             options = {"reset_memory": [fresh], "session_ids": [self._sid]}
             fresh = False
             if self._check_cancelled is not None:
                 self._check_cancelled()
             actions = self._vla_client.predict(obs, options)
+            actions, horizon = self._validate_actions(actions)
             # gym Dict -> native flat 12-d [eef_pos(3),eef_rot(3),gripper(1),base(4),mode(1)]
-            horizon = actions["action.gripper_close"].shape[1]
             for step in range(min(n_action_steps, horizon)):
                 base_motion = np.asarray(actions["action.base_motion"])[0, step]
                 if base_clip is not None:
@@ -308,14 +480,17 @@ class RLDXSkill:
                     prompt
                 )  # PER-SIM-STEP history (matches eval cadence)
                 self._capture_video_frame()  # OPTIONAL video (no-op if RLDX_VIDEO_DIR unset)
+                if self.env.check_success():
+                    status = "success"
+                    success_latched = True
+                    break
+            if success_latched:
+                break
             # ROBUST grasp check once per chunk (direction-agnostic; see _grasp_contact)
             g_now, g_obj = self._grasp_contact()
             if g_now:
                 grasp_ever = True
                 grasp_obj = grasp_obj or g_obj
-            if self.env.check_success():
-                status = "success"
-                break
             eef_now = np.asarray(self.env.eef_pos, np.float64)
             grip_now = float(self.env.gripper_qpos[0])
             eef_min_z = min(eef_min_z, float(eef_now[2]))
@@ -354,7 +529,7 @@ class RLDXSkill:
             "ok": True,
             "prompt": prompt,
             "status": status,
-            "chunks": c + 1,
+            "chunks": chunks_executed,
             "steps_applied": applied,
             "grasped": grasped_now,  # holding at end-of-call (carry-ready)
             "grasp_detected": grasp_detected,  # grabbed at some chunk (may have placed since)
@@ -374,10 +549,7 @@ class RLDXSkill:
 
     def reset_session(self):
         if self._vla_client is not None:
-            try:
-                self._vla_client.reset_session(self._sid)
-            except Exception:
-                pass
+            self._vla_client.reset_session(self._sid)
         self._last_prompt = None  # post-reset: next call is a fresh task
         if self._hist is not None:
             self._hist.clear()

--- a/robots/robocasa/toolkit.py
+++ b/robots/robocasa/toolkit.py
@@ -34,6 +34,19 @@ if TYPE_CHECKING:
 
 logger = get_logger("robocasa_toolkit")
 
+FORMAL_PRIMITIVE_TOOLS = frozenset(
+    {
+        "navigate_to",
+        "move_base",
+        "move_to",
+        "move_delta",
+        "rotate_pitch",
+        "set_gripper",
+        "release",
+        "vla_act",
+    }
+)
+
 
 class RoboCasaToolkit(Toolkit):
     """Toolkit for the RoboCasa robot."""
@@ -78,6 +91,13 @@ class RoboCasaToolkit(Toolkit):
         }
         for spec in robocasa_tools.TOOLS_SPEC:
             name = spec["name"]
+            if (
+                self._primitives._perception_isolation
+                and name not in FORMAL_PRIMITIVE_TOOLS
+                and name not in state_handlers
+                and name != "finish"
+            ):
+                continue
             if name in state_handlers:
                 handler = state_handlers[name]
             elif name == "finish":
@@ -139,18 +159,18 @@ class RoboCasaToolkit(Toolkit):
             check_cancelled=self.raise_if_cancelled,
             **primitives_kwargs,
         )
-        primitives.reset()
         primitives.start_recording()
         self._action_frame_cursor = primitives.recorded_frame_count()
         record = robocasa_tools.dump_state(primitives, self._state, log=None)
-        try:
-            self._state.save(
-                "success_criteria.md",
-                primitives.dump_success_criteria(),
-                step=None,
-            )
-        except Exception as e:
-            logger.warning("failed to save success_criteria.md: %s", e)
+        if not primitives._perception_isolation:
+            try:
+                self._state.save(
+                    "success_criteria.md",
+                    primitives.dump_success_criteria(),
+                    step=None,
+                )
+            except Exception as e:
+                logger.warning("failed to save success_criteria.md: %s", e)
         self._primitives = primitives
         self._publish_step(record)
 

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -33,7 +33,7 @@ from rpent.tools.toolkit import readonly
 if TYPE_CHECKING:
     from robots.robocasa.primitives import RoboCasaPrimitives
 
-# ---- TOOLS_SPEC: 17 Anthropic-shaped tool schemas ----
+# ---- Anthropic-shaped tool schemas ----
 
 TOOLS_SPEC = [
     # ---- primitive tools (11): dispatched by the toolkit base to primitives.<name> ----
@@ -180,6 +180,26 @@ TOOLS_SPEC = [
                     "description": "Number of env steps (default 10)",
                 },
             },
+        },
+    },
+    {
+        "name": "vla_act",
+        "description": (
+            "Run the unified VLA primitive using the current benchmark task "
+            "instruction. The prompt must equal state.task_language verbatim. "
+            "Its chunk budget, action horizon, base control, stopping rule, and "
+            "history reset semantics are fixed by the evaluation harness."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "The current state.task_language verbatim",
+                },
+            },
+            "required": ["prompt"],
+            "additionalProperties": False,
         },
     },
     {
@@ -454,7 +474,7 @@ TOOLS_SPEC = [
             "properties": {
                 "camera": {
                     "type": "string",
-                    "enum": ["agentview", "navview"],
+                    "enum": ["agentview", "navview", "wrist"],
                     "description": "Camera metadata to read (default agentview).",
                 },
                 "step": {
@@ -667,6 +687,74 @@ _CAMERA_WORLD_ARTIFACTS = {
     "wrist": ("wrist_world.npz", None),
 }
 
+_CAMERA_METADATA_ARTIFACTS = {
+    "agentview": "agentview_metadata.json",
+    "navview": "navview_metadata.json",
+    "wrist": "wrist_metadata.json",
+}
+
+MAX_BACK_PROJECT_PIXELS = 50
+
+
+def _resolve_step(state: EnvState, step: int | None):
+    if step is not None and (
+        isinstance(step, (bool, np.bool_))
+        or not isinstance(step, (int, np.integer))
+        or int(step) < 0
+    ):
+        raise ValueError("step must be null or a nonnegative integer")
+    return state.get(-1 if step is None else int(step))
+
+
+def _camera_and_resolution(camera, resolution):
+    if not isinstance(camera, str) or camera not in _CAMERA_WORLD_ARTIFACTS:
+        raise ValueError("camera must be one of: agentview, navview, wrist")
+    if resolution not in {"low", "high"}:
+        raise ValueError("resolution must be 'low' or 'high'")
+    low_name, hi_name = _CAMERA_WORLD_ARTIFACTS[camera]
+    artifact = hi_name if resolution == "high" else low_name
+    if artifact is None:
+        raise ValueError(f"{camera} has no {resolution}-resolution world map")
+    return artifact
+
+
+def _world_map_for(state, record, artifact):
+    if artifact not in record.artifacts:
+        raise FileNotFoundError(
+            f"{artifact} was not recorded for step {record.step_idx}"
+        )
+    world_map = np.asarray(state.load(artifact, step=record.step_idx))
+    if world_map.ndim != 3 or world_map.shape[2] < 3:
+        raise ValueError(
+            f"{artifact} must have shape (height, width, >=3), got {world_map.shape}"
+        )
+    if not np.issubdtype(world_map.dtype, np.number):
+        raise TypeError(f"{artifact} must contain numeric values")
+    return world_map
+
+
+def _finite_tool_number(value, name):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.number)
+    ):
+        raise TypeError(f"{name} must be numeric")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _ordered_range(value, name):
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"{name} must be null or [min, max]")
+    lower = _finite_tool_number(value[0], f"{name}[0]")
+    upper = _finite_tool_number(value[1], f"{name}[1]")
+    if lower > upper:
+        raise ValueError(f"{name} minimum must not exceed maximum")
+    return lower, upper
+
 
 def dump_state(
     primitives: RoboCasaPrimitives,
@@ -682,19 +770,21 @@ def dump_state(
     """
     state_dict = primitives.current_state_dict()
     log = log or {}
+    extras = {
+        "task_language": state_dict["task_language"],
+        "success": state_dict["success"],
+        "vla_desync": primitives._vla_desync,
+    }
+    if "task_progress" in state_dict:
+        extras["task_progress"] = state_dict["task_progress"]
     with env_state.record_step(
         state=state_dict["state"],
-        terminated=state_dict["robocasa_terminated"],
+        terminated=state_dict.get("robocasa_terminated", state_dict["success"]),
         truncated=False,
         command=log.get("command"),
         result=log.get("result"),
         elapsed_s=log.get("elapsed_s"),
-        extras={
-            "task_language": state_dict["task_language"],
-            "success": state_dict["success"],
-            "task_progress": state_dict["task_progress"],
-            "vla_desync": primitives._vla_desync,
-        },
+        extras=extras,
     ) as step_idx:
         _save_observation_artifacts(primitives, env_state, step_idx)
         _prune_heavy_artifacts(primitives, env_state, step_idx)
@@ -749,8 +839,15 @@ def _save_observation_artifacts(
     try:
         nrgb, _ = env.render_camera("navview", depth=True)
         nworld = env.world_map("navview").astype(np.float32)
+        if "navview" not in primitives._cam_meta_cache:
+            primitives._cam_meta_cache["navview"] = env.get_camera_meta("navview")
         env_state.save("navview.png", nrgb, step=step_idx)
         env_state.save("navview_world.npz", nworld, step=step_idx)
+        env_state.save(
+            "navview_metadata.json",
+            primitives._cam_meta_cache["navview"],
+            step=step_idx,
+        )
         floor = (nworld[:, :, 2] < 0.12) & (nworld[:, :, 2] > -0.2)
         overlay = nrgb.copy()
         overlay[floor] = [0, 255, 0]
@@ -790,7 +887,6 @@ def view_env_state(step: int | None = None, *, state: EnvState) -> dict:
     extras = record.extras
     out: dict = {
         "step": nn,
-        "task_progress": extras.get("task_progress", {}),
         "task_language": extras.get("task_language", ""),
         "state": record.state,
         "robocasa_terminated": record.terminated,
@@ -803,6 +899,8 @@ def view_env_state(step: int | None = None, *, state: EnvState) -> dict:
         },
         "images": [],
     }
+    if "task_progress" in extras:
+        out["task_progress"] = extras["task_progress"]
 
     for kind, candidates in (
         ("_image_cam_bytes", _CAMERA_IMAGE_ARTIFACTS["agentview"]),
@@ -840,8 +938,52 @@ def view_camera_meta(
     *,
     state: EnvState,
 ) -> dict:
-    """Read camera calibration metadata. Skeleton — returns error."""
-    return {"error": "not implemented"}
+    """Read and validate the calibration captured with one recorded frame."""
+    if not isinstance(camera, str) or camera not in _CAMERA_METADATA_ARTIFACTS:
+        return {"error": "camera must be one of: agentview, navview, wrist"}
+    try:
+        record = _resolve_step(state, step)
+    except Exception as exc:
+        return {"error": f"state step not available: {exc}"}
+    artifact = _CAMERA_METADATA_ARTIFACTS[camera]
+    if artifact not in record.artifacts:
+        return {"error": f"{artifact} not recorded for step {record.step_idx}"}
+    try:
+        meta = state.load(artifact, step=record.step_idx)
+    except Exception as exc:
+        return {"error": f"{artifact} not found for step {record.step_idx}: {exc}"}
+    if not isinstance(meta, dict):
+        return {"error": f"{artifact} must contain a JSON object"}
+    try:
+        intrinsic = np.asarray(meta["intrinsic"], dtype=np.float64)
+        extrinsic = np.asarray(meta["extrinsic_cam2world"], dtype=np.float64)
+        if intrinsic.shape != (3, 3) or not np.isfinite(intrinsic).all():
+            raise ValueError("intrinsic must be a finite 3x3 matrix")
+        if extrinsic.shape != (4, 4) or not np.isfinite(extrinsic).all():
+            raise ValueError("extrinsic_cam2world must be a finite 4x4 matrix")
+        height = meta["height"]
+        width = meta["width"]
+        if (
+            isinstance(height, bool)
+            or not isinstance(height, int)
+            or height <= 0
+            or isinstance(width, bool)
+            or not isinstance(width, int)
+            or width <= 0
+        ):
+            raise ValueError("height and width must be positive integers")
+        near = float(meta["depth_near"])
+        far = float(meta["depth_far"])
+        if not np.isfinite([near, far]).all() or not 0 < near < far:
+            raise ValueError("depth_near/depth_far must be finite and ordered")
+    except (KeyError, TypeError, ValueError) as exc:
+        return {"error": f"invalid {artifact}: {exc}"}
+    return {
+        **meta,
+        "step": record.step_idx,
+        "camera": camera,
+        "artifact": artifact,
+    }
 
 
 @readonly
@@ -854,8 +996,26 @@ def back_project(
     *,
     state: EnvState,
 ) -> dict:
-    """Back-project a single pixel to world XYZ. Skeleton — returns error."""
-    return {"error": "not implemented"}
+    """Back-project one pixel using the world map captured at the same step."""
+    batch = back_project_batch(
+        [[row, col]],
+        step=step,
+        camera=camera,
+        resolution=resolution,
+        state=state,
+    )
+    if "error" in batch:
+        return batch
+    result = dict(batch["results"][0])
+    result.update(
+        {
+            "step": batch["step"],
+            "camera": batch["camera"],
+            "resolution": batch["resolution"],
+            "source_artifact": batch["source_artifact"],
+        }
+    )
+    return result
 
 
 @readonly
@@ -872,29 +1032,24 @@ def back_project_batch(
     Loads the precomputed world map once and queries all *pixels*, returning
     each result individually plus a summary with the median of valid points.
     """
-    camera = camera or "agentview"
-    resolution = resolution or "low"
-    if camera not in _CAMERA_WORLD_ARTIFACTS:
-        return {"error": f"bad camera '{camera}' (use agentview, navview, or wrist)"}
-    low_name, hi_name = _CAMERA_WORLD_ARTIFACTS[camera]
-    source_artifact = hi_name if resolution == "high" else low_name
-    if source_artifact is None:
-        return {"error": f"{camera} has no {resolution}-resolution world map"}
+    if not isinstance(pixels, (list, tuple)):
+        return {"error": "pixels must be a list of [row, col] pairs"}
+    if not 1 <= len(pixels) <= MAX_BACK_PROJECT_PIXELS:
+        return {"error": f"pixels must contain 1-{MAX_BACK_PROJECT_PIXELS} entries"}
+    try:
+        source_artifact = _camera_and_resolution(camera, resolution)
+    except (TypeError, ValueError) as exc:
+        return {"error": str(exc)}
 
     try:
-        record = state.get(step if step is not None else -1)
+        record = _resolve_step(state, step)
     except Exception as exc:
         return {"error": f"state step not available: {exc}"}
     nn = record.step_idx
-    if source_artifact not in record.artifacts:
-        return {
-            "error": f"{camera} {resolution}-resolution world map not recorded for step {nn}"
-        }
-
     try:
-        world_map = state.load(source_artifact, step=nn)
+        world_map = _world_map_for(state, record, source_artifact)
     except Exception as exc:
-        return {"error": f"{source_artifact} not found for step {nn}: {exc}"}
+        return {"error": str(exc)}
 
     results = []
     valid_xyzs = []
@@ -906,6 +1061,20 @@ def back_project_batch(
                     "world_xyz": None,
                     "valid": False,
                     "error": "pixel must be [row, col]",
+                }
+            )
+            continue
+        if any(
+            isinstance(value, (bool, np.bool_))
+            or not isinstance(value, (int, np.integer))
+            for value in pixel
+        ):
+            results.append(
+                {
+                    "pixel": pixel,
+                    "world_xyz": None,
+                    "valid": False,
+                    "error": "row and col must be integers",
                 }
             )
             continue
@@ -922,7 +1091,7 @@ def back_project_batch(
             )
             continue
         xyz = world_map[row, col, :3]
-        if not np.isfinite(xyz).all() or abs(float(xyz.sum())) <= 1e-6:
+        if not np.isfinite(xyz).all() or float(np.linalg.norm(xyz)) <= 1e-6:
             results.append(
                 {
                     "pixel": pixel,
@@ -964,6 +1133,8 @@ def back_project_batch(
         "step": nn,
         "camera": camera,
         "resolution": resolution,
+        "source_artifact": source_artifact,
+        "world_map_shape": list(world_map.shape),
     }
 
 
@@ -980,35 +1151,39 @@ def query_world_map(
     state: EnvState,
 ) -> dict:
     """Query the world map by z-range and/or region to find objects."""
-    if camera not in _CAMERA_WORLD_ARTIFACTS:
-        return {"error": f"bad camera '{camera}' (use agentview, navview, or wrist)"}
-    low_name, hi_name = _CAMERA_WORLD_ARTIFACTS[camera]
-    source_artifact = hi_name if resolution == "high" else low_name
-    if source_artifact is None:
-        return {"error": f"{camera} has no {resolution}-resolution world map"}
+    try:
+        source_artifact = _camera_and_resolution(camera, resolution)
+        z_min = _finite_tool_number(z_min, "z_min")
+        z_max = _finite_tool_number(z_max, "z_max")
+        if z_min > z_max:
+            raise ValueError("z_min must not exceed z_max")
+        x_range = _ordered_range(x_range, "x_range")
+        y_range = _ordered_range(y_range, "y_range")
+        if (
+            isinstance(min_cluster_size, (bool, np.bool_))
+            or not isinstance(min_cluster_size, (int, np.integer))
+            or not 1 <= int(min_cluster_size) <= 10_000
+        ):
+            raise ValueError("min_cluster_size must be an integer in [1, 10000]")
+        min_cluster_size = int(min_cluster_size)
+    except (TypeError, ValueError) as exc:
+        return {"error": str(exc)}
 
     try:
         record = state.get(-1)
     except Exception:
         return {"error": "no state trace available"}
-    nn = record.step_idx
-    if source_artifact not in record.artifacts:
-        return {
-            "error": f"{camera} {resolution}-resolution world map not found for step {nn}"
-        }
     try:
-        world_map = state.load(source_artifact, step=nn)
-    except Exception:
-        return {
-            "error": f"{camera} {resolution}-resolution world map not found for step {nn}"
-        }
+        world_map = _world_map_for(state, record, source_artifact)
+    except Exception as exc:
+        return {"error": str(exc)}
 
     z = world_map[:, :, 2]
     mask = (z >= z_min) & (z <= z_max) & np.isfinite(z)
-    if x_range:
+    if x_range is not None:
         x = world_map[:, :, 0]
         mask &= (x >= x_range[0]) & (x <= x_range[1])
-    if y_range:
+    if y_range is not None:
         y = world_map[:, :, 1]
         mask &= (y >= y_range[0]) & (y <= y_range[1])
 
@@ -1092,6 +1267,7 @@ _PRIMITIVE_ACTIONS = frozenset(
         "rotate_pitch",
         "set_gripper",
         "release",
+        "vla_act",
         "scripted_grasp",
         "rldx_skill",
         "rldx_arm",

--- a/robots/robocasa/vla_client.py
+++ b/robots/robocasa/vla_client.py
@@ -16,35 +16,182 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
+import numpy as np
+
 from rpent.robots.components.vla_client_base import BaseVLAClient
+
+VLA_PROTOCOL_VERSION = 1
+EXPECTED_ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
 
 
 class RoboCasaVLAClient(BaseVLAClient):
     _TIMEOUT_S = BaseVLAClient._TIMEOUT_S
 
-    def __init__(self, client):
+    def __init__(
+        self,
+        client,
+        *,
+        expected_model_fingerprint: str | None = None,
+        require_verified_model: bool = False,
+    ):
         super().__init__(client)
+        self.runtime_info = self.get_runtime_info()
+        self._validate_runtime_info(
+            self.runtime_info,
+            expected_model_fingerprint=expected_model_fingerprint,
+            require_verified_model=require_verified_model,
+        )
+        self.runtime_id = self.runtime_info["runtime_id"]
+        self.action_schema = self.runtime_info["action_schema"]
+        self.model_identity = self.runtime_info["model"]
+
+    def get_runtime_info(self) -> dict:
+        return self._client.call(
+            "vla.get_runtime_info", timeout_s=self._TIMEOUT_S["default"]
+        )
+
+    @staticmethod
+    def _validate_runtime_info(
+        info,
+        *,
+        expected_model_fingerprint=None,
+        require_verified_model=False,
+    ):
+        if not isinstance(info, Mapping):
+            raise TypeError("VLA runtime handshake must return a mapping")
+        if info.get("protocol_version") != VLA_PROTOCOL_VERSION:
+            raise RuntimeError(
+                f"unsupported VLA protocol_version={info.get('protocol_version')!r}; "
+                f"expected {VLA_PROTOCOL_VERSION}"
+            )
+        if not isinstance(info.get("runtime_id"), str) or not info["runtime_id"]:
+            raise RuntimeError("VLA runtime handshake is missing runtime_id")
+        if info.get("backend") != "rldx":
+            raise RuntimeError(f"unsupported VLA backend {info.get('backend')!r}")
+        if info.get("warmed_up") is not True:
+            raise RuntimeError("VLA server has not completed model warmup")
+        model = info.get("model")
+        if not isinstance(model, Mapping) or not isinstance(
+            model.get("fingerprint"), str
+        ):
+            raise RuntimeError("VLA runtime handshake is missing model identity")
+        if require_verified_model and model.get("verified") is not True:
+            raise RuntimeError("VLA runtime handshake has no verified model identity")
+        if (
+            expected_model_fingerprint is not None
+            and model.get("fingerprint") != expected_model_fingerprint
+        ):
+            raise RuntimeError("VLA runtime model fingerprint mismatch")
+        schema = info.get("action_schema")
+        if not isinstance(schema, Mapping):
+            raise RuntimeError("VLA runtime handshake is missing action_schema")
+        if schema.get("batch_size") != 1 or schema.get("flat_dim") != sum(
+            EXPECTED_ACTION_FIELDS.values()
+        ):
+            raise RuntimeError(f"incompatible VLA action schema: {schema!r}")
+        fields = schema.get("fields")
+        if not isinstance(fields, list):
+            raise RuntimeError("VLA action schema fields must be a list")
+        actual_fields = {
+            field.get("name"): field.get("size")
+            for field in fields
+            if isinstance(field, Mapping)
+        }
+        if actual_fields != EXPECTED_ACTION_FIELDS:
+            raise RuntimeError(
+                f"incompatible VLA action fields: expected={EXPECTED_ACTION_FIELDS!r}, "
+                f"actual={actual_fields!r}"
+            )
+        horizon = schema.get("max_horizon")
+        if isinstance(horizon, bool) or not isinstance(horizon, int) or horizon <= 0:
+            raise RuntimeError(f"invalid VLA max_horizon={horizon!r}")
 
     def get_modality_config(self) -> dict:
-        return self._client.call(
-            "vla.get_modality_config",
-            timeout_s=self._TIMEOUT_S["default"],
+        config = self._client.call(
+            "vla.get_modality_config", timeout_s=self._TIMEOUT_S["default"]
         )
+        if not isinstance(config, Mapping):
+            raise TypeError("VLA modality config must be a mapping")
+        indices = np.asarray(config.get("video_delta_indices"))
+        hist_maxlen = config.get("hist_maxlen")
+        if (
+            indices.ndim != 1
+            or indices.size == 0
+            or not np.issubdtype(indices.dtype, np.integer)
+            or np.any(np.diff(indices) <= 0)
+            or int(indices[-1]) != 0
+        ):
+            raise RuntimeError(f"invalid VLA video_delta_indices={indices!r}")
+        expected_hist = int(indices.max() - indices.min()) + 2
+        if (
+            isinstance(hist_maxlen, bool)
+            or not isinstance(hist_maxlen, int)
+            or hist_maxlen != expected_hist
+        ):
+            raise RuntimeError(
+                f"invalid VLA hist_maxlen={hist_maxlen!r}; expected {expected_hist}"
+            )
+        return dict(config)
 
     def predict(self, obs_dict: dict, options: dict) -> dict:
         """Run inference; returns raw actions dict.
 
         Actions are numpy arrays.
         """
-        return self._client.call(
+        actions = self._client.call(
             "vla.predict",
             args=(obs_dict, options),
             timeout_s=self._TIMEOUT_S["predict"],
         )
+        if not isinstance(actions, Mapping):
+            raise TypeError("VLA predict response must be an action mapping")
+        normalized = dict(actions)
+        horizon = None
+        max_horizon = int(self.action_schema["max_horizon"])
+        for name, size in EXPECTED_ACTION_FIELDS.items():
+            if name not in actions:
+                raise RuntimeError(f"VLA predict response is missing {name!r}")
+            array = np.asarray(actions[name])
+            if array.ndim != 3 or array.shape[0] != 1 or array.shape[2] != size:
+                raise ValueError(
+                    f"{name} must have shape (1, horizon, {size}), got {array.shape}"
+                )
+            if not 0 < array.shape[1] <= max_horizon:
+                raise ValueError(f"{name} has invalid horizon {array.shape[1]}")
+            if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+                array.dtype, np.bool_
+            ):
+                raise TypeError(f"{name} must contain numeric values")
+            if not np.isfinite(array).all():
+                raise ValueError(f"{name} must contain only finite values")
+            if horizon is None:
+                horizon = array.shape[1]
+            elif array.shape[1] != horizon:
+                raise ValueError("VLA action fields have inconsistent horizons")
+            normalized[name] = array
+        return normalized
 
     def reset_session(self, session_id: str) -> dict:
-        return self._client.call(
+        if not isinstance(session_id, str) or not session_id:
+            raise TypeError("session_id must be a non-empty string")
+        result = self._client.call(
             "vla.reset_session",
             args=(session_id,),
             timeout_s=self._TIMEOUT_S["default"],
         )
+        if (
+            not isinstance(result, Mapping)
+            or result.get("ok") is not True
+            or result.get("runtime_id") != self.runtime_id
+            or result.get("session_id") != session_id
+        ):
+            raise RuntimeError(f"invalid VLA reset_session response: {result!r}")
+        return dict(result)

--- a/robots/robocasa/vla_server.py
+++ b/robots/robocasa/vla_server.py
@@ -15,7 +15,13 @@
 """RoboCasa VLA server — loads RLDX model and exposes inference calls via RPC."""
 
 import argparse
+import hashlib
+import json
 import os
+import re
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
 
 import numpy as np
 
@@ -24,12 +30,115 @@ from rpent.utils.logging import get_logger
 
 logger = get_logger("vla_server")
 
+VLA_PROTOCOL_VERSION = 1
+MAX_ACTION_HORIZON = 512
+MAX_SESSION_ID_LENGTH = 192
+ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
+STATE_FIELDS = {
+    "state.gripper_qpos": 2,
+    "state.base_position": 3,
+    "state.base_rotation": 4,
+    "state.end_effector_position_relative": 3,
+    "state.end_effector_rotation_relative": 4,
+}
+VIDEO_FIELDS = (
+    "video.robot0_agentview_left",
+    "video.robot0_agentview_right",
+    "video.robot0_eye_in_hand",
+)
+ANNOTATION_FIELD = "annotation.human.task_description"
+_SESSION_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _model_identity(model_path):
+    if not isinstance(model_path, (str, os.PathLike)) or not str(model_path).strip():
+        raise TypeError("model_path must be a non-empty path or model id")
+    requested = str(model_path)
+    path = Path(requested).expanduser()
+    if not path.exists():
+        return {
+            "kind": "remote",
+            "requested": requested,
+            "fingerprint": f"remote:{requested}",
+        }
+    if not path.is_dir():
+        raise ValueError(f"model_path must be a checkpoint directory, got {path}")
+    path = path.resolve()
+    config_path = path / "config.json"
+    index_path = path / "model.safetensors.index.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"checkpoint config is missing: {config_path}")
+    files = {"config.json": _sha256_file(config_path)}
+    total_size = None
+    if index_path.is_file():
+        files[index_path.name] = _sha256_file(index_path)
+        try:
+            with open(index_path, encoding="utf-8") as stream:
+                index = json.load(stream)
+            total_size = index.get("metadata", {}).get("total_size")
+        except (OSError, TypeError, ValueError):
+            total_size = None
+    digest = hashlib.sha256()
+    for name, value in sorted(files.items()):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(value.encode("ascii"))
+        digest.update(b"\0")
+    return {
+        "kind": "local",
+        "requested": requested,
+        "resolved_path": str(path),
+        "fingerprint": digest.hexdigest(),
+        "files": files,
+        "total_size": total_size,
+    }
+
+
+def _session_id(value):
+    if not isinstance(value, str) or not value:
+        raise TypeError("session_id must be a non-empty string")
+    if len(value) > MAX_SESSION_ID_LENGTH or _SESSION_RE.fullmatch(value) is None:
+        raise ValueError(
+            "session_id must be at most 192 characters and contain only "
+            "letters, digits, '_', '-', '.', or ':'"
+        )
+    return value
+
+
+def _numeric_array(value, name, *, shape):
+    array = np.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
 
 class RoboCasaVLAFacade(BaseVLAFacade):
     """Loads RLDX model and exposes inference-only RPC methods."""
 
     def __init__(self, model_path):
         super().__init__()
+        self._runtime_id = uuid.uuid4().hex
+        self._model_identity = _model_identity(model_path)
         from rldx.data.embodiment_tags import EmbodimentTag
         from rldx.eval.rollout_policy import create_rldx_sim_policy
 
@@ -39,9 +148,23 @@ class RoboCasaVLAFacade(BaseVLAFacade):
             "",
             None,
         )
+        loaded_identity = _model_identity(model_path)
+        if loaded_identity != self._model_identity:
+            raise RuntimeError("checkpoint identity changed while loading the VLA")
         mod = self.policy.get_modality_config()
         self._vdi = np.asarray(mod["video"].delta_indices)
+        if (
+            self._vdi.ndim != 1
+            or self._vdi.size == 0
+            or not np.issubdtype(self._vdi.dtype, np.integer)
+            or np.any(np.diff(self._vdi) <= 0)
+            or int(self._vdi[-1]) != 0
+        ):
+            raise RuntimeError(f"invalid model video delta indices: {self._vdi!r}")
+        self._vdi = self._vdi.astype(np.int64, copy=False)
         self._hist_maxlen = int(self._vdi.max() - self._vdi.min()) + 2
+        self._warmed_up = False
+        self._warmup()
         print(
             f"[vla_server] policy loaded; video_delta_indices={self._vdi.tolist()} "
             f"hist_maxlen={self._hist_maxlen}",
@@ -53,7 +176,42 @@ class RoboCasaVLAFacade(BaseVLAFacade):
         self._rpc["vla.get_modality_config"] = self.get_modality_config
         self._rpc["vla.predict"] = self.predict
         self._rpc["vla.reset_session"] = self.reset_session
-        self._readonly_methods.add("vla.get_modality_config")
+        self._rpc["vla.get_runtime_info"] = self.get_runtime_info
+        self._readonly_methods.update(
+            {
+                "vla.get_modality_config",
+                "vla.get_runtime_info",
+            }
+        )
+
+    def get_runtime_info(self):
+        return {
+            "protocol_version": VLA_PROTOCOL_VERSION,
+            "runtime_id": self._runtime_id,
+            "backend": "rldx",
+            "model": self._model_identity,
+            "warmed_up": self._warmed_up,
+            "action_schema": {
+                "name": "rldx.robocasa.action.v1",
+                "batch_size": 1,
+                "max_horizon": MAX_ACTION_HORIZON,
+                "flat_dim": sum(ACTION_FIELDS.values()),
+                "fields": [
+                    {"name": name, "size": size} for name, size in ACTION_FIELDS.items()
+                ],
+            },
+            "observation_schema": {
+                "name": "rldx.robocasa.observation.v1",
+                "batch_size": 1,
+                "video_frames": int(self._vdi.size),
+                "video_height": 256,
+                "video_width": 256,
+                "state_fields": dict(STATE_FIELDS),
+                "video_fields": list(VIDEO_FIELDS),
+                "annotation_field": ANNOTATION_FIELD,
+            },
+            "modality": self.get_modality_config(),
+        }
 
     def get_modality_config(self):
         return {
@@ -61,18 +219,119 @@ class RoboCasaVLAFacade(BaseVLAFacade):
             "hist_maxlen": self._hist_maxlen,
         }
 
+    def _validate_observation(self, obs_dict):
+        if not isinstance(obs_dict, Mapping):
+            raise TypeError("obs_dict must be a mapping")
+        for name, size in STATE_FIELDS.items():
+            if name not in obs_dict:
+                raise ValueError(f"obs_dict is missing {name!r}")
+            _numeric_array(obs_dict[name], name, shape=(1, 1, size))
+        video_shape = (1, int(self._vdi.size), 256, 256, 3)
+        for name in VIDEO_FIELDS:
+            if name not in obs_dict:
+                raise ValueError(f"obs_dict is missing {name!r}")
+            video = np.asarray(obs_dict[name])
+            if video.shape != video_shape or video.dtype != np.uint8:
+                raise ValueError(
+                    f"{name} must be uint8 with shape {video_shape}, "
+                    f"got dtype={video.dtype}, shape={video.shape}"
+                )
+        annotation = obs_dict.get(ANNOTATION_FIELD)
+        if (
+            not isinstance(annotation, (list, tuple))
+            or len(annotation) != 1
+            or not isinstance(annotation[0], str)
+            or not annotation[0].strip()
+        ):
+            raise ValueError(f"{ANNOTATION_FIELD} must contain one non-empty string")
+
+    @staticmethod
+    def _validate_options(options):
+        if not isinstance(options, Mapping):
+            raise TypeError("options must be a mapping")
+        unknown = set(options).difference({"session_ids", "reset_memory"})
+        if unknown:
+            raise ValueError(f"unsupported VLA options: {sorted(unknown)}")
+        sessions = options.get("session_ids")
+        resets = options.get("reset_memory")
+        if not isinstance(sessions, (list, tuple)) or len(sessions) != 1:
+            raise ValueError("options.session_ids must contain exactly one session id")
+        if not isinstance(resets, (list, tuple)) or len(resets) != 1:
+            raise ValueError("options.reset_memory must contain exactly one boolean")
+        _session_id(sessions[0])
+        if not isinstance(resets[0], (bool, np.bool_)):
+            raise TypeError("options.reset_memory[0] must be boolean")
+
+    @staticmethod
+    def _validate_actions(actions):
+        if not isinstance(actions, Mapping):
+            raise TypeError("RLDX policy must return an action mapping")
+        normalized = dict(actions)
+        horizon = None
+        for name, size in ACTION_FIELDS.items():
+            if name not in actions:
+                raise ValueError(f"RLDX action output is missing {name!r}")
+            array = np.asarray(actions[name])
+            if array.ndim != 3 or array.shape[0] != 1 or array.shape[2] != size:
+                raise ValueError(
+                    f"{name} must have shape (1, horizon, {size}), got {array.shape}"
+                )
+            if array.shape[1] <= 0 or array.shape[1] > MAX_ACTION_HORIZON:
+                raise ValueError(f"{name} has invalid horizon {array.shape[1]}")
+            if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+                array.dtype, np.bool_
+            ):
+                raise TypeError(f"{name} must contain numeric values")
+            if not np.isfinite(array).all():
+                raise ValueError(f"{name} must contain only finite values")
+            if horizon is None:
+                horizon = array.shape[1]
+            elif array.shape[1] != horizon:
+                raise ValueError("RLDX action fields have inconsistent horizons")
+            normalized[name] = array
+        return normalized, horizon
+
     def predict(self, obs_dict, options):
         # policy.get_action returns dict[str, np.ndarray] because RLDX's
         # PolicyRuntime._decode already .cpu().numpy()s torch internally, and
         # _NumpyEncoder (http_rpc) tags numpy arrays at JSON time. If you ever
         # bypass _decode (e.g. call the model forward directly), you must
         # .cpu().numpy() the result here — _NumpyEncoder raises on torch.Tensor.
-        actions, info = self.policy.get_action(obs_dict, options=options)
+        self._validate_observation(obs_dict)
+        self._validate_options(options)
+        actions, info = self.policy.get_action(obs_dict, options=dict(options))
+        actions, _ = self._validate_actions(actions)
         return actions
 
+    def _warmup(self):
+        frames = int(self._vdi.size)
+        obs = {
+            name: np.zeros((1, 1, size), dtype=np.float32)
+            for name, size in STATE_FIELDS.items()
+        }
+        obs["state.base_rotation"][0, 0, 3] = 1.0
+        obs["state.end_effector_rotation_relative"][0, 0, 3] = 1.0
+        obs.update(
+            {
+                name: np.zeros((1, frames, 256, 256, 3), dtype=np.uint8)
+                for name in VIDEO_FIELDS
+            }
+        )
+        obs[ANNOTATION_FIELD] = ["warm up the robocasa policy"]
+        session_id = f"warmup:{self._runtime_id}"
+        try:
+            self.predict(
+                obs,
+                {"session_ids": [session_id], "reset_memory": [True]},
+            )
+        finally:
+            self.policy.reset({"session_ids": [session_id]})
+        self._warmed_up = True
+
     def reset_session(self, session_id):
+        session_id = _session_id(session_id)
         self.policy.reset({"session_ids": [session_id]})
-        return {"ok": True}
+        return {"ok": True, "runtime_id": self._runtime_id, "session_id": session_id}
 
 
 def main():

--- a/tests/test_robocasa_runtime.py
+++ b/tests/test_robocasa_runtime.py
@@ -1,0 +1,669 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robots.robocasa.env_client import RoboCasaEnvClient
+from robots.robocasa.env_server import RoboCasaEnvFacade
+from robots.robocasa.primitives import RoboCasaPrimitives
+from robots.robocasa.rldx_skill import ACTION_FIELDS, RLDXSkill
+from robots.robocasa.toolkit import FORMAL_PRIMITIVE_TOOLS, RoboCasaToolkit
+from robots.robocasa.tools import (
+    back_project,
+    back_project_batch,
+    view_camera_meta,
+    view_env_state,
+)
+from robots.robocasa.vla_client import RoboCasaVLAClient
+from robots.robocasa.vla_server import RoboCasaVLAFacade
+from rpent.session import EnvState
+
+ACTION_SCHEMA = {
+    "name": "rldx.robocasa.action.v1",
+    "batch_size": 1,
+    "max_horizon": 512,
+    "flat_dim": 12,
+    "fields": [{"name": name, "size": size} for name, size in ACTION_FIELDS.items()],
+}
+
+
+def _env_runtime(
+    *,
+    episode_id=0,
+    sim_step=0,
+    success=False,
+    perception_isolation=False,
+):
+    return {
+        "protocol_version": 1,
+        "runtime_id": "env-runtime",
+        "episode_id": episode_id,
+        "sim_step": sim_step,
+        "success_latched": success,
+        "perception_isolation": perception_isolation,
+        "robot": "PandaOmron",
+        "action_schema": {
+            "name": "robocasa.panda_omron.flat.v1",
+            "flat_dim": 12,
+            "fields": [
+                {"name": name, "size": size} for name, size in ACTION_FIELDS.items()
+            ],
+        },
+        "cameras": [
+            "mobilebase0_navview",
+            "robot0_agentview_left",
+            "robot0_agentview_right",
+            "robot0_eye_in_hand",
+        ],
+    }
+
+
+def _vla_runtime(*, warmed_up=True, verified=False):
+    return {
+        "protocol_version": 1,
+        "runtime_id": "vla-runtime",
+        "backend": "rldx",
+        "model": {
+            "kind": "local",
+            "fingerprint": "model-fingerprint",
+            "verified": verified,
+        },
+        "warmed_up": warmed_up,
+        "action_schema": ACTION_SCHEMA,
+        "observation_schema": {},
+        "modality": {"video_delta_indices": [-6, -4, -2, 0], "hist_maxlen": 8},
+    }
+
+
+def _raw_obs():
+    return {
+        "language": "pick up the mug",
+        "robot0_eef_pos": np.array([0.0, 0.0, 1.0]),
+        "robot0_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+        "robot0_gripper_qpos": np.array([0.02, 0.02]),
+        "robot0_base_pos": np.array([0.0, 0.0, 0.0]),
+        "robot0_base_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+        "robot0_base_to_eef_pos": np.array([0.0, 0.0, 1.0]),
+        "robot0_base_to_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+    }
+
+
+def _actions(horizon=4, *, fill=0.0):
+    return {
+        name: np.full((1, horizon, size), fill, dtype=np.float32)
+        for name, size in ACTION_FIELDS.items()
+    }
+
+
+class _EnvRpc:
+    def __init__(self):
+        self.episode = 0
+        self.sim_step = 0
+        self.reset_calls = 0
+        self.success = False
+
+    def call(self, method, args=(), kwargs=None, timeout_s=None):
+        if method == "env.get_env_meta":
+            return {
+                "task_name": "OpenDrawer",
+                "split": "target",
+                "seed": 7,
+                "camera_h": 256,
+                "camera_w": 256,
+            }
+        if method == "env.get_runtime_info":
+            return _env_runtime(
+                episode_id=self.episode,
+                sim_step=self.sim_step,
+                success=self.success,
+            )
+        if method == "env.reset":
+            self.reset_calls += 1
+            self.episode += 1
+            self.sim_step = 0
+            self.success = False
+            return _raw_obs()
+        if method == "env.step":
+            self.sim_step += 1
+            return (
+                _raw_obs(),
+                0.0,
+                False,
+                {
+                    "rpent_runtime_id": "env-runtime",
+                    "rpent_episode_id": self.episode,
+                    "rpent_sim_step": self.sim_step,
+                    "rpent_success_latched": self.success,
+                },
+            )
+        if method == "env.check_success":
+            return self.success
+        raise AssertionError(f"unexpected RPC method: {method}")
+
+
+class _FakeVLA:
+    runtime_id = "vla-runtime"
+    action_schema = ACTION_SCHEMA
+
+    def __init__(self, *, horizon=4):
+        self.horizon = horizon
+        self.predict_calls = 0
+        self.reset_calls = []
+
+    def get_modality_config(self):
+        return {"video_delta_indices": [-6, -4, -2, 0], "hist_maxlen": 8}
+
+    def predict(self, obs, options):
+        self.predict_calls += 1
+        return _actions(self.horizon)
+
+    def reset_session(self, session_id):
+        self.reset_calls.append(session_id)
+        return {"ok": True, "runtime_id": self.runtime_id, "session_id": session_id}
+
+
+class _SkillEnv:
+    runtime_id = "env-runtime"
+    action_dim = 12
+
+    def __init__(self, *, succeed_after=1):
+        self.last_obs = _raw_obs()
+        self.step_calls = 0
+        self.succeed_after = succeed_after
+        self.reset_calls = 0
+
+    @property
+    def current_raw_obs(self):
+        return self.last_obs
+
+    @property
+    def eef_pos(self):
+        return self.last_obs["robot0_eef_pos"]
+
+    @property
+    def eef_quat(self):
+        return self.last_obs["robot0_eef_quat"]
+
+    @property
+    def gripper_qpos(self):
+        return self.last_obs["robot0_gripper_qpos"]
+
+    def get_task_language(self):
+        return self.last_obs["language"]
+
+    def render_camera(self, *args, **kwargs):
+        return np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def reassemble_env_action(self, value):
+        return np.zeros(12, dtype=np.float64)
+
+    def step(self, action):
+        assert np.asarray(action).shape == (12,)
+        self.step_calls += 1
+        return self.last_obs, 0.0, False, {}
+
+    def check_success(self):
+        return self.step_calls >= self.succeed_after
+
+    @property
+    def terminated(self):
+        return self.check_success()
+
+    def grasp_contact(self):
+        return False, None
+
+    def reset(self):
+        self.reset_calls += 1
+        return self.last_obs
+
+
+def test_navview_is_required_only_for_formal_isolation():
+    ordinary = _env_runtime()
+    ordinary["cameras"].remove("mobilebase0_navview")
+    RoboCasaEnvClient._validate_runtime_info(ordinary)
+
+    formal = {**ordinary, "perception_isolation": True}
+    with pytest.raises(RuntimeError, match="mobilebase0_navview"):
+        RoboCasaEnvClient._validate_runtime_info(formal)
+
+
+def test_client_and_primitives_only_reset_once_on_startup(tmp_path):
+    rpc = _EnvRpc()
+    client = RoboCasaEnvClient(
+        rpc,
+        expected_meta={
+            "task_name": "OpenDrawer",
+            "split": "target",
+            "seed": 7,
+            "camera_h": 256,
+            "camera_w": 256,
+        },
+    )
+    assert rpc.reset_calls == 1
+
+    RoboCasaPrimitives(client, str(tmp_path), None, _FakeVLA())
+    assert rpc.reset_calls == 1
+
+
+class _RawEnv:
+    action_dim = 12
+
+    def __init__(self, *, reset_success=False):
+        self.success = reset_success
+        self.reset_success = reset_success
+        self.step_calls = 0
+
+    def reset(self):
+        self.success = self.reset_success
+        return {"obs": 0}
+
+    def step(self, action):
+        self.step_calls += 1
+        self.success = True
+        return {"obs": 1}, 0.0, False, {}
+
+    def _check_success(self):
+        return self.success
+
+
+def test_env_server_latches_success_on_each_simulator_action():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv()
+    facade._runtime_id = "runtime"
+    facade._episode_id = 0
+    facade._sim_step = 0
+    facade._success_latched = False
+
+    facade.reset()
+    _, _, _, info = facade.step(np.zeros(12))
+    assert info["rpent_success_now"] is True
+    assert info["rpent_success_latched"] is True
+
+    facade.env.success = False
+    assert facade.check_success() is True
+    with pytest.raises(ValueError, match="shape"):
+        facade.step(np.zeros((1, 12)))
+    bad = np.zeros(12)
+    bad[0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        facade.step(bad)
+
+    facade.reset()
+    observations, rewards, dones, infos = facade.chunk_step(
+        np.zeros((4, 12)), return_all_frames=True
+    )
+    assert len(observations) == len(rewards) == len(dones) == len(infos) == 1
+    assert infos[0]["rpent_success_latched"] is True
+
+
+def test_env_server_latches_reset_success_and_refuses_further_motion():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv(reset_success=True)
+    facade._runtime_id = "runtime"
+    facade._episode_id = 0
+    facade._sim_step = 0
+    facade._success_latched = False
+
+    facade.reset()
+    assert facade.check_success() is True
+    with pytest.raises(RuntimeError, match="further motion is disabled"):
+        facade.step(np.zeros(12))
+    assert facade.env.step_calls == 0
+
+
+def test_rldx_uses_unique_sessions_and_stops_inside_action_chunk():
+    env = _SkillEnv(succeed_after=1)
+    vla = _FakeVLA(horizon=4)
+    skill = RLDXSkill(env, vla_client=vla)
+    other = RLDXSkill(env, vla_client=vla)
+    assert skill._sid != other._sid
+    assert "rc_agent_rldx_0" not in skill._sid
+
+    skill._unmap = lambda value: value
+    result = skill.run("pick up the mug", max_chunks=2, n_action_steps=4)
+    assert result["status"] == "success"
+    assert result["steps_applied"] == 1
+    assert result["chunks"] == 1
+    assert env.step_calls == 1
+    assert vla.predict_calls == 1
+
+
+def test_vla_server_warmup_and_client_handshake():
+    class Policy:
+        def __init__(self):
+            self.predict_calls = 0
+            self.reset_calls = []
+
+        def get_action(self, obs, options):
+            self.predict_calls += 1
+            return _actions(2), {}
+
+        def reset(self, options):
+            self.reset_calls.append(options["session_ids"][0])
+
+    facade = object.__new__(RoboCasaVLAFacade)
+    facade._vdi = np.array([-6, -4, -2, 0])
+    facade._runtime_id = "warmup-runtime"
+    facade._warmed_up = False
+    facade.policy = Policy()
+    facade._warmup()
+    assert facade._warmed_up is True
+    assert facade.policy.predict_calls == 1
+    assert facade.policy.reset_calls == ["warmup:warmup-runtime"]
+
+    class Rpc:
+        def call(self, method, args=(), kwargs=None, timeout_s=None):
+            if method == "vla.get_runtime_info":
+                return _vla_runtime()
+            if method == "vla.get_modality_config":
+                return {"video_delta_indices": [-6, -4, -2, 0], "hist_maxlen": 8}
+            if method == "vla.predict":
+                return _actions(2)
+            if method == "vla.reset_session":
+                return {"ok": True, "runtime_id": "vla-runtime", "session_id": args[0]}
+            raise AssertionError(method)
+
+    client = RoboCasaVLAClient(Rpc())
+    assert client.runtime_id == "vla-runtime"
+    assert client.get_modality_config()["hist_maxlen"] == 8
+    assert client.predict({}, {})["action.base_motion"].shape == (1, 2, 4)
+
+    class ColdRpc(Rpc):
+        def call(self, method, args=(), kwargs=None, timeout_s=None):
+            if method == "vla.get_runtime_info":
+                return _vla_runtime(warmed_up=False)
+            return super().call(method, args=args, kwargs=kwargs, timeout_s=timeout_s)
+
+    with pytest.raises(RuntimeError, match="warmup"):
+        RoboCasaVLAClient(ColdRpc())
+
+    with pytest.raises(RuntimeError, match="verified"):
+        RoboCasaVLAClient(Rpc(), require_verified_model=True)
+
+    class VerifiedRpc(Rpc):
+        def call(self, method, args=(), kwargs=None, timeout_s=None):
+            if method == "vla.get_runtime_info":
+                return _vla_runtime(verified=True)
+            return super().call(method, args=args, kwargs=kwargs, timeout_s=timeout_s)
+
+    verified = RoboCasaVLAClient(
+        VerifiedRpc(),
+        require_verified_model=True,
+        expected_model_fingerprint="model-fingerprint",
+    )
+    assert verified.model_identity["verified"] is True
+    with pytest.raises(RuntimeError, match="fingerprint"):
+        RoboCasaVLAClient(
+            VerifiedRpc(), expected_model_fingerprint="different-fingerprint"
+        )
+
+
+def test_base_and_vla_motion_invalidate_pose_dependent_calibration(tmp_path):
+    env = _SkillEnv(succeed_after=999)
+    primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
+    primitives._pos_jac = np.eye(3)
+    primitives._cam_meta_cache = {
+        "agentview": {"old": True},
+        "navview": {"old": True},
+        "wrist": {"old": True},
+    }
+    primitives.move_base(forward=0.1, steps=1)
+    assert primitives._pos_jac is None
+    assert "agentview" not in primitives._cam_meta_cache
+    assert "navview" not in primitives._cam_meta_cache
+    assert "wrist" in primitives._cam_meta_cache
+
+    primitives._pos_jac = np.eye(3)
+    primitives._fwd_offset = 1.0
+    primitives._cam_meta_cache = {
+        "agentview": {},
+        "navview": {},
+        "wrist": {},
+    }
+    primitives._rldx.run = lambda *args, **kwargs: {"ok": True}
+    primitives.run_rldx_skill(None, 1, True, "pick up the mug", False, 1, 1, 0.01)
+    assert primitives._pos_jac is None
+    assert primitives._fwd_offset is None
+    assert primitives._cam_meta_cache == {}
+
+    with pytest.raises(ValueError, match="steps"):
+        primitives.move_base(steps=0)
+    with pytest.raises(ValueError, match="finite"):
+        primitives.move_base(forward=np.nan)
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("move_base", {"forward": 0.1, "steps": 5}),
+        ("set_gripper", {"gripper": 1.0, "steps": 5}),
+        ("rotate_pitch", {"target_pitch": 0.5, "n": 5}),
+    ],
+)
+def test_analytic_primitives_stop_on_first_success(tmp_path, method, kwargs):
+    env = _SkillEnv(succeed_after=1)
+    primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
+
+    getattr(primitives, method)(**kwargs)
+
+    assert env.step_calls == 1
+
+
+def test_perception_isolation_never_reads_or_exposes_task_progress(
+    tmp_path, monkeypatch
+):
+    class IsolatedEnv(_SkillEnv):
+        def __init__(self):
+            super().__init__(succeed_after=999)
+            self.progress_calls = 0
+            self.criteria_calls = 0
+
+        def get_task_progress(self):
+            self.progress_calls += 1
+            return {"hidden_counter": 7}
+
+        def get_success_criteria_text(self):
+            self.criteria_calls += 1
+            return "hidden predicate"
+
+    monkeypatch.setenv("RLDX_PERCEPTION_ISOLATION", "1")
+    env = IsolatedEnv()
+    primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
+
+    state = primitives.current_state_dict()
+    assert "task_progress" not in state
+    assert "robocasa_terminated" not in state
+    assert primitives.task_progress() == {}
+    with pytest.raises(PermissionError, match="unavailable"):
+        primitives.dump_success_criteria()
+    assert env.progress_calls == 0
+    assert env.criteria_calls == 0
+
+
+def test_formal_vla_act_uses_exact_prompt_and_frozen_controls(tmp_path, monkeypatch):
+    monkeypatch.setenv("RLDX_PERCEPTION_ISOLATION", "1")
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+    monkeypatch.setenv("RLDX_SETTLE_PATIENCE", "999")
+    primitives = RoboCasaPrimitives(
+        _SkillEnv(succeed_after=999), str(tmp_path), None, _FakeVLA()
+    )
+    calls = []
+
+    def run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "ok": True,
+            "prompt": "pick up the mug",
+            "status": "settled",
+            "chunks": 3,
+            "steps_applied": 24,
+            "grasp_detected": True,
+            "grasped": False,
+            "grasp_obj": "mug",
+        }
+
+    primitives._rldx.run = run
+    result = primitives.vla_act("pick up the mug")
+    args, kwargs = calls[0]
+    assert args == ("pick up the mug", 40, 8)
+    assert kwargs == {
+        "base_clip": None,
+        "settle_patience": 999,
+        "settle_eps": 0.012,
+        "force_reset": True,
+        "recording": False,
+        "record_frame": primitives.record_frame,
+    }
+    assert result == {
+        "ok": True,
+        "status": "settled",
+        "chunks": 3,
+        "steps_applied": 24,
+        "contact_made": True,
+        "holding": False,
+    }
+    with pytest.raises(ValueError, match="verbatim"):
+        primitives.vla_act("pick up a mug")
+    assert len(calls) == 1
+
+
+def test_formal_toolkit_registers_only_frozen_primitive_actions(tmp_path):
+    class PrimitiveHandlers:
+        _perception_isolation = True
+
+        def __getattr__(self, _name):
+            return lambda **_kwargs: {}
+
+    toolkit = object.__new__(RoboCasaToolkit)
+    toolkit._state = EnvState(tmp_path)
+    toolkit._primitives = PrimitiveHandlers()
+    toolkit._tools = {}
+    toolkit._register_robocasa_tools()
+
+    readonly_names = {
+        "view_env_state",
+        "view_camera_meta",
+        "back_project",
+        "back_project_batch",
+        "query_world_map",
+        "finish",
+    }
+    assert set(toolkit._tools) - readonly_names == FORMAL_PRIMITIVE_TOOLS
+    assert {"scripted_grasp", "rldx_skill", "rldx_arm", "reset"}.isdisjoint(
+        toolkit._tools
+    )
+
+
+def test_env_server_removes_privileged_rpcs_in_isolation():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade._perception_isolation = True
+    facade._rpc = {}
+    facade._readonly_methods = set()
+    facade._register_rpc()
+
+    assert "env.get_success_criteria_text" not in facade._rpc
+    assert "env.get_task_progress" not in facade._rpc
+    with pytest.raises(PermissionError, match="unavailable"):
+        facade.get_success_criteria_text()
+    with pytest.raises(PermissionError, match="unavailable"):
+        facade.get_task_progress()
+
+
+def test_env_server_allows_only_initial_reset_in_formal_mode():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv()
+    facade._perception_isolation = True
+    facade._allow_reset = False
+    facade._initial_reset_consumed = False
+    facade._episode_id = 0
+    facade._sim_step = 0
+    facade._success_latched = False
+
+    assert facade.reset() == {"obs": 0}
+    with pytest.raises(PermissionError, match="disabled"):
+        facade.reset()
+    assert facade._episode_id == 1
+
+
+def test_env_server_allows_explicit_exploration_reset():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv()
+    facade._perception_isolation = True
+    facade._allow_reset = True
+    facade._initial_reset_consumed = True
+    facade._episode_id = 1
+    facade._sim_step = 12
+    facade._success_latched = True
+
+    assert facade.reset() == {"obs": 0}
+    assert facade._episode_id == 2
+    assert facade._sim_step == 0
+    assert facade._success_latched is False
+
+
+def test_view_state_omits_absent_progress_field(tmp_path):
+    state = EnvState(tmp_path)
+    with state.record_step(
+        state={"robot0_eef_pos": [0.0, 0.0, 1.0]},
+        terminated=False,
+        extras={
+            "task_language": "pick up the mug",
+            "success": False,
+            "vla_desync": True,
+        },
+    ):
+        pass
+    result = view_env_state(step=0, state=state)
+    assert "task_progress" not in result
+
+
+def test_camera_metadata_and_back_projection_tools(tmp_path):
+    state = EnvState(tmp_path)
+    world = np.zeros((4, 5, 3), dtype=np.float32)
+    world[1, 2] = [1.25, -0.5, 0.9]
+    meta = {
+        "camera_name": "robot0_agentview_left",
+        "height": 4,
+        "width": 5,
+        "intrinsic": np.eye(3).tolist(),
+        "extrinsic_cam2world": np.eye(4).tolist(),
+        "depth_near": 0.01,
+        "depth_far": 10.0,
+        "runtime_id": "env-runtime",
+        "episode_id": 1,
+        "sim_step": 0,
+    }
+    with state.record_step(state={}, terminated=False) as step:
+        state.save("agentview_world.npz", world, step=step)
+        state.save("agentview_world_high.npz", world, step=step)
+        state.save("agentview_metadata.json", meta, step=step)
+
+    camera_meta = view_camera_meta("agentview", step=0, state=state)
+    assert camera_meta["artifact"] == "agentview_metadata.json"
+    assert camera_meta["step"] == 0
+
+    point = back_project(1, 2, step=0, state=state)
+    assert point["valid"] is True
+    assert point["world_xyz"] == [1.25, -0.5, 0.9]
+    assert point["source_artifact"] == "agentview_world_high.npz"
+    assert point["step"] == 0
+
+    invalid = back_project_batch([[1.5, 2]], step=0, state=state)
+    assert invalid["results"][0]["valid"] is False
+    assert "integers" in invalid["results"][0]["error"]
+    assert "error" in back_project_batch([[0, 0]] * 51, step=0, state=state)
+    assert "error" in view_camera_meta("unknown", step=0, state=state)


### PR DESCRIPTION
## Summary

- add explicit, versioned runtime handshakes for the RoboCasa environment and RLDX VLA RPC services
- validate environment actions, VLA observations/actions, modality metadata, session IDs, runtime IDs, and model fingerprints before execution
- latch task success after every simulator action and stop action chunks, analytic primitives, and VLA rollout chunks immediately after success
- enforce perception-isolated RPC/tool surfaces without exposing task progress or success predicates
- expose camera metadata and bounded pixel-to-world back-projection tools, with calibration cache invalidation after robot/base motion

## Why

The initial RoboCasa integration is functional, but long benchmark runs need fail-fast contracts around independently spawned environment and VLA services. Without these checks, stale sessions, malformed action batches, post-success motion, or privileged simulator state can silently invalidate a cell.

This PR is intentionally limited to the runtime boundary. Checkpoint attestation, packaged dependency patches, immutable memory resources, the frozen benchmark protocol, and the resumable reproduction CLI are kept in follow-up PRs. It is independent of #124 and is part of the RoboCasa release work tracked by #21.

## Compatibility

- ordinary RoboCasa runs retain the existing CLI and server startup flow
- formal perception isolation is opt-in through the runtime environment
- no planner credentials, model weights, memory artifacts, local paths, or private launch scripts are included

## Verification

- `pytest -q`: 19 passed
- focused runtime contract suite: 18 passed
- `ruff check .`: passed
- `ruff format --check .`: passed