### PR TITLE
feat(robocasa): add isolated planner adapters and cell execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ robocasa = [
     "rpent[rlinf]",
     "rlinf-robocasa365",
     "rlinf-rldx>=1.0.1.post10",
-    "robosuite @ git+https://github.com/RLinf/robosuite.git@rlinf",
+    "robosuite @ git+https://github.com/RLinf/robosuite.git@85abee228d1c43ab1939bce33028099945d453b4",
 ]
 full = [
     "rpent[rlinf,openpi,libero-pro,sam3,robocasa]",
@@ -103,11 +103,12 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["rpent*"]
+include = ["rpent*", "robots*"]
 exclude = ["tests*", "docs*", "examples*", "docker*", "toolkits*"]
 
 [tool.setuptools.package-data]
 "rpent.dashboard" = ["*.html", "static/*.css", "static/*.js"]
+"robots.robocasa" = ["checkpoint_manifest.json", "patches/*.patch", "patches/*.md"]
 
 [tool.ruff]
 line-length = 88

--- a/robots/robocasa/checkpoint_identity.py
+++ b/robots/robocasa/checkpoint_identity.py
@@ -1,0 +1,267 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Content identity and reusable attestation for the frozen RLDX checkpoint."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+AUTHORITY_PATH = Path(__file__).with_name("checkpoint_manifest.json")
+STAT_FIELDS = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _authority() -> tuple[dict[str, Any], str]:
+    raw = AUTHORITY_PATH.read_bytes()
+    value = json.loads(raw.decode("utf-8", errors="strict"))
+    if (
+        not isinstance(value, dict)
+        or value.get("schema_version") != 1
+        or value.get("checkpoint_id") != "RLDX-1-FT-RC365"
+        or value.get("algorithm") != "sha256"
+        or not isinstance(value.get("files"), dict)
+    ):
+        raise ValueError("unsupported checkpoint authority manifest")
+    for name, record in value["files"].items():
+        path = Path(name)
+        if (
+            path.as_posix() != name
+            or path.is_absolute()
+            or ".." in path.parts
+            or path.parts[0] not in {"model", "vlm"}
+            or not isinstance(record, dict)
+            or type(record.get("size")) is not int
+            or record["size"] <= 0
+            or not isinstance(record.get("sha256"), str)
+            or len(record["sha256"]) != 64
+        ):
+            raise ValueError(f"invalid checkpoint authority entry: {name!r}")
+    return value, _sha256_bytes(raw)
+
+
+def expected_fingerprint() -> str:
+    manifest, _ = _authority()
+    payload = {
+        "checkpoint_id": manifest["checkpoint_id"],
+        "files": manifest["files"],
+    }
+    canonical = json.dumps(
+        payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("ascii")
+    return _sha256_bytes(canonical)
+
+
+def authority_manifest() -> dict[str, Any]:
+    """Return the validated immutable authority manifest."""
+    manifest, _ = _authority()
+    return manifest
+
+
+def _root_problem(path: Path, label: str) -> str | None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect {label}: {exc}"
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+        return f"{label} must be a real directory"
+    if metadata.st_uid != os.geteuid() or metadata.st_mode & 0o022:
+        return f"{label} must be owned by the current user and not group/other writable"
+    return None
+
+
+def _file_metadata(path: Path) -> os.stat_result:
+    metadata = path.lstat()
+    if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"checkpoint input must be a regular non-symlink file: {path}")
+    if metadata.st_uid != os.geteuid() or metadata.st_mode & 0o022:
+        raise ValueError(
+            f"checkpoint input must be owned by the current user and not writable "
+            f"by group/other: {path}"
+        )
+    return metadata
+
+
+def _stat_record(metadata: os.stat_result) -> dict[str, int]:
+    return {name: int(getattr(metadata, name)) for name in STAT_FIELDS}
+
+
+def _path_for(name: str, model_root: Path, vlm_root: Path) -> Path:
+    root = model_root if name.startswith("model/") else vlm_root
+    return root / name.split("/", 1)[1]
+
+
+def _validate_weight_index(model_root: Path, manifest: dict[str, Any]) -> None:
+    declared = {
+        Path(name).name
+        for name in manifest["files"]
+        if name.startswith("model/") and name.endswith(".safetensors")
+    }
+    actual = {path.name for path in model_root.glob("*.safetensors")}
+    if actual != declared:
+        raise ValueError(
+            f"checkpoint shard set mismatch: expected={sorted(declared)}, "
+            f"actual={sorted(actual)}"
+        )
+    index_path = model_root / "model.safetensors.index.json"
+    _file_metadata(index_path)
+    index = json.loads(index_path.read_text(encoding="utf-8", errors="strict"))
+    indexed = set(index.get("weight_map", {}).values())
+    if indexed != declared:
+        raise ValueError("checkpoint index shard set differs from authority")
+    total = sum(manifest["files"][f"model/{name}"]["size"] for name in declared)
+    if (
+        index.get("metadata", {}).get("total_size") != total
+        or manifest.get("weight_total_size") != total
+    ):
+        raise ValueError("checkpoint index total_size differs from authority")
+
+
+def verify_checkpoint(
+    model_root: Path,
+    vlm_root: Path,
+    *,
+    hasher: Callable[[Path], str] = sha256_file,
+) -> dict[str, Any]:
+    """Hash every authority input once and return a reusable attestation."""
+    model_input = Path(model_root)
+    vlm_input = Path(vlm_root)
+    for root, label in ((model_input, "model root"), (vlm_input, "VLM root")):
+        if problem := _root_problem(root, label):
+            raise ValueError(problem)
+    model_root = model_input.resolve()
+    vlm_root = vlm_input.resolve()
+    manifest, authority_hash = _authority()
+    _validate_weight_index(model_root, manifest)
+    files: dict[str, dict[str, Any]] = {}
+    for name, expected in sorted(manifest["files"].items()):
+        path = _path_for(name, model_root, vlm_root)
+        before = _file_metadata(path)
+        if before.st_size != expected["size"]:
+            raise ValueError(f"checkpoint size mismatch: {name}")
+        digest = hasher(path)
+        after = _file_metadata(path)
+        if _stat_record(before) != _stat_record(after):
+            raise ValueError(f"checkpoint input changed while hashing: {name}")
+        if digest != expected["sha256"]:
+            raise ValueError(f"checkpoint hash mismatch: {name}")
+        files[name] = {
+            "size": expected["size"],
+            "sha256": digest,
+            "stat": _stat_record(after),
+        }
+    return {
+        "schema_version": 1,
+        "checkpoint_id": manifest["checkpoint_id"],
+        "authority_manifest_sha256": authority_hash,
+        "fingerprint": expected_fingerprint(),
+        "model_root": str(model_root),
+        "vlm_root": str(vlm_root),
+        "files": files,
+        "verified_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def validate_attestation(
+    value: Any, model_root: Path, vlm_root: Path
+) -> dict[str, Any]:
+    """Validate an attestation and cheaply prove its inputs have not changed."""
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        raise ValueError("unsupported checkpoint attestation")
+    manifest, authority_hash = _authority()
+    model_input = Path(model_root)
+    vlm_input = Path(vlm_root)
+    for root, label in ((model_input, "model root"), (vlm_input, "VLM root")):
+        if problem := _root_problem(root, label):
+            raise ValueError(problem)
+    model_root = model_input.resolve()
+    vlm_root = vlm_input.resolve()
+    if value.get("checkpoint_id") != manifest["checkpoint_id"]:
+        raise ValueError("checkpoint attestation id mismatch")
+    if value.get("authority_manifest_sha256") != authority_hash:
+        raise ValueError("checkpoint authority manifest mismatch")
+    if value.get("fingerprint") != expected_fingerprint():
+        raise ValueError("checkpoint fingerprint mismatch")
+    if value.get("model_root") != str(model_root) or value.get("vlm_root") != str(
+        vlm_root
+    ):
+        raise ValueError("checkpoint attestation root mismatch")
+    records = value.get("files")
+    if not isinstance(records, dict) or set(records) != set(manifest["files"]):
+        raise ValueError("checkpoint attestation file set mismatch")
+    _validate_weight_index(model_root, manifest)
+    for name, expected in manifest["files"].items():
+        record = records.get(name)
+        if (
+            not isinstance(record, dict)
+            or record.get("size") != expected["size"]
+            or record.get("sha256") != expected["sha256"]
+        ):
+            raise ValueError(f"checkpoint attestation content mismatch: {name}")
+        current = _file_metadata(_path_for(name, model_root, vlm_root))
+        if record.get("stat") != _stat_record(current):
+            raise ValueError(f"checkpoint input changed since verification: {name}")
+        if not name.endswith(".safetensors") and sha256_file(
+            _path_for(name, model_root, vlm_root)
+        ) != record.get("sha256"):
+            raise ValueError(f"checkpoint input changed since verification: {name}")
+    return value
+
+
+def load_attestation(path: Path, model_root: Path, vlm_root: Path) -> dict[str, Any]:
+    """Securely read and validate a private checkpoint attestation file."""
+    path = Path(path)
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+    ):
+        raise ValueError("checkpoint attestation must be owned, regular, and mode 0600")
+    if metadata.st_size <= 0 or metadata.st_size > 16 * 1024 * 1024:
+        raise ValueError("checkpoint attestation has an invalid size")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if _stat_record(opened) != _stat_record(metadata):
+            raise ValueError("checkpoint attestation changed while opening")
+        raw = os.read(descriptor, metadata.st_size + 1)
+        after = os.fstat(descriptor)
+        if _stat_record(opened) != _stat_record(after) or len(raw) != metadata.st_size:
+            raise ValueError("checkpoint attestation changed while reading")
+    finally:
+        os.close(descriptor)
+    value = json.loads(raw.decode("utf-8", errors="strict"))
+    return validate_attestation(value, model_root, vlm_root)

--- a/robots/robocasa/checkpoint_manifest.json
+++ b/robots/robocasa/checkpoint_manifest.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "checkpoint_id": "RLDX-1-FT-RC365",
+  "algorithm": "sha256",
+  "weight_total_size": 13825888896,
+  "files": {
+    "model/config.json": {"size": 1770, "sha256": "dab438af2c898e60337cc82756fd98494fdaede6a49f545b9661a77c8799bf58"},
+    "model/embodiment_id.json": {"size": 1139, "sha256": "ccf32782b105603c2fc8c36939d37ea9cf1f0ca4fec1b4d6a358d091e3027b7f"},
+    "model/model-00001-of-00003.safetensors": {"size": 4912540968, "sha256": "2a2f48bd2d2979979700c85c44051c37c3256de528842d82883ba756b070e541"},
+    "model/model-00002-of-00003.safetensors": {"size": 4446192352, "sha256": "4bb91b9038d7825809c09da425d5dbd6a52ba1a1af25de09bc94ff218e1f80fc"},
+    "model/model-00003-of-00003.safetensors": {"size": 4467155576, "sha256": "f348bb0aee031e6fd32cad2ff51aa5e4eaf74fa42299dae051f7e3ca0b8adf53"},
+    "model/model.safetensors.index.json": {"size": 76228, "sha256": "017ebdc3d66b8c755d59964c227c4d898dc1aa013d06d58ab8866f07c4082f08"},
+    "model/processor_config.json": {"size": 72898, "sha256": "67c2b1319213aec7009ffd0329adbafe318dd24ef7cc643a93a8b880ab0780da"},
+    "model/statistics.json": {"size": 189345, "sha256": "516d2c5f52a271fa5f0ebe03ac7816b993f8b5d46e4db0efd11c1559c8974a01"},
+    "vlm/added_tokens.json": {"size": 59083, "sha256": "5d2f525c0a6ecbe1aeb24557bb962ec5f96c21d64816b5e8c29c8055aaf3bf11"},
+    "vlm/chat_template.jinja": {"size": 5292, "sha256": "3636d0f0bd6bef02654cdffdc447b79cb2cef8ab02cc75267345946291a489e4"},
+    "vlm/config.json": {"size": 1591, "sha256": "682bfd9abd200c50dee97346211a437ef0f68f498e427f9e6e5fda3750232056"},
+    "vlm/generation_config.json": {"size": 199, "sha256": "a0acd9cf47909f86b54951dbf2cfd2af3b0b36178211926760a3a27edb49378d"},
+    "vlm/merges.txt": {"size": 1671853, "sha256": "8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5"},
+    "vlm/preprocessor_config.json": {"size": 390, "sha256": "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516"},
+    "vlm/special_tokens_map.json": {"size": 613, "sha256": "76862e765266b85aa9459767e33cbaf13970f327a0e88d1c65846c2ddd3a1ecd"},
+    "vlm/tokenizer_config.json": {"size": 377581, "sha256": "afaa8c12c3ef968a10c298c38195ea5a2b79f1037f2e476554d843af51f391bf"},
+    "vlm/video_preprocessor_config.json": {"size": 385, "sha256": "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13"},
+    "vlm/vocab.json": {"size": 2776833, "sha256": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910"}
+  }
+}

--- a/robots/robocasa/env_client.py
+++ b/robots/robocasa/env_client.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -38,6 +39,46 @@ CAM_ALIAS = {
     "mobilebase0_navview": "mobilebase0_navview",
 }
 
+ENV_PROTOCOL_VERSION = 1
+EXPECTED_ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
+EXPECTED_ACTION_DIM = sum(EXPECTED_ACTION_FIELDS.values())
+EXPECTED_CAMERAS = {
+    "robot0_agentview_left",
+    "robot0_agentview_right",
+    "robot0_eye_in_hand",
+}
+MAX_RENDER_DIM = 4096
+MAX_ACTION_CHUNK = 512
+
+
+def _positive_int(value, name, *, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be in [1, {maximum}], got {value}")
+    return value
+
+
+def _finite_array(value, name, *, shape):
+    array = np.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(np.float64, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
 
 class RoboCasaEnvClient(BaseEnvClient):
     _TIMEOUT_S = {
@@ -46,80 +87,369 @@ class RoboCasaEnvClient(BaseEnvClient):
     }
 
     def __init__(self, client: RpcClient, *, expected_meta: dict):
-        super().__init__(client, expected_meta=expected_meta)
-        self.camera_h = expected_meta["camera_h"]
-        self.camera_w = expected_meta["camera_w"]
+        self._client = client
+        server_meta = self._client.call(
+            "env.get_env_meta", timeout_s=self._TIMEOUT_S["default"]
+        )
+        if server_meta != expected_meta:
+            raise RuntimeError(
+                f"env_meta mismatch: expected={expected_meta!r} "
+                f"actual={server_meta!r}. The env_server was launched with "
+                "different args than this client expects — kill the stale "
+                "env_server and relaunch."
+            )
+        self.camera_h = server_meta["camera_h"]
+        self.camera_w = server_meta["camera_w"]
+        self.runtime_info = self._client.call(
+            "env.get_runtime_info", timeout_s=self._TIMEOUT_S["default"]
+        )
+        self._validate_runtime_info(self.runtime_info)
+        self.runtime_id = self.runtime_info["runtime_id"]
+        self._action_dim = int(self.runtime_info["action_schema"]["flat_dim"])
+        self._episode_id = int(self.runtime_info["episode_id"])
+        self._sim_step = int(self.runtime_info["sim_step"])
+        self._success_latched = bool(self.runtime_info["success_latched"])
+        self.last_obs = None
+        self.reset()
+
+    @staticmethod
+    def _validate_runtime_info(info):
+        if not isinstance(info, Mapping):
+            raise TypeError("env runtime handshake must return a mapping")
+        if info.get("protocol_version") != ENV_PROTOCOL_VERSION:
+            raise RuntimeError(
+                f"unsupported env protocol_version={info.get('protocol_version')!r}; "
+                f"expected {ENV_PROTOCOL_VERSION}"
+            )
+        runtime_id = info.get("runtime_id")
+        if not isinstance(runtime_id, str) or not runtime_id:
+            raise RuntimeError("env runtime handshake is missing runtime_id")
+        schema = info.get("action_schema")
+        if (
+            not isinstance(schema, Mapping)
+            or schema.get("flat_dim") != EXPECTED_ACTION_DIM
+        ):
+            raise RuntimeError(f"incompatible env action schema: {schema!r}")
+        fields = schema.get("fields")
+        if not isinstance(fields, list):
+            raise RuntimeError("env action schema fields must be a list")
+        actual_fields = {
+            field.get("name"): field.get("size")
+            for field in fields
+            if isinstance(field, Mapping)
+        }
+        if actual_fields != EXPECTED_ACTION_FIELDS:
+            raise RuntimeError(
+                f"incompatible env action fields: expected={EXPECTED_ACTION_FIELDS!r}, "
+                f"actual={actual_fields!r}"
+            )
+        cameras = info.get("cameras")
+        if not isinstance(cameras, list):
+            raise RuntimeError("env runtime cameras must be a list")
+        perception_isolation = info.get("perception_isolation", False)
+        if not isinstance(perception_isolation, bool):
+            raise RuntimeError("invalid env runtime perception_isolation flag")
+        required_cameras = set(EXPECTED_CAMERAS)
+        if perception_isolation:
+            required_cameras.add("mobilebase0_navview")
+        missing_cameras = required_cameras.difference(cameras)
+        if missing_cameras:
+            raise RuntimeError(
+                f"env runtime is missing required cameras {sorted(missing_cameras)}"
+            )
+        for key in ("episode_id", "sim_step"):
+            value = info.get(key)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise RuntimeError(f"invalid env runtime {key}={value!r}")
+        if not isinstance(info.get("success_latched"), bool):
+            raise RuntimeError("invalid env runtime success_latched flag")
 
     def _resolve_cam(self, name):
+        if not isinstance(name, str) or not name:
+            raise TypeError("camera name must be a non-empty string")
         return CAM_ALIAS.get(name, name)
 
+    def _resolve_size(self, height, width):
+        height = self.camera_h if height is None else height
+        width = self.camera_w if width is None else width
+        return (
+            _positive_int(height, "height", maximum=MAX_RENDER_DIM),
+            _positive_int(width, "width", maximum=MAX_RENDER_DIM),
+        )
+
+    # ---- lifecycle ----
     # ---- state accessors ----
     def reset(self):
-        self.last_obs = self._client.call(
-            "env.reset", timeout_s=self._TIMEOUT_S["env.reset"]
+        obs = self._client.call("env.reset", timeout_s=self._TIMEOUT_S["env.reset"])
+        if not isinstance(obs, Mapping):
+            raise TypeError(
+                f"env.reset returned {type(obs).__name__}, expected mapping"
+            )
+        previous_episode = self._episode_id
+        runtime_info = self._client.call(
+            "env.get_runtime_info", timeout_s=self._TIMEOUT_S["default"]
         )
+        self._validate_runtime_info(runtime_info)
+        if runtime_info["runtime_id"] != self.runtime_id:
+            raise RuntimeError("env runtime changed during reset")
+        if runtime_info["episode_id"] != previous_episode + 1:
+            raise RuntimeError(
+                "env reset did not advance exactly one episode: "
+                f"before={previous_episode}, after={runtime_info['episode_id']!r}"
+            )
+        if runtime_info["sim_step"] != 0:
+            raise RuntimeError("env reset returned a nonzero simulator step")
+        self.last_obs = obs
+        self.runtime_info = runtime_info
+        self._episode_id = runtime_info["episode_id"]
+        self._sim_step = 0
+        self._success_latched = runtime_info["success_latched"]
         return self.last_obs
 
     def step(self, flat_action):
+        action = _finite_array(flat_action, "flat_action", shape=(self._action_dim,))
         result = self._client.call(
-            "env.step", args=(flat_action,), timeout_s=self._TIMEOUT_S["env.step"]
+            "env.step", args=(action,), timeout_s=self._TIMEOUT_S["env.step"]
         )
-        self.last_obs = result[0]
+        if not isinstance(result, (list, tuple)) or len(result) != 4:
+            raise RuntimeError("env.step must return (obs, reward, done, info)")
+        obs, reward, done, info = result
+        if not isinstance(obs, Mapping):
+            raise TypeError("env.step observation must be a mapping")
+        if isinstance(reward, bool) or not isinstance(reward, (int, float, np.number)):
+            raise TypeError("env.step reward must be numeric")
+        if not np.isfinite(float(reward)):
+            raise ValueError("env.step reward must be finite")
+        if not isinstance(done, (bool, np.bool_)):
+            raise TypeError("env.step done must be boolean")
+        if not isinstance(info, Mapping):
+            raise TypeError("env.step info must be a mapping")
+        if info.get("rpent_runtime_id") != self.runtime_id:
+            raise RuntimeError("env.step response came from a different runtime")
+        if info.get("rpent_episode_id") != self._episode_id:
+            raise RuntimeError("env.step response episode identity mismatch")
+        sim_step = info.get("rpent_sim_step")
+        if (
+            isinstance(sim_step, bool)
+            or not isinstance(sim_step, int)
+            or sim_step != self._sim_step + 1
+        ):
+            raise RuntimeError(
+                f"env.step sequence mismatch: expected {self._sim_step + 1}, got {sim_step!r}"
+            )
+        success_latched = info.get("rpent_success_latched")
+        if not isinstance(success_latched, bool):
+            raise RuntimeError("env.step response is missing the success latch")
+        self._sim_step = sim_step
+        self._success_latched = self._success_latched or success_latched
+        self.last_obs = obs
         return result
 
+    def chunk_step(self, flat_actions, *, return_all_frames=False):
+        """Apply a bounded chunk and verify the server's per-action identities."""
+        actions = np.asarray(flat_actions)
+        if actions.ndim != 2 or actions.shape[1:] != (self._action_dim,):
+            raise ValueError(
+                f"flat_actions must have shape (steps, {self._action_dim}), "
+                f"got {actions.shape}"
+            )
+        if not 1 <= actions.shape[0] <= MAX_ACTION_CHUNK:
+            raise ValueError(
+                f"action chunk length must be in [1, {MAX_ACTION_CHUNK}], "
+                f"got {actions.shape[0]}"
+            )
+        if not np.issubdtype(actions.dtype, np.number) or np.issubdtype(
+            actions.dtype, np.bool_
+        ):
+            raise TypeError("flat_actions must contain numeric values")
+        if not np.isfinite(actions).all():
+            raise ValueError("flat_actions must contain only finite values")
+        if not isinstance(return_all_frames, (bool, np.bool_)):
+            raise TypeError("return_all_frames must be boolean")
+        result = self._client.call(
+            "env.chunk_step",
+            args=(actions,),
+            kwargs={"return_all_frames": bool(return_all_frames)},
+            timeout_s=self._TIMEOUT_S["env.chunk_step"],
+        )
+        if not isinstance(result, (list, tuple)) or len(result) != 4:
+            raise RuntimeError(
+                "env.chunk_step must return (obs, rewards, dones, infos)"
+            )
+        obs_field, rewards, dones, infos = result
+        observations = obs_field if return_all_frames else [obs_field]
+        if not isinstance(observations, list) or not observations:
+            raise RuntimeError("env.chunk_step returned no observations")
+        if any(not isinstance(obs, Mapping) for obs in observations):
+            raise TypeError("env.chunk_step observations must be mappings")
+        if not isinstance(infos, list) or not 1 <= len(infos) <= actions.shape[0]:
+            raise RuntimeError("env.chunk_step returned an invalid info sequence")
+        rewards = _finite_array(rewards, "chunk rewards", shape=(len(infos),))
+        dones = np.asarray(dones)
+        if dones.shape != (len(infos),) or dones.dtype != np.bool_:
+            raise ValueError(
+                f"chunk dones must be boolean with shape {(len(infos),)}, "
+                f"got dtype={dones.dtype}, shape={dones.shape}"
+            )
+        if return_all_frames and len(observations) != len(infos):
+            raise RuntimeError("env.chunk_step observation/info lengths differ")
+        for info in infos:
+            if not isinstance(info, Mapping):
+                raise TypeError("env.chunk_step infos must be mappings")
+            expected_step = self._sim_step + 1
+            if (
+                info.get("rpent_runtime_id") != self.runtime_id
+                or info.get("rpent_episode_id") != self._episode_id
+                or info.get("rpent_sim_step") != expected_step
+            ):
+                raise RuntimeError("env.chunk_step response identity/sequence mismatch")
+            latched = info.get("rpent_success_latched")
+            if not isinstance(latched, bool):
+                raise RuntimeError(
+                    "env.chunk_step response is missing the success latch"
+                )
+            self._sim_step = expected_step
+            self._success_latched = self._success_latched or latched
+        if self._success_latched and len(infos) > 1:
+            first_success = next(
+                (i for i, info in enumerate(infos) if info["rpent_success_latched"]),
+                None,
+            )
+            if first_success is not None and first_success != len(infos) - 1:
+                raise RuntimeError("env.chunk_step did not stop at the first success")
+        self.last_obs = observations[-1]
+        return obs_field, rewards, dones, infos
+
     def check_success(self):
-        return self._client.call(
+        if self._success_latched:
+            return True
+        value = self._client.call(
             "env.check_success", timeout_s=self._TIMEOUT_S["default"]
         )
+        if not isinstance(value, (bool, np.bool_)):
+            raise TypeError("env.check_success must return a boolean")
+        self._success_latched = bool(value)
+        return self._success_latched
+
+    @property
+    def success_latched(self):
+        """Return the authoritative latch carried by reset and step responses."""
+        return self._success_latched
 
     @property
     def terminated(self):
         return self.check_success()
 
     @property
+    def action_dim(self):
+        return self._action_dim
+
+    @property
     def current_raw_obs(self):
+        if self.last_obs is None:
+            raise RuntimeError("environment has not been reset")
         return self.last_obs
 
     @property
     def eef_pos(self):
-        return np.array(self.last_obs["robot0_eef_pos"], dtype=np.float64)
+        return _finite_array(
+            self.current_raw_obs["robot0_eef_pos"],
+            "robot0_eef_pos",
+            shape=(3,),
+        )
 
     @property
     def eef_quat(self):
-        return np.array(self.last_obs["robot0_eef_quat"], dtype=np.float64)
+        return _finite_array(
+            self.current_raw_obs["robot0_eef_quat"],
+            "robot0_eef_quat",
+            shape=(4,),
+        )
 
     @property
     def gripper_qpos(self):
-        return np.array(self.last_obs.get("robot0_gripper_qpos", []), dtype=np.float64)
+        return _finite_array(
+            self.current_raw_obs.get("robot0_gripper_qpos"),
+            "robot0_gripper_qpos",
+            shape=(2,),
+        )
 
     # ---- task info ----
+    def get_task_language(self) -> str | None:
+        value = super().get_task_language()
+        if value is not None and not isinstance(value, str):
+            raise TypeError("env.get_task_language must return a string or null")
+        return value
+
     def get_success_criteria_text(self):
         return self._client.call(
             "env.get_success_criteria_text", timeout_s=self._TIMEOUT_S["default"]
         )
 
     def get_task_progress(self):
-        return self._client.call(
+        progress = self._client.call(
             "env.get_task_progress", timeout_s=self._TIMEOUT_S["default"]
         )
+        if not isinstance(progress, Mapping):
+            raise TypeError("env.get_task_progress must return a mapping")
+        return dict(progress)
 
     # ---- rendering / perception ----
+    def _render_native(self, camera_name, height, width, depth):
+        """Render through the shared RPC contract and validate its payload."""
+        camera_name = self._resolve_cam(camera_name)
+        height, width = self._resolve_size(height, width)
+        if not isinstance(depth, (bool, np.bool_)):
+            raise TypeError("depth must be a boolean")
+        result = super().render_camera(
+            camera_name,
+            height=height,
+            width=width,
+            depth=bool(depth),
+        )
+        if depth:
+            if not isinstance(result, (list, tuple)) or len(result) != 2:
+                raise RuntimeError("depth render must return (rgb, depth)")
+            rgb = np.asarray(result[0])
+            real = _finite_array(result[1], "depth", shape=(height, width))
+            if rgb.shape != (height, width, 3) or rgb.dtype != np.uint8:
+                raise ValueError(
+                    f"RGB render must be uint8 with shape {(height, width, 3)}, "
+                    f"got dtype={rgb.dtype}, shape={rgb.shape}"
+                )
+            return rgb, real
+        rgb = np.asarray(result)
+        if rgb.shape != (height, width, 3) or rgb.dtype != np.uint8:
+            raise ValueError(
+                f"RGB render must be uint8 with shape {(height, width, 3)}, "
+                f"got dtype={rgb.dtype}, shape={rgb.shape}"
+            )
+        return rgb
+
     def render_camera(self, camera_name, height=None, width=None, depth=False):
         """Agent-facing: vertically flip to top-down so the rgb reads naturally and
         is pixel-aligned with world_map()."""
         cam = self._resolve_cam(camera_name)
-        h = height or self.camera_h
-        w = width or self.camera_w
+        h, w = self._resolve_size(height, width)
         if depth:
-            rgb, real = super().render_camera(cam, height=h, width=w, depth=True)
+            rgb, real = self._render_native(cam, h, w, True)
             return rgb[::-1], real[::-1]
-        return super().render_camera(cam, height=h, width=w, depth=False)[::-1]
+        return self._render_native(cam, h, w, False)[::-1]
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         cam = self._resolve_cam(camera_name)
-        h = height or self.camera_h
-        w = width or self.camera_w
-        return super().get_camera_meta(cam, height=h, width=w)
+        h, w = self._resolve_size(height, width)
+        meta = super().get_camera_meta(cam, height=h, width=w)
+        if not isinstance(meta, Mapping):
+            raise TypeError("camera metadata must be a mapping")
+        if (
+            meta.get("runtime_id") != self.runtime_id
+            or meta.get("episode_id") != self._episode_id
+        ):
+            raise RuntimeError("camera metadata identity mismatch")
+        _finite_array(meta.get("intrinsic"), "camera intrinsic", shape=(3, 3))
+        _finite_array(meta.get("extrinsic_cam2world"), "camera extrinsic", shape=(4, 4))
+        return dict(meta)
 
     def world_map(self, camera_name, height=None, width=None):
         """HxWx3 world xyz per pixel, TOP-DOWN (row 0 = image top), pixel-aligned
@@ -128,34 +458,53 @@ class RoboCasaEnvClient(BaseEnvClient):
         transform's top-down convention (VERIFIED: GT object back-projects within
         ~2cm). Dense vectorized: world = T_p2w @ [col*z, row*z, z, 1]."""
         cam = self._resolve_cam(camera_name)
-        h = height or self.camera_h
-        w = width or self.camera_w
-        _, z_native = super().render_camera(
-            cam, height=h, width=w, depth=True
-        )  # metric depth, bottom-up
+        h, w = self._resolve_size(height, width)
+        _, z_native = self._render_native(cam, h, w, True)  # metric depth, bottom-up
         z = z_native[::-1]  # -> top-down
         T_p2w = self._client.call(
             "env.get_camera_transform",
             kwargs={"camera_name": cam, "height": h, "width": w},
             timeout_s=self._TIMEOUT_S["default"],
         )
+        T_p2w = _finite_array(T_p2w, "pixel-to-world transform", shape=(4, 4))
         rows, cols = np.meshgrid(np.arange(h), np.arange(w), indexing="ij")
         homog = np.stack([cols * z, rows * z, z, np.ones_like(z)], axis=-1)  # HxWx4
         world = homog @ T_p2w.T  # HxWx4
         return world[..., :3]  # top-down, aligned with rgb
 
     def world_xyz_at(self, camera_name, row, col, height=None, width=None):
-        return self.world_map(camera_name, height, width)[row, col]
+        if isinstance(row, (bool, np.bool_)) or not isinstance(row, (int, np.integer)):
+            raise TypeError("row must be an integer")
+        if isinstance(col, (bool, np.bool_)) or not isinstance(col, (int, np.integer)):
+            raise TypeError("col must be an integer")
+        world = self.world_map(camera_name, height, width)
+        row, col = int(row), int(col)
+        if not (0 <= row < world.shape[0] and 0 <= col < world.shape[1]):
+            raise IndexError(f"pixel ({row}, {col}) is outside {world.shape[:2]}")
+        return world[row, col]
 
     # ---- other ----
     def grasp_contact(self):
-        return self._client.call(
+        result = self._client.call(
             "env.grasp_contact", timeout_s=self._TIMEOUT_S["env.grasp_contact"]
         )
+        if not isinstance(result, (list, tuple)) or len(result) != 2:
+            raise RuntimeError("env.grasp_contact must return (bool, object_name)")
+        grasping, object_name = result
+        if not isinstance(grasping, (bool, np.bool_)):
+            raise TypeError("env.grasp_contact flag must be boolean")
+        if object_name is not None and not isinstance(object_name, str):
+            raise TypeError("env.grasp_contact object name must be a string or null")
+        return bool(grasping), object_name
 
     def reassemble_env_action(self, unmap_result):
-        return self._client.call(
+        if not isinstance(unmap_result, Mapping):
+            raise TypeError("unmap_result must be a mapping")
+        action = self._client.call(
             "env.reassemble_env_action",
-            args=(unmap_result,),
+            args=(dict(unmap_result),),
             timeout_s=self._TIMEOUT_S["default"],
+        )
+        return _finite_array(
+            action, "reassembled env action", shape=(self._action_dim,)
         )

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -22,6 +22,8 @@ import re
 import sys
 import threading
 import traceback
+import uuid
+from collections.abc import Mapping
 
 import numpy as np
 
@@ -39,6 +41,57 @@ DEFAULT_CAMS = [
     "robot0_agentview_right",
     "robot0_eye_in_hand",
 ]
+
+ENV_PROTOCOL_VERSION = 1
+NAV_CAMERA = "mobilebase0_navview"
+RLDX_ACTION_FIELDS = (
+    ("action.end_effector_position", 3),
+    ("action.end_effector_rotation", 3),
+    ("action.gripper_close", 1),
+    ("action.base_motion", 4),
+    ("action.control_mode", 1),
+)
+RLDX_ACTION_DIM = sum(size for _, size in RLDX_ACTION_FIELDS)
+MAX_RENDER_DIM = 4096
+MAX_RENDER_PIXELS = MAX_RENDER_DIM * MAX_RENDER_DIM
+MAX_ACTION_CHUNK = 512
+
+
+def _env_flag(name, default):
+    raw = os.environ.get(name, default)
+    if raw not in {"0", "1"}:
+        raise ValueError(f"{name} must be 0 or 1, got {raw!r}")
+    return raw == "1"
+
+
+def _positive_int(value, name, *, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be in [1, {maximum}], got {value}")
+    return value
+
+
+def _finite_array(value, name, *, shape):
+    array = np.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(np.float64, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _finite_action_part(value, name, size):
+    array = np.asarray(value)
+    if size == 1 and array.shape == ():
+        array = array.reshape(1)
+    return _finite_array(array, name, shape=(size,))
 
 
 def _split_kwargs(split):
@@ -87,6 +140,9 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         cameras=None,
         use_camera_obs=False,
     ):
+        self._perception_isolation = _env_flag("RLDX_PERCEPTION_ISOLATION", "0")
+        self._allow_reset = _env_flag("RLDX_ALLOW_RESET", "0")
+        self._initial_reset_consumed = False
         super().__init__()
         import robocasa  # noqa: F401 — registers robocasa envs
         import robosuite
@@ -118,6 +174,26 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             **_split_kwargs(split),
         )
         self.env = robosuite.make(**env_kwargs)
+        self._runtime_id = uuid.uuid4().hex
+        self._episode_id = 0
+        self._sim_step = 0
+        self._success_latched = False
+        self._camera_names = self._discover_camera_names()
+        required_cameras = set(DEFAULT_CAMS)
+        if self._perception_isolation:
+            required_cameras.add(NAV_CAMERA)
+        missing_cameras = required_cameras.difference(self._camera_names)
+        if missing_cameras:
+            raise RuntimeError(
+                "RoboCasa camera contract is not satisfied; missing "
+                f"{sorted(missing_cameras)}. {NAV_CAMERA!r} requires the PandaOmron "
+                "navview XML patch on robosuite commit 85abee228d1c43ab1939bce33028099945d453b4."
+            )
+        if int(self.env.action_dim) != RLDX_ACTION_DIM:
+            raise RuntimeError(
+                f"RLDX/RoboCasa action schema requires {RLDX_ACTION_DIM} values, "
+                f"but env.action_dim={self.env.action_dim}"
+            )
         self._meta = {
             "task_name": self.task_name,
             "split": self.split,
@@ -133,24 +209,75 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         self._rpc["env.get_camera_transform"] = self.get_camera_transform
         self._rpc["env.grasp_contact"] = self.grasp_contact
         self._rpc["env.reassemble_env_action"] = self.reassemble_env_action
-        self._rpc["env.get_success_criteria_text"] = self.get_success_criteria_text
-        self._rpc["env.get_task_progress"] = self.get_task_progress
+        if not self._perception_isolation:
+            self._rpc["env.get_success_criteria_text"] = self.get_success_criteria_text
+            self._rpc["env.get_task_progress"] = self.get_task_progress
+        self._rpc["env.get_runtime_info"] = self.get_runtime_info
         # Read-only methods
         self._readonly_methods.update(
             [
-                "env.check_success",
                 "env.get_camera_transform",
+                "env.check_success",
                 "env.grasp_contact",
-                "env.get_success_criteria_text",
-                "env.get_task_progress",
+                "env.get_runtime_info",
             ]
         )
+        if not self._perception_isolation:
+            self._readonly_methods.update(
+                {
+                    "env.get_success_criteria_text",
+                    "env.get_task_progress",
+                }
+            )
 
     def get_env_meta(self):
         return self._meta
 
+    def _discover_camera_names(self):
+        model = self.env.sim.model
+        raw_names = getattr(model, "camera_names", ())
+        names = (
+            {str(name) for name in raw_names if name}
+            if raw_names is not None
+            else set()
+        )
+        for name in DEFAULT_CAMS + [NAV_CAMERA]:
+            try:
+                model.camera_name2id(name)
+            except Exception:
+                continue
+            names.add(name)
+        return names
+
+    def get_runtime_info(self):
+        return {
+            "protocol_version": ENV_PROTOCOL_VERSION,
+            "runtime_id": self._runtime_id,
+            "episode_id": self._episode_id,
+            "sim_step": self._sim_step,
+            "success_latched": self._success_latched,
+            "perception_isolation": self._perception_isolation,
+            "robot": "PandaOmron",
+            "action_schema": {
+                "name": "robocasa.panda_omron.flat.v1",
+                "flat_dim": RLDX_ACTION_DIM,
+                "fields": [
+                    {"name": name, "size": size} for name, size in RLDX_ACTION_FIELDS
+                ],
+            },
+            "cameras": sorted(self._camera_names),
+        }
+
     # ---- lifecycle ----
     def reset(self):
+        if (
+            getattr(self, "_perception_isolation", False)
+            and not getattr(self, "_allow_reset", False)
+            and getattr(self, "_initial_reset_consumed", False)
+        ):
+            raise PermissionError(
+                "reset is disabled after formal episode initialization"
+            )
         # RLDX_RESET_SEED=<episode_seed> -> reproduce the EXACT scene the fullshot eval
         # generated for that episode, seeded the SAME way as the eval's VideoRecordingWrapper
         # (random.seed + np.random.seed + robosuite env.rng/seed) BEFORE reset. Lets the
@@ -160,72 +287,219 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         if rs_env:
             import random
 
-            sd = int(rs_env)
+            try:
+                sd = int(rs_env)
+            except ValueError as exc:
+                raise ValueError("RLDX_RESET_SEED must be an integer") from exc
+            if sd < 0 or sd > np.iinfo(np.uint32).max:
+                raise ValueError("RLDX_RESET_SEED must be in [0, 2**32 - 1]")
             random.seed(sd)
             np.random.seed(sd)
             if hasattr(self.env, "seed"):
                 self.env.seed = sd
             if hasattr(self.env, "rng"):
                 self.env.rng = np.random.default_rng(sd)
-        return self.env.reset()
+        obs = self.env.reset()
+        if not isinstance(obs, dict):
+            raise TypeError(
+                f"env.reset must return an observation dict, got {type(obs).__name__}"
+            )
+        self._episode_id += 1
+        self._sim_step = 0
+        self._success_latched = bool(self.env._check_success())
+        self._initial_reset_consumed = True
+        return obs
 
     def step(self, flat_action):
         """flat_action: np.ndarray[12] = [eef_pos(3), eef_rot(3), gripper(1),
         base_motion(4), control_mode(1)] in the PandaOmron composite layout."""
-        a = np.asarray(flat_action, dtype=np.float64).reshape(-1)
-        assert a.shape[0] == self.env.action_dim, (
-            f"action dim {a.shape[0]} != env.action_dim {self.env.action_dim}"
+        a = _finite_array(
+            flat_action,
+            "flat_action",
+            shape=(int(self.env.action_dim),),
         )
+        if self._success_latched:
+            raise RuntimeError(
+                "episode success is already latched; further motion is disabled"
+            )
         obs, reward, done, info = self.env.step(a)
+        if not isinstance(obs, dict):
+            raise TypeError(
+                f"env.step must return an observation dict, got {type(obs).__name__}"
+            )
+        self._sim_step += 1
+        success_now = bool(self.env._check_success())
+        self._success_latched = self._success_latched or success_now
+        info = dict(info) if isinstance(info, dict) else {"env_info": info}
+        info.update(
+            {
+                "rpent_runtime_id": self._runtime_id,
+                "rpent_episode_id": self._episode_id,
+                "rpent_sim_step": self._sim_step,
+                "rpent_success_now": success_now,
+                "rpent_success_latched": self._success_latched,
+            }
+        )
         return obs, reward, done, info
 
+    def chunk_step(self, flat_actions, *, return_all_frames=False):
+        """Apply a bounded action chunk, stopping at the first latched success."""
+        actions = np.asarray(flat_actions)
+        if actions.ndim != 2 or actions.shape[1:] != (int(self.env.action_dim),):
+            raise ValueError(
+                "flat_actions must have shape "
+                f"(steps, {self.env.action_dim}), got {actions.shape}"
+            )
+        if not 1 <= actions.shape[0] <= MAX_ACTION_CHUNK:
+            raise ValueError(
+                f"action chunk length must be in [1, {MAX_ACTION_CHUNK}], "
+                f"got {actions.shape[0]}"
+            )
+        if not np.issubdtype(actions.dtype, np.number) or np.issubdtype(
+            actions.dtype, np.bool_
+        ):
+            raise TypeError("flat_actions must contain numeric values")
+        if not np.isfinite(actions).all():
+            raise ValueError("flat_actions must contain only finite values")
+        if not isinstance(return_all_frames, (bool, np.bool_)):
+            raise TypeError("return_all_frames must be boolean")
+
+        observations = []
+        rewards = []
+        dones = []
+        infos = []
+        for action in actions:
+            obs, reward, done, info = self.step(action)
+            observations.append(obs)
+            rewards.append(reward)
+            dones.append(done)
+            infos.append(info)
+            if self._success_latched:
+                break
+        obs_field = observations if return_all_frames else observations[-1]
+        return (
+            obs_field,
+            np.asarray(rewards, dtype=np.float64),
+            np.asarray(dones, dtype=np.bool_),
+            infos,
+        )
+
     def check_success(self):
-        return bool(self.env._check_success())
+        return self._success_latched
+
+    def _validate_camera_request(self, camera_name, height, width):
+        if not isinstance(camera_name, str) or not camera_name:
+            raise TypeError("camera_name must be a non-empty string")
+        if camera_name not in self._camera_names:
+            raise ValueError(
+                f"unknown camera {camera_name!r}; available={sorted(self._camera_names)}"
+            )
+        height = self.camera_h if height is None else height
+        width = self.camera_w if width is None else width
+        height = _positive_int(height, "height", maximum=MAX_RENDER_DIM)
+        width = _positive_int(width, "width", maximum=MAX_RENDER_DIM)
+        if height * width > MAX_RENDER_PIXELS:
+            raise ValueError(f"render size {height}x{width} exceeds pixel budget")
+        return camera_name, height, width
 
     def render_camera(self, camera_name, height, width, depth):
-        """sim.render in ROBOSUITE-NATIVE orientation (matches the camera
-        transform matrices). rgb uint8 HxWx3, depth metric HxW."""
+        """Render one validated camera in robosuite-native orientation."""
         import robosuite.utils.camera_utils as CU
 
+        camera_name, height, width = self._validate_camera_request(
+            camera_name, height, width
+        )
+        if not isinstance(depth, (bool, np.bool_)):
+            raise TypeError("depth must be a boolean")
         out = self.env.sim.render(
-            width=width, height=height, camera_name=camera_name, depth=depth
+            width=width,
+            height=height,
+            camera_name=camera_name,
+            depth=depth,
         )
         if depth:
-            rgb, d = out
-            # Sanitize the raw OpenGL normalized depth into [0,1]: replace NaN/inf
-            # (degenerate camera pose) then clip numerical overshoot. Otherwise an
-            # assertion inside get_real_depth_map crashes the whole env server process.
-            d = np.nan_to_num(d, nan=1.0, posinf=1.0, neginf=0.0)
-            d = np.clip(d, 0.0, 1.0)
-            if d.ndim == 3:
-                depth = CU.get_real_depth_map(self.env.sim, d)[..., 0]
+            rgb, normalized_depth = out
+            rgb = np.asarray(rgb)
+            normalized_depth = np.asarray(normalized_depth)
+            if rgb.shape != (height, width, 3):
+                raise ValueError(
+                    "rendered RGB must have shape "
+                    f"{(height, width, 3)}, got {rgb.shape}"
+                )
+            if normalized_depth.shape not in {
+                (height, width),
+                (height, width, 1),
+            }:
+                raise ValueError(
+                    "rendered depth must have shape "
+                    f"{(height, width)} or {(height, width, 1)}, "
+                    f"got {normalized_depth.shape}"
+                )
+            normalized_depth = np.nan_to_num(
+                normalized_depth,
+                nan=1.0,
+                posinf=1.0,
+                neginf=0.0,
+            )
+            normalized_depth = np.clip(normalized_depth, 0.0, 1.0)
+            if normalized_depth.ndim == 3:
+                real_depth = CU.get_real_depth_map(self.env.sim, normalized_depth)[
+                    ..., 0
+                ]
             else:
-                depth = CU.get_real_depth_map(self.env.sim, d[..., None])[..., 0]
-            return rgb, depth
-        return out
+                real_depth = CU.get_real_depth_map(
+                    self.env.sim, normalized_depth[..., None]
+                )[..., 0]
+            return rgb, real_depth
+        rgb = np.asarray(out)
+        if rgb.shape != (height, width, 3):
+            raise ValueError(
+                f"rendered RGB must have shape {(height, width, 3)}, got {rgb.shape}"
+            )
+        return rgb
 
     def get_camera_meta(self, camera_name, height=None, width=None):
         import robosuite.utils.camera_utils as CU
 
+        camera_name, height, width = self._validate_camera_request(
+            camera_name, height, width
+        )
         K = CU.get_camera_intrinsic_matrix(self.env.sim, camera_name, height, width)
         Ext = CU.get_camera_extrinsic_matrix(self.env.sim, camera_name)  # cam->world
+        K = _finite_array(K, "camera intrinsic", shape=(3, 3))
+        Ext = _finite_array(Ext, "camera extrinsic", shape=(4, 4))
         m = self.env.sim.model
         extent = m.stat.extent
+        near = float(m.vis.map.znear * extent)
+        far = float(m.vis.map.zfar * extent)
+        if not np.isfinite([near, far]).all() or not (0 < near < far):
+            raise ValueError(f"invalid camera depth range near={near}, far={far}")
         return {
             "camera_name": camera_name,
             "height": height,
             "width": width,
-            "intrinsic": np.asarray(K, dtype=np.float64).tolist(),
-            "extrinsic_cam2world": np.asarray(Ext, dtype=np.float64).tolist(),
-            "depth_near": float(m.vis.map.znear * extent),
-            "depth_far": float(m.vis.map.zfar * extent),
+            "intrinsic": K.tolist(),
+            "extrinsic_cam2world": Ext.tolist(),
+            "depth_near": near,
+            "depth_far": far,
+            "runtime_id": self._runtime_id,
+            "episode_id": self._episode_id,
+            "sim_step": self._sim_step,
         }
 
     def get_camera_transform(self, camera_name, height=None, width=None):
         import robosuite.utils.camera_utils as CU
 
+        camera_name, height, width = self._validate_camera_request(
+            camera_name, height, width
+        )
         T = CU.get_camera_transform_matrix(self.env.sim, camera_name, height, width)
-        return np.linalg.inv(T)  # T_p2w
+        T = _finite_array(T, "camera transform", shape=(4, 4))
+        try:
+            inverse = np.linalg.inv(T)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError("camera transform is singular") from exc
+        return inverse  # T_p2w
 
     def get_task_language(self) -> str | None:
         return self.env.get_ep_meta().get("lang")
@@ -251,6 +525,9 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             HybridMobileBase,
         )
 
+        if not isinstance(unmap_result, Mapping):
+            raise TypeError("unmap_result must be a mapping")
+        parts = dict(unmap_result)
         env_action = []
         for robot in self.env.robots:
             cc = robot.composite_controller
@@ -258,14 +535,30 @@ class RoboCasaEnvFacade(BaseEnvFacade):
             a = np.zeros(cc.action_limits[0].shape)
             for part_name in cc.part_controllers:
                 s, e = cc._action_split_indexes[part_name]
-                a[s:e] = unmap_result.pop(f"{pf}{part_name}")
+                key = f"{pf}{part_name}"
+                if key not in parts:
+                    raise ValueError(f"unmap_result is missing {key!r}")
+                a[s:e] = _finite_action_part(parts.pop(key), key, e - s)
             if isinstance(cc, HybridMobileBase):
-                a[-1] = unmap_result.pop(f"{pf}base_mode")
+                key = f"{pf}base_mode"
+                if key not in parts:
+                    raise ValueError(f"unmap_result is missing {key!r}")
+                a[-1] = _finite_action_part(parts.pop(key), key, 1)[0]
             env_action.append(a)
-        return np.concatenate(env_action)
+        if parts:
+            raise ValueError(f"unmap_result has unexpected keys: {sorted(parts)}")
+        return _finite_array(
+            np.concatenate(env_action),
+            "reassembled env action",
+            shape=(int(self.env.action_dim),),
+        )
 
     def get_success_criteria_text(self):
         """Return the success_criteria.md text for this task."""
+        if self._perception_isolation:
+            raise PermissionError(
+                "success criteria are unavailable in perception-isolated evaluation"
+            )
         env = self.env
         out = []
         try:
@@ -306,6 +599,10 @@ class RoboCasaEnvFacade(BaseEnvFacade):
 
     def get_task_progress(self):
         """Return the progress dict for this task."""
+        if self._perception_isolation:
+            raise PermissionError(
+                "task progress is unavailable in perception-isolated evaluation"
+            )
         env = self.env
         prog = {}
         code = type(env)._check_success.__code__
@@ -384,9 +681,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
                 event, req = item
                 try:
                     req["result"] = self._dispatch(
-                        req["method"],
-                        req["args"],
-                        req["kwargs"],
+                        req["method"], req["args"], req["kwargs"]
                     )
                 except Exception:
                     req["error"] = traceback.format_exc()

--- a/robots/robocasa/patches/README.md
+++ b/robots/robocasa/patches/README.md
@@ -1,0 +1,18 @@
+# RoboCasa navview patch
+
+`robosuite_navview.patch` targets
+`robosuite/models/assets/bases/omron_mobile_base.xml` from the currently
+audited upstream snapshot `RLinf/robosuite@85abee228d1c43ab1939bce33028099945d453b4`.
+It adds the base-mounted `navview` camera required by the RoboCasa runtime.
+
+From the root of a clean robosuite checkout:
+
+```bash
+git apply --check /path/to/robosuite_navview.patch
+git apply /path/to/robosuite_navview.patch
+```
+
+Do not apply the patch twice. The reproduction `doctor` command verifies that
+exactly one `navview` camera exists and that all four camera attributes match.
+The patch identifies the audited input snapshot; a formal release must also
+publish and freeze its complete runtime and robosuite revisions.

--- a/robots/robocasa/patches/robosuite_navview.patch
+++ b/robots/robocasa/patches/robosuite_navview.patch
@@ -1,0 +1,8 @@
+diff --git a/robosuite/models/assets/bases/omron_mobile_base.xml b/robosuite/models/assets/bases/omron_mobile_base.xml
+--- a/robosuite/models/assets/bases/omron_mobile_base.xml
++++ b/robosuite/models/assets/bases/omron_mobile_base.xml
+@@ -29,3 +29,4 @@
+     <worldbody>
+         <body name="base" pos="0 0 0">
++            <camera name="navview" mode="fixed" pos="0.2 0 1.6" xyaxes="0 -1 0 0.643 0 0.766" fovy="75"/>
+             <body name="fixed_support" pos="-0.05 0 0.50">

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -22,13 +22,66 @@ from robots.robocasa.rldx_skill import RLDXSkill
 
 OSC_POS_SCALE = 0.05  # action 1.0 -> 0.05 m target delta
 OSC_ROT_SCALE = 0.5  # action 1.0 -> 0.5 rad
+MAX_ENV_STEPS = 10_000
+MAX_VLA_CHUNKS = 1_000
+MAX_VLA_ACTION_STEPS = 512
+MAX_HI_RES = 4096
+
+
+def _bounded_int(value, name, *, minimum=1, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be in [{minimum}, {maximum}], got {value}")
+    return value
+
+
+def _finite_scalar(value, name, *, minimum=None, maximum=None):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.number)
+    ):
+        raise TypeError(f"{name} must be numeric")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value}")
+    return value
+
+
+def _finite_vector(value, name, size):
+    array = np.asarray(value)
+    if array.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},), got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(np.float64, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _env_flag(name, default):
+    raw = os.environ.get(name, default)
+    if raw not in {"0", "1"}:
+        raise ValueError(f"{name} must be 0 or 1, got {raw!r}")
+    return raw == "1"
 
 
 class RoboCasaPrimitives:
     def __init__(self, env_client, workdir, hi_res, vla_client, check_cancelled=None):
         self.env = env_client
         self.workdir = workdir
-        self.hi_res = hi_res
+        self.hi_res = (
+            None
+            if hi_res is None
+            else _bounded_int(hi_res, "hi_res", maximum=MAX_HI_RES)
+        )
         # Cancellation checkpoint callback (e.g. Toolkit.raise_if_cancelled),
         # invoked before long-running env.step loops so an interrupted tool
         # operation stops promptly instead of draining the whole episode.
@@ -37,13 +90,23 @@ class RoboCasaPrimitives:
         # localizes every object, so they are never optional. Disk is bounded by keeping only
         # the last `_keep_heavy` steps' heavy npy on disk (pruned in dump_state) + each
         # launcher's per-cell workdir cleanup.
-        self._keep_heavy = int(os.environ.get("RLDX_KEEP_HEAVY_NPY", "25"))
+        try:
+            keep_heavy = int(os.environ.get("RLDX_KEEP_HEAVY_NPY", "25"))
+        except ValueError as exc:
+            raise ValueError("RLDX_KEEP_HEAVY_NPY must be an integer") from exc
+        self._keep_heavy = _bounded_int(
+            keep_heavy, "RLDX_KEEP_HEAVY_NPY", maximum=10_000
+        )
         # reset (restart the episode) is ONLY legitimate in EXPLORE mode (reset-based recipe
         # search). It is FORBIDDEN in multi-seed / matched-scene evaluation (a give-up-and-
         # restart). Gated by RLDX_ALLOW_RESET (default 0 = off); explore runs opt in.
-        self._allow_reset = bool(int(os.environ.get("RLDX_ALLOW_RESET", "0")))
+        self._allow_reset = _env_flag("RLDX_ALLOW_RESET", "0")
+        self._perception_isolation = _env_flag("RLDX_PERCEPTION_ISOLATION", "0")
         os.makedirs(workdir, exist_ok=True)
-        self.env.reset()
+        if self.env.current_raw_obs is None:
+            raise RuntimeError(
+                "RoboCasaEnvClient must complete its initial reset first"
+            )
         self._pos_jac = None  # 3x3 action(arm xyz) -> world dpos
         self._fwd_offset = None  # world_forward_heading = base_yaw + offset
         self._cam_meta_cache = {}
@@ -59,6 +122,16 @@ class RoboCasaPrimitives:
         # Recording (off by default — zero overhead when not recording)
         self._recording = False
         self._frames = []
+
+    def _invalidate_geometry(self, *, base_moved=False, vla_moved=False):
+        """Drop pose-dependent calibration after motions outside the OSC servo."""
+        if base_moved or vla_moved:
+            self._pos_jac = None
+            self._cam_meta_cache.pop("agentview", None)
+            self._cam_meta_cache.pop("navview", None)
+        if vla_moved:
+            self._fwd_offset = None
+            self._cam_meta_cache.pop("wrist", None)
 
     # ---- recording methods ----
     def start_recording(self):
@@ -98,7 +171,18 @@ class RoboCasaPrimitives:
 
     def _hold_gripper_val(self, g):
         # +1 close/hold, -1 open
+        g = _finite_scalar(g, "gripper")
         return float(np.clip(g, -1, 1))
+
+    @staticmethod
+    def _validate_gripper(gripper):
+        if gripper is None:
+            return gripper
+        if isinstance(gripper, str):
+            if gripper == "hold":
+                return gripper
+            raise ValueError("gripper string must be 'hold'")
+        return _finite_scalar(gripper, "gripper")
 
     def _resolve_grip(self, gripper, target_q):
         """Return the a[6] gripper command for a motion step.
@@ -109,6 +193,7 @@ class RoboCasaPrimitives:
         during a +1 carry). Servoing to the grasped width holds the object without crushing
         it and without letting it drift open. A numeric gripper (+1 close / -1 open) is an
         EXPLICIT override and passes through unchanged."""
+        gripper = self._validate_gripper(gripper)
         if isinstance(gripper, str) or gripper is None:
             cur = float(self.env.gripper_qpos[0])
             return float(
@@ -116,17 +201,35 @@ class RoboCasaPrimitives:
             )  # +a[6] closes (qpos↓)
         return self._hold_gripper_val(gripper)
 
+    def _success_latched(self):
+        value = getattr(self.env, "success_latched", None)
+        if value is not None:
+            return bool(value)
+        return bool(self.env.check_success())
+
+    def _apply_step(self, action, *, record=False):
+        """Apply at most one physical step and stop permanently on first success."""
+        if self._success_latched():
+            return False
+        if self._check_cancelled is not None:
+            self._check_cancelled()
+        self.env.step(action)
+        if record and self._recording:
+            self.record_frame()
+        return not self._success_latched()
+
     def _step_arm(self, dpos=(0, 0, 0), drot=(0, 0, 0), gripper=-1.0, n=1):
+        dpos = _finite_vector(dpos, "dpos", 3)
+        drot = _finite_vector(drot, "drot", 3)
+        gripper = _finite_scalar(gripper, "gripper")
+        n = _bounded_int(n, "n", maximum=MAX_ENV_STEPS)
         a = self._zero(base_mode=-1.0)
         a[0:3] = np.clip(np.asarray(dpos) / OSC_POS_SCALE, -1, 1)
         a[3:6] = np.clip(np.asarray(drot) / OSC_ROT_SCALE, -1, 1)
         a[6] = self._hold_gripper_val(gripper)
         for _ in range(n):
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
-            if self._recording:
-                self.record_frame()
+            if not self._apply_step(a, record=True):
+                break
         return self.env.eef_pos
 
     # ---- Phase 2: online jacobian + move_to ----
@@ -135,18 +238,29 @@ class RoboCasaPrimitives:
         world_dpos ~= J @ action_xyz. move_to inverts J to map desired world delta."""
         cols = []
         for axis in range(3):
+            if self._success_latched():
+                return None
             p0 = self.env.eef_pos.copy()
             a = self._zero()
             a[axis] = 0.4
             a[6] = gripper
+            applied = 0
             for _ in range(3):
-                if self._check_cancelled is not None:
-                    self._check_cancelled()
-                self.env.step(a)
-            d = (self.env.eef_pos - p0) / (0.4 * 3)  # world dpos per unit action
+                applied += 1
+                if not self._apply_step(a):
+                    return None
+            d = (self.env.eef_pos - p0) / (0.4 * applied)
             cols.append(d)
             # settle back is not needed (closed-loop re-reads); keep going
         self._pos_jac = np.stack(cols, axis=1)  # 3x3: world_dpos = J @ a_xyz
+        if (
+            not np.isfinite(self._pos_jac).all()
+            or np.linalg.matrix_rank(self._pos_jac) < 3
+        ):
+            self._pos_jac = None
+            raise RuntimeError(
+                "arm position Jacobian calibration is singular or non-finite"
+            )
         return self._pos_jac
 
     def move_to(self, xyz, gripper="hold", step_clip=0.02, max_steps=200, tol=0.012):
@@ -155,10 +269,38 @@ class RoboCasaPrimitives:
         object WITHOUT crushing it (a sustained +1 squeezes small objects out) or letting
         it drop. Pass +1 to actively CLOSE, -1 to actively OPEN."""
         self._vla_desync = True
-        target = np.asarray(xyz, dtype=np.float64)
+        target = _finite_vector(xyz, "xyz", 3)
+        gripper = self._validate_gripper(gripper)
+        step_clip = _finite_scalar(
+            step_clip, "step_clip", minimum=np.finfo(float).eps, maximum=0.30
+        )
+        max_steps = _bounded_int(max_steps, "max_steps", maximum=MAX_ENV_STEPS)
+        tol = _finite_scalar(tol, "tol", minimum=np.finfo(float).eps, maximum=1.0)
         target_q = float(self.env.gripper_qpos[0])  # finger width to hold
+        if self._success_latched():
+            cur = self.env.eef_pos
+            return {
+                "ok": True,
+                "status": "task_success",
+                "steps": 0,
+                "final_dist": float(np.linalg.norm(target - cur)),
+                "eef": cur.tolist(),
+                "gripper_qpos": round(float(self.env.gripper_qpos[0]), 4),
+            }
         if self._pos_jac is None:
-            self._calibrate_pos_jacobian(gripper=self._resolve_grip(gripper, target_q))
+            calibrated = self._calibrate_pos_jacobian(
+                gripper=self._resolve_grip(gripper, target_q)
+            )
+            if calibrated is None:
+                cur = self.env.eef_pos
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": 0,
+                    "final_dist": float(np.linalg.norm(target - cur)),
+                    "eef": cur.tolist(),
+                    "gripper_qpos": round(float(self.env.gripper_qpos[0]), 4),
+                }
         Jinv = np.linalg.pinv(self._pos_jac)
         for i in range(max_steps):
             cur = self.env.eef_pos
@@ -177,11 +319,16 @@ class RoboCasaPrimitives:
             a = self._zero()
             a[0:3] = a_xyz
             a[6] = self._resolve_grip(gripper, target_q)
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
-            if self._recording:
-                self.record_frame()
+            if not self._apply_step(a, record=True):
+                cur = self.env.eef_pos
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": i + 1,
+                    "final_dist": float(np.linalg.norm(target - cur)),
+                    "eef": cur.tolist(),
+                    "gripper_qpos": round(float(self.env.gripper_qpos[0]), 4),
+                }
         cur = self.env.eef_pos
         return {
             "ok": False,
@@ -193,27 +340,35 @@ class RoboCasaPrimitives:
 
     def move_delta(self, dxyz, gripper="hold", step_clip=0.02, max_steps=80):
         self._vla_desync = True
-        return self.move_to(
-            self.env.eef_pos + np.asarray(dxyz), gripper, step_clip, max_steps
-        )
+        dxyz = _finite_vector(dxyz, "dxyz", 3)
+        gripper = self._validate_gripper(gripper)
+        return self.move_to(self.env.eef_pos + dxyz, gripper, step_clip, max_steps)
 
     def rotate_pitch(self, target_pitch=0.6, gripper=1, n=12):
         """Tilt the wrist forward (axis-angle about control-x). Reuses arm drot."""
         self._vla_desync = True
-        per = float(np.clip(target_pitch, -1.5, 1.5)) / n
+        target_pitch = _finite_scalar(
+            target_pitch, "target_pitch", minimum=-1.5, maximum=1.5
+        )
+        gripper = _finite_scalar(gripper, "gripper")
+        n = _bounded_int(n, "n", maximum=MAX_ENV_STEPS)
+        per = target_pitch / n
         for _ in range(n):
             self._step_arm(drot=(per, 0, 0), gripper=gripper, n=1)
+            if self._success_latched():
+                break
         return {"ok": True, "eef": self.env.eef_pos.tolist()}
 
     def set_gripper(self, gripper=1, steps=10):
         self._vla_desync = True
+        gripper = _finite_scalar(gripper, "gripper")
+        steps = _bounded_int(steps, "steps", maximum=MAX_ENV_STEPS)
         g = self._hold_gripper_val(gripper)
         a = self._zero()
         a[6] = g
         for _ in range(steps):
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                break
         return {"ok": True, "gripper_qpos": self.env.gripper_qpos.tolist()}
 
     def release(self, steps=10):
@@ -223,7 +378,14 @@ class RoboCasaPrimitives:
     def scripted_grasp(self, xyz, approach_z=0.10, grasp_z_offset=0.0, step_clip=0.02):
         """Open -> hover above target -> descend -> close -> lift. Coarse; replace
         with RLDX closed-loop grasp for hard objects."""
-        t = np.asarray(xyz, dtype=np.float64)
+        t = _finite_vector(xyz, "xyz", 3)
+        approach_z = _finite_scalar(approach_z, "approach_z", minimum=0.0, maximum=1.0)
+        grasp_z_offset = _finite_scalar(
+            grasp_z_offset, "grasp_z_offset", minimum=-1.0, maximum=1.0
+        )
+        step_clip = _finite_scalar(
+            step_clip, "step_clip", minimum=np.finfo(float).eps, maximum=0.30
+        )
         self.set_gripper(-1.0, steps=4)
         r = self.move_to(t + [0, 0, approach_z], gripper=-1.0, step_clip=step_clip)
         if not r["ok"]:
@@ -247,14 +409,20 @@ class RoboCasaPrimitives:
     def _base_pose(self):
         o = self.env.current_raw_obs
         return (
-            np.asarray(o["robot0_base_pos"], dtype=np.float64),
-            np.asarray(o["robot0_base_quat"], dtype=np.float64),
+            _finite_vector(o["robot0_base_pos"], "robot0_base_pos", 3),
+            _finite_vector(o["robot0_base_quat"], "robot0_base_quat", 4),
         )
 
     def move_base(self, forward=0, lateral=0, turn=0, steps=10, gripper="hold"):
         """Raw base velocity command (robot-local: +fwd, +lateral, +turn yaw).
         gripper="hold" (DEFAULT) maintains the finger width while driving (carry-safe)."""
         self._vla_desync = True
+        forward = _finite_scalar(forward, "forward")
+        lateral = _finite_scalar(lateral, "lateral")
+        turn = _finite_scalar(turn, "turn")
+        steps = _bounded_int(steps, "steps", maximum=MAX_ENV_STEPS)
+        gripper = self._validate_gripper(gripper)
+        self._invalidate_geometry(base_moved=True)
         target_q = float(self.env.gripper_qpos[0])
         a = self._zero(base_mode=1.0)
         a[7:10] = [
@@ -265,9 +433,8 @@ class RoboCasaPrimitives:
         bp0, _ = self._base_pose()
         for _ in range(steps):
             a[6] = self._resolve_grip(gripper, target_q)
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                break
         bp1, _ = self._base_pose()
         return {
             "ok": True,
@@ -278,24 +445,26 @@ class RoboCasaPrimitives:
     def _yaw(self):
         from scipy.spatial.transform import Rotation as R
 
-        return float(
-            R.from_quat(
-                np.asarray(self.env.current_raw_obs["robot0_base_quat"])
-            ).as_euler("xyz")[2]
+        quat = _finite_vector(
+            self.env.current_raw_obs["robot0_base_quat"], "robot0_base_quat", 4
         )
+        if float(np.linalg.norm(quat)) <= np.finfo(float).eps:
+            raise ValueError("robot0_base_quat must be nonzero")
+        return float(R.from_quat(quat).as_euler("xyz")[2])
 
     def _calibrate_forward(self, gripper=1.0):
         """Drive forward briefly, measure the WORLD direction the base actually goes,
         so navigate_to can steer regardless of the base->world frame offset."""
+        gripper = _finite_scalar(gripper, "gripper")
+        self._invalidate_geometry(base_moved=True)
         p0, _ = self._base_pose()
         y0 = self._yaw()
         a = self._zero(base_mode=1.0)
         a[6] = self._hold_gripper_val(gripper)
         a[7] = 1.0
         for _ in range(6):
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                break
         p1, _ = self._base_pose()
         disp = (p1 - p0)[:2]
         if np.linalg.norm(disp) > 0.005:
@@ -310,17 +479,30 @@ class RoboCasaPrimitives:
         speed (closed-loop). Holds the arm (base_mode>0). Base ~2.3mm/step.
         gripper="hold" (DEFAULT) maintains the finger width while driving (carry-safe)."""
         self._vla_desync = True
-        target = np.asarray(xy[:2], dtype=np.float64)
+        target = _finite_vector(xy, "xy", 2)
+        tol = _finite_scalar(tol, "tol", minimum=np.finfo(float).eps, maximum=5.0)
+        max_steps = _bounded_int(max_steps, "max_steps", maximum=MAX_ENV_STEPS)
+        gripper = self._validate_gripper(gripper)
+        self._invalidate_geometry(base_moved=True)
         target_q = float(self.env.gripper_qpos[0])
         if self._fwd_offset is None:
             self._calibrate_forward(self._resolve_grip(gripper, target_q))
         start = self._base_pose()[0][:2].copy()
         for i in range(max_steps):
             bp, _ = self._base_pose()
+            if self._success_latched():
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": i,
+                    "final_dist": float(np.linalg.norm(target - bp[:2])),
+                    "moved": float(np.linalg.norm(bp[:2] - start)),
+                    "start_pos": start.tolist(),
+                    "base_pos": bp.tolist(),
+                }
             to = target - bp[:2]
             dist = float(np.linalg.norm(to))
             if dist < tol:
-                self._pos_jac = None  # base moved -> recalibrate arm
                 moved = float(np.linalg.norm(bp[:2] - start))
                 return {
                     "ok": True,
@@ -340,11 +522,18 @@ class RoboCasaPrimitives:
             else:  # drive forward + small steer
                 a[7] = 1.0
                 a[9] = float(np.clip(dyaw * 1.5, -0.4, 0.4))
-            if self._check_cancelled is not None:
-                self._check_cancelled()
-            self.env.step(a)
+            if not self._apply_step(a):
+                bp = self._base_pose()[0]
+                return {
+                    "ok": True,
+                    "status": "task_success",
+                    "steps": i + 1,
+                    "final_dist": float(np.linalg.norm(target - bp[:2])),
+                    "moved": float(np.linalg.norm(bp[:2] - start)),
+                    "start_pos": start.tolist(),
+                    "base_pos": bp.tolist(),
+                }
         bp, _ = self._base_pose()
-        self._pos_jac = None
         moved = float(np.linalg.norm(bp[:2] - start))
         # stuck = ran out of steps having barely moved (rammed a fixture, no path-planning)
         return {
@@ -363,6 +552,10 @@ class RoboCasaPrimitives:
         This is the success LOGIC (conditions on named objects/fixtures + thresholds) —
         it does NOT reveal GT object COORDINATES (the agent still localizes every object
         from perception). The caller writes it to the run's EnvState."""
+        if self._perception_isolation:
+            raise PermissionError(
+                "success criteria are unavailable in perception-isolated evaluation"
+            )
         return self.env.get_success_criteria_text()
 
     def task_progress(self):
@@ -379,6 +572,8 @@ class RoboCasaPrimitives:
              read-only call of _check_success.
         This is the success CRITERION's current value — NOT ground-truth object coords
         (the agent still localizes objects from perception)."""
+        if self._perception_isolation:
+            return {}
         try:
             return self.env.get_task_progress()
         except Exception:
@@ -393,21 +588,31 @@ class RoboCasaPrimitives:
         object stays free of any output-dir / file-IO concern).
         """
         o = self.env.current_raw_obs
-        return {
-            "task_language": o.get("language", self.env.get_task_language()) or "",
-            "success": self.env.check_success(),
-            # NUMERIC progress toward success (counters/sub-predicates the env's own
-            # _check_success computes) so the agent has a feedback loop, not just a bool.
-            "task_progress": self.task_progress(),
-            "robocasa_terminated": self.env.terminated,
+        if not isinstance(o, dict):
+            raise TypeError("current_raw_obs must be a dict")
+        task_language = o.get("language") or self.env.get_task_language() or ""
+        if not isinstance(task_language, str):
+            raise TypeError("task language must be a string")
+        success = self.env.check_success()
+        base_pos = _finite_vector(o["robot0_base_pos"], "robot0_base_pos", 3)
+        base_quat = _finite_vector(o["robot0_base_quat"], "robot0_base_quat", 4)
+        result = {
+            "task_language": task_language,
+            "success": success,
             "state": {
                 "robot0_eef_pos": self.env.eef_pos.tolist(),
                 "robot0_eef_quat": self.env.eef_quat.tolist(),
                 "robot0_gripper_qpos": self.env.gripper_qpos.tolist(),
-                "robot0_base_pos": np.asarray(o["robot0_base_pos"]).tolist(),
-                "robot0_base_quat": np.asarray(o["robot0_base_quat"]).tolist(),
+                "robot0_base_pos": base_pos.tolist(),
+                "robot0_base_quat": base_quat.tolist(),
             },
         }
+        if not self._perception_isolation:
+            # Exploratory runs may opt into predicate progress. Formal evaluation
+            # omits both fields entirely and never invokes the progress RPC.
+            result["task_progress"] = self.task_progress()
+            result["robocasa_terminated"] = success
+        return result
 
     # ---- VLA execution ----
     def run_rldx_skill(
@@ -423,6 +628,24 @@ class RoboCasaPrimitives:
     ):
         """Execute a VLA skill (RLDX). Resolves task_lang, computes force_reset with
         _vla_desync, clears _vla_desync."""
+        if not isinstance(prompt, str):
+            raise TypeError("prompt must be a string")
+        if use_prompt not in (None, True, False):
+            raise TypeError("use_prompt must be true, false, or null")
+        if not isinstance(force_reset, (bool, np.bool_)):
+            raise TypeError("force_reset must be a boolean")
+        if base_clip is not None:
+            base_clip = _finite_scalar(base_clip, "base_clip", minimum=0.0, maximum=1.0)
+        max_chunks = _bounded_int(max_chunks, "max_chunks", maximum=MAX_VLA_CHUNKS)
+        n_action_steps = _bounded_int(
+            n_action_steps, "n_action_steps", maximum=MAX_VLA_ACTION_STEPS
+        )
+        settle_patience = _bounded_int(
+            settle_patience, "settle_patience", maximum=MAX_VLA_CHUNKS
+        )
+        settle_eps = _finite_scalar(
+            settle_eps, "settle_eps", minimum=np.finfo(float).eps, maximum=1.0
+        )
         if use_prompt:
             task_lang = prompt
         else:
@@ -433,17 +656,73 @@ class RoboCasaPrimitives:
         # (read _vla_desync BEFORE clearing it)
         fr = bool(force_reset) or self._vla_desync
         self._vla_desync = False
-        return self._rldx.run(
-            task_lang,
-            max_chunks,
-            n_action_steps,
-            base_clip=base_clip,
-            settle_patience=settle_patience,
-            settle_eps=settle_eps,
-            force_reset=fr,
-            recording=self._recording,
-            record_frame=self.record_frame,
+        try:
+            return self._rldx.run(
+                task_lang,
+                max_chunks,
+                n_action_steps,
+                base_clip=base_clip,
+                settle_patience=settle_patience,
+                settle_eps=settle_eps,
+                force_reset=fr,
+                recording=self._recording,
+                record_frame=self.record_frame,
+            )
+        except Exception:
+            self._vla_desync = True
+            raise
+        finally:
+            self._invalidate_geometry(vla_moved=True)
+
+    def vla_act(self, prompt):
+        """Run the frozen formal VLA primitive on the benchmark instruction."""
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise TypeError("prompt must be a non-empty string")
+        observation = self.env.current_raw_obs
+        if not isinstance(observation, dict):
+            raise TypeError("current_raw_obs must be a dict")
+        task_language = (
+            observation.get("language") or self.env.get_task_language() or ""
         )
+        if not isinstance(task_language, str) or not task_language.strip():
+            raise RuntimeError("environment task language is unavailable")
+        if prompt != task_language:
+            raise ValueError("vla_act prompt must equal state.task_language verbatim")
+        try:
+            max_chunks = int(os.environ.get("RLDX_MAX_CHUNKS", "40"))
+            settle_patience = int(os.environ.get("RLDX_SETTLE_PATIENCE", "999"))
+        except ValueError as exc:
+            raise ValueError(
+                "RLDX_MAX_CHUNKS and RLDX_SETTLE_PATIENCE must be integers"
+            ) from exc
+        max_chunks = _bounded_int(max_chunks, "RLDX_MAX_CHUNKS", maximum=MAX_VLA_CHUNKS)
+        settle_patience = _bounded_int(
+            settle_patience,
+            "RLDX_SETTLE_PATIENCE",
+            maximum=MAX_VLA_CHUNKS,
+        )
+        result = self.run_rldx_skill(
+            None,
+            max_chunks,
+            True,
+            prompt,
+            False,
+            8,
+            settle_patience,
+            0.012,
+        )
+        if not self._perception_isolation:
+            return result
+        if not isinstance(result, dict):
+            raise TypeError("VLA result must be a dict")
+        return {
+            "ok": bool(result.get("ok")),
+            "status": result.get("status"),
+            "chunks": result.get("chunks"),
+            "steps_applied": result.get("steps_applied"),
+            "contact_made": bool(result.get("grasp_detected")),
+            "holding": bool(result.get("grasped")),
+        }
 
     # ---- reset ----
     def reset(self):
@@ -462,6 +741,7 @@ class RoboCasaPrimitives:
         self.env.reset()
         self._pos_jac = None
         self._fwd_offset = None
+        self._cam_meta_cache.clear()
         self._rldx.reset_session()
         return {"ok": True, "reset": True, "eef": self.env.eef_pos.tolist()}
 

--- a/robots/robocasa/prompts/__init__.py
+++ b/robots/robocasa/prompts/__init__.py
@@ -14,4 +14,32 @@
 
 """RoboCasa prompt sections."""
 
-from robots.robocasa.prompts.system import *  # noqa: F403
+from robots.robocasa.prompts.system import (
+    ENVIRONMENT,
+    GOAL,
+    GRIPPER_RULES,
+    LOCALIZATION,
+    NAVIGATION,
+    NEXT,
+    PREAMBLE,
+    PRIMITIVES,
+    RULES,
+    USER_MODE,
+    VLA_RULES,
+    WORKFLOW,
+)
+
+__all__ = [
+    "ENVIRONMENT",
+    "GOAL",
+    "GRIPPER_RULES",
+    "LOCALIZATION",
+    "NAVIGATION",
+    "NEXT",
+    "PREAMBLE",
+    "PRIMITIVES",
+    "RULES",
+    "USER_MODE",
+    "VLA_RULES",
+    "WORKFLOW",
+]

--- a/robots/robocasa/rldx_skill.py
+++ b/robots/robocasa/rldx_skill.py
@@ -24,12 +24,73 @@ with a per-call session id + reset_memory for the RLDX memory module.
 """
 
 import os
+import uuid
 from collections import deque
+from collections.abc import Mapping
 
 import imageio.v2 as imageio
 import numpy as np
 
 from robots.robocasa.env_client import RoboCasaEnvClient
+
+ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
+STATE_FIELDS = {
+    "state.gripper_qpos": ("robot0_gripper_qpos", 2),
+    "state.base_position": ("robot0_base_pos", 3),
+    "state.base_rotation": ("robot0_base_quat", 4),
+    "state.end_effector_position_relative": ("robot0_base_to_eef_pos", 3),
+    "state.end_effector_rotation_relative": ("robot0_base_to_eef_quat", 4),
+}
+MAX_VLA_CHUNKS = 1_000
+MAX_ACTION_STEPS = 512
+
+
+def _bounded_int(value, name, *, maximum):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be in [1, {maximum}], got {value}")
+    return value
+
+
+def _finite_scalar(value, name, *, minimum=None, maximum=None):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.number)
+    ):
+        raise TypeError(f"{name} must be numeric")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value}")
+    return value
+
+
+def _numeric_vector(value, name, size, *, dtype=np.float64):
+    array = np.asarray(value)
+    if array.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},), got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    array = array.astype(dtype, copy=False)
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _identity_token(value):
+    return "".join(ch for ch in str(value) if ch.isalnum())[:16] or "unknown"
 
 
 class RLDXSkill:
@@ -43,7 +104,9 @@ class RLDXSkill:
         )
         self._vdi = None  # video delta indices, e.g. [-6,-4,-2,0]
         self._hist = None  # deque of raw frame dicts
-        self._sid = "rc_agent_rldx_0"  # TODO: fix for vla, single server multi client
+        env_runtime = _identity_token(getattr(env_client, "runtime_id", "env"))
+        vla_runtime = _identity_token(getattr(vla_client, "runtime_id", "vla"))
+        self._sid = f"rc:{env_runtime}:{vla_runtime}:{uuid.uuid4().hex}"
         self._unmap = None  # lazy: eval's PandaOmronKeyConverter.unmap_action
         # OPTIONAL per-sim-step video capture. OFF by default (env RLDX_VIDEO_DIR unset):
         # the VLA rollout is closed-loop over 100s of sim-steps but the primitives only dump
@@ -51,16 +114,57 @@ class RLDXSkill:
         # When RLDX_VIDEO_DIR is set, we collect the 3 VLA camera frames (already rendered
         # for the obs — ZERO extra render cost) per step and write one mp4 per run() call.
         self._video_dir = os.environ.get("RLDX_VIDEO_DIR") or None
-        self._video_fps = int(os.environ.get("RLDX_VIDEO_FPS", "20"))
+        try:
+            video_fps = int(os.environ.get("RLDX_VIDEO_FPS", "20"))
+        except ValueError as exc:
+            raise ValueError("RLDX_VIDEO_FPS must be an integer") from exc
+        self._video_fps = _bounded_int(video_fps, "RLDX_VIDEO_FPS", maximum=240)
         self._video_idx = 0  # cmd counter for cmd_NN.mp4 naming
         self._frames = None  # list of HxWx3 uint8 for the current run() call
 
     def _load(self):
         if self._vdi is not None:
             return
+        if self._vla_client is None:
+            raise RuntimeError("RLDXSkill requires a RoboCasaVLAClient")
+        action_schema = getattr(self._vla_client, "action_schema", None)
+        if not isinstance(action_schema, Mapping):
+            raise RuntimeError(
+                "VLA client has not completed its action-schema handshake"
+            )
+        if action_schema.get("flat_dim") != self.env.action_dim:
+            raise RuntimeError(
+                f"VLA/env action dimension mismatch: VLA={action_schema.get('flat_dim')!r}, "
+                f"env={self.env.action_dim}"
+            )
+        fields = action_schema.get("fields")
+        actual_fields = {
+            item.get("name"): item.get("size")
+            for item in fields or []
+            if isinstance(item, Mapping)
+        }
+        if actual_fields != ACTION_FIELDS:
+            raise RuntimeError(
+                f"VLA action fields mismatch: expected={ACTION_FIELDS!r}, "
+                f"actual={actual_fields!r}"
+            )
         mod = self._vla_client.get_modality_config()
         self._vdi = np.asarray(mod["video_delta_indices"])
-        self._hist = deque(maxlen=mod["hist_maxlen"])
+        if (
+            self._vdi.ndim != 1
+            or self._vdi.size == 0
+            or not np.issubdtype(self._vdi.dtype, np.integer)
+            or np.any(np.diff(self._vdi) <= 0)
+            or int(self._vdi[-1]) != 0
+        ):
+            raise RuntimeError(f"invalid video_delta_indices={self._vdi!r}")
+        self._vdi = self._vdi.astype(np.int64, copy=False)
+        expected_hist = int(self._vdi.max() - self._vdi.min()) + 2
+        if mod["hist_maxlen"] != expected_hist:
+            raise RuntimeError(
+                f"hist_maxlen={mod['hist_maxlen']!r}, expected {expected_hist}"
+            )
+        self._hist = deque(maxlen=expected_hist)
         print(
             f"[rldx_skill] modality loaded via RPC; video_delta_indices={self._vdi.tolist()} "
             f"hist_maxlen={self._hist.maxlen}",
@@ -68,12 +172,15 @@ class RLDXSkill:
         )
 
     # ---- obs construction (mirror robocasa gym get_observation) ----
-    # RoboCasa365 evaluation renders the three VLA cameras at 256 instead of
-    # create_env's 128 default. Evaluation observations and primitive output
-    # are byte-identical at this resolution.
-    VLA_OBS_RES = 256
+    VLA_OBS_RES = (
+        256  # matches the eval: robocasa365 gym_wrapper get_camera_config renders
+    )
+    # the 3 VLA cameras at 256 (overriding create_env's 128 DEFAULT).
+    # Verified: eval gym obs are (256,256,3) and primitives@256 is byte-identical.
 
     def _raw_frame(self, task_text):
+        if not isinstance(task_text, str) or not task_text.strip():
+            raise ValueError("task_text must be a non-empty string")
         e = self.env
         o = e.current_raw_obs
         # render the 3 VLA cameras at the eval's resolution (256)
@@ -81,21 +188,26 @@ class RLDXSkill:
         vL = e.render_camera("robot0_agentview_left", height=r, width=r)
         vR = e.render_camera("robot0_agentview_right", height=r, width=r)
         vW = e.render_camera("robot0_eye_in_hand", height=r, width=r)
-        return {
-            "state.gripper_qpos": np.asarray(o["robot0_gripper_qpos"], np.float32),
-            "state.base_position": np.asarray(o["robot0_base_pos"], np.float32),
-            "state.base_rotation": np.asarray(o["robot0_base_quat"], np.float32),
-            "state.end_effector_position_relative": np.asarray(
-                o["robot0_base_to_eef_pos"], np.float32
-            ),
-            "state.end_effector_rotation_relative": np.asarray(
-                o["robot0_base_to_eef_quat"], np.float32
-            ),
-            "video.robot0_agentview_left": vL.astype(np.uint8),
-            "video.robot0_agentview_right": vR.astype(np.uint8),
-            "video.robot0_eye_in_hand": vW.astype(np.uint8),
-            "annotation.human.task_description": task_text,
+        frame = {
+            output_name: _numeric_vector(
+                o[input_name], input_name, size, dtype=np.float32
+            )
+            for output_name, (input_name, size) in STATE_FIELDS.items()
         }
+        for name, image in (
+            ("video.robot0_agentview_left", vL),
+            ("video.robot0_agentview_right", vR),
+            ("video.robot0_eye_in_hand", vW),
+        ):
+            image = np.asarray(image)
+            if image.shape != (r, r, 3) or image.dtype != np.uint8:
+                raise ValueError(
+                    f"{name} must be uint8 with shape {(r, r, 3)}, "
+                    f"got dtype={image.dtype}, shape={image.shape}"
+                )
+            frame[name] = image
+        frame["annotation.human.task_description"] = task_text
+        return frame
 
     def _seed_hist(self, task_text):
         """Pad the per-sim-step history with copies of the CURRENT frame, mirroring the
@@ -155,6 +267,8 @@ class RLDXSkill:
         """Build the batched (n_envs=1), history-stacked obs by indexing the per-sim-step
         history at vdi-1 = [-7,-5,-3,-1], EXACTLY like the eval MultiStepWrapper._get_obs
         (delta_indices = video_delta_indices - 1, over self.obs[i])."""
+        if self._hist is None or not self._hist:
+            raise RuntimeError("VLA observation history has not been seeded")
         buf = list(self._hist)
         idx = [len(buf) + (int(d) - 1) for d in self._vdi]  # vdi-1 offset from end
         idx = [max(0, min(len(buf) - 1, k)) for k in idx]
@@ -186,20 +300,53 @@ class RLDXSkill:
             self._unmap = PandaOmronKeyConverter.unmap_action
         ad = self._unmap(
             {
-                "action.end_effector_position": np.asarray(eef_pos, np.float64).reshape(
-                    -1
+                "action.end_effector_position": _numeric_vector(
+                    eef_pos, "action.end_effector_position", 3
                 ),
-                "action.end_effector_rotation": np.asarray(eef_rot, np.float64).reshape(
-                    -1
+                "action.end_effector_rotation": _numeric_vector(
+                    eef_rot, "action.end_effector_rotation", 3
                 ),
-                "action.gripper_close": np.asarray(gripper_close, np.float64).reshape(
-                    -1
+                "action.gripper_close": _numeric_vector(
+                    gripper_close, "action.gripper_close", 1
                 ),
-                "action.base_motion": np.asarray(base_motion, np.float64).reshape(-1),
-                "action.control_mode": np.asarray(control_mode, np.float64).reshape(-1),
+                "action.base_motion": _numeric_vector(
+                    base_motion, "action.base_motion", 4
+                ),
+                "action.control_mode": _numeric_vector(
+                    control_mode, "action.control_mode", 1
+                ),
             }
         )
         return self.env.reassemble_env_action(ad)
+
+    @staticmethod
+    def _validate_actions(actions):
+        if not isinstance(actions, Mapping):
+            raise TypeError("VLA predict must return an action mapping")
+        normalized = {}
+        horizon = None
+        for name, size in ACTION_FIELDS.items():
+            if name not in actions:
+                raise ValueError(f"VLA action output is missing {name!r}")
+            array = np.asarray(actions[name])
+            if array.ndim != 3 or array.shape[0] != 1 or array.shape[2] != size:
+                raise ValueError(
+                    f"{name} must have shape (1, horizon, {size}), got {array.shape}"
+                )
+            if not 0 < array.shape[1] <= MAX_ACTION_STEPS:
+                raise ValueError(f"{name} has invalid horizon {array.shape[1]}")
+            if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+                array.dtype, np.bool_
+            ):
+                raise TypeError(f"{name} must contain numeric values")
+            if not np.isfinite(array).all():
+                raise ValueError(f"{name} must contain only finite values")
+            if horizon is None:
+                horizon = array.shape[1]
+            elif array.shape[1] != horizon:
+                raise ValueError("VLA action fields have inconsistent horizons")
+            normalized[name] = array
+        return normalized, horizon
 
     def _grasp_contact(self):
         """Direction-AGNOSTIC grasp check: True iff BOTH gripper fingerpads are in
@@ -232,6 +379,26 @@ class RLDXSkill:
         base_clip=None -> full base motion; base_clip=v -> clamp base_motion to [-v,v]
         (whole-body policy: never zero it). Returns status + grasp signals so the LLM
         decides: continue (call again) vs done vs genuinely-failed."""
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+        max_chunks = _bounded_int(max_chunks, "max_chunks", maximum=MAX_VLA_CHUNKS)
+        n_action_steps = _bounded_int(
+            n_action_steps, "n_action_steps", maximum=MAX_ACTION_STEPS
+        )
+        settle_patience = _bounded_int(
+            settle_patience, "settle_patience", maximum=MAX_VLA_CHUNKS
+        )
+        settle_eps = _finite_scalar(
+            settle_eps, "settle_eps", minimum=np.finfo(float).eps, maximum=1.0
+        )
+        if base_clip is not None:
+            base_clip = _finite_scalar(base_clip, "base_clip", minimum=0.0, maximum=1.0)
+        if not isinstance(force_reset, (bool, np.bool_)):
+            raise TypeError("force_reset must be boolean")
+        if not isinstance(recording, (bool, np.bool_)):
+            raise TypeError("recording must be boolean")
+        if recording and not callable(record_frame):
+            raise TypeError("record_frame must be callable when recording=True")
         self._load()
         # Start a fresh video buffer for this run() call (no-op if RLDX_VIDEO_DIR unset).
         self._frames = [] if self._video_dir is not None else None
@@ -263,18 +430,23 @@ class RLDXSkill:
         applied = 0
         settled = 0
         status = "cap"
+        chunks_executed = 0
+        success_latched = bool(self.env.check_success())
+        if success_latched:
+            status = "success"
         grasp_ever = False
         grasp_obj = None
         last_cmd_close = False
-        for c in range(max_chunks):
+        for _ in range(max_chunks if not success_latched else 0):
+            chunks_executed += 1
             obs = self._build_obs(prompt)
             options = {"reset_memory": [fresh], "session_ids": [self._sid]}
             fresh = False
             if self._check_cancelled is not None:
                 self._check_cancelled()
             actions = self._vla_client.predict(obs, options)
+            actions, horizon = self._validate_actions(actions)
             # gym Dict -> native flat 12-d [eef_pos(3),eef_rot(3),gripper(1),base(4),mode(1)]
-            horizon = actions["action.gripper_close"].shape[1]
             for step in range(min(n_action_steps, horizon)):
                 base_motion = np.asarray(actions["action.base_motion"])[0, step]
                 if base_clip is not None:
@@ -308,14 +480,17 @@ class RLDXSkill:
                     prompt
                 )  # PER-SIM-STEP history (matches eval cadence)
                 self._capture_video_frame()  # OPTIONAL video (no-op if RLDX_VIDEO_DIR unset)
+                if self.env.check_success():
+                    status = "success"
+                    success_latched = True
+                    break
+            if success_latched:
+                break
             # ROBUST grasp check once per chunk (direction-agnostic; see _grasp_contact)
             g_now, g_obj = self._grasp_contact()
             if g_now:
                 grasp_ever = True
                 grasp_obj = grasp_obj or g_obj
-            if self.env.check_success():
-                status = "success"
-                break
             eef_now = np.asarray(self.env.eef_pos, np.float64)
             grip_now = float(self.env.gripper_qpos[0])
             eef_min_z = min(eef_min_z, float(eef_now[2]))
@@ -354,7 +529,7 @@ class RLDXSkill:
             "ok": True,
             "prompt": prompt,
             "status": status,
-            "chunks": c + 1,
+            "chunks": chunks_executed,
             "steps_applied": applied,
             "grasped": grasped_now,  # holding at end-of-call (carry-ready)
             "grasp_detected": grasp_detected,  # grabbed at some chunk (may have placed since)
@@ -374,10 +549,7 @@ class RLDXSkill:
 
     def reset_session(self):
         if self._vla_client is not None:
-            try:
-                self._vla_client.reset_session(self._sid)
-            except Exception:
-                pass
+            self._vla_client.reset_session(self._sid)
         self._last_prompt = None  # post-reset: next call is a fresh task
         if self._hist is not None:
             self._hist.clear()

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -23,6 +23,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from robots.robocasa.checkpoint_identity import expected_fingerprint
 from robots.robocasa.prompt_bundle import (
     system_prompt,
     user_prompt,
@@ -145,6 +146,16 @@ def _add_cli_args(parser: argparse.ArgumentParser, use_dashboard: bool) -> None:
         help="RLDX checkpoint path for locally spawned vla_server",
     )
     parser.add_argument(
+        "--vla-metadata-path",
+        default=None,
+        help="RLDX VLM metadata path used by an attested local vla_server",
+    )
+    parser.add_argument(
+        "--checkpoint-attestation",
+        default=None,
+        help="private checkpoint attestation for formal local VLA startup",
+    )
+    parser.add_argument(
         "--cuda-device",
         type=int,
         default=None,
@@ -156,13 +167,28 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
     """Validate final ``args`` and derive per-run identifiers."""
     if not args.task_name:
         raise ValueError("--task-name is required")
+    if bool(args.checkpoint_attestation) != bool(args.vla_metadata_path):
+        raise ValueError(
+            "--checkpoint-attestation and --vla-metadata-path must be provided together"
+        )
 
     recipe_tag = f"{args.task_name}_{args.split}_s{args.seed}"
+    memory_profile = getattr(args, "memory_profile", None) or "hf"
+    memory_arg = getattr(args, "memory_dir", None)
+    if memory_profile == "hf" and memory_arg is not None:
+        raise ValueError("--memory-dir requires --memory-profile local")
+    memory_dir = (
+        Path(memory_arg).expanduser().resolve()
+        if memory_arg
+        else get_memory_dir("robocasa")
+    )
     prompt_vars = {
         "task_name": args.task_name,
         "split": args.split,
         "seed": args.seed,
         "recipe_tag": recipe_tag,
+        "memory_profile": memory_profile,
+        "memory_dir": str(memory_dir),
     }
 
     output_dir = args.output_dir
@@ -259,11 +285,27 @@ def _spawn_vla_server(
                 str(port),
                 "--parent-watch",
                 *(
+                    [
+                        "--vlm-path",
+                        args.vla_metadata_path,
+                        "--checkpoint-attestation",
+                        args.checkpoint_attestation,
+                    ]
+                    if args.checkpoint_attestation is not None
+                    and args.vla_metadata_path is not None
+                    else []
+                ),
+                *(
                     ["--cuda-device", str(args.cuda_device)]
                     if args.cuda_device is not None
                     else []
                 ),
             ],
+            env_overrides=(
+                {"RLDX_VLM_PATH": args.vla_metadata_path}
+                if args.vla_metadata_path is not None
+                else None
+            ),
             log_path=str(Path(output_dir) / "vla_server.log"),
         )
         daemon.start()
@@ -304,7 +346,17 @@ def _init_runtime(
             "workdir": str(output_dir),
             "hi_res": args.hi_res or None,
         },
-        "vla": lambda rpc: {"vla_client": RoboCasaVLAClient(rpc)},
+        "vla": lambda rpc: {
+            "vla_client": RoboCasaVLAClient(
+                rpc,
+                expected_model_fingerprint=(
+                    expected_fingerprint()
+                    if args.checkpoint_attestation is not None
+                    else None
+                ),
+                require_verified_model=args.checkpoint_attestation is not None,
+            )
+        },
     }
     timeouts = {"env": 120.0, "vla": 300.0}
     selected = set(starters) if components is None else components

--- a/robots/robocasa/toolkit.py
+++ b/robots/robocasa/toolkit.py
@@ -34,6 +34,19 @@ if TYPE_CHECKING:
 
 logger = get_logger("robocasa_toolkit")
 
+FORMAL_PRIMITIVE_TOOLS = frozenset(
+    {
+        "navigate_to",
+        "move_base",
+        "move_to",
+        "move_delta",
+        "rotate_pitch",
+        "set_gripper",
+        "release",
+        "vla_act",
+    }
+)
+
 
 class RoboCasaToolkit(Toolkit):
     """Toolkit for the RoboCasa robot."""
@@ -78,6 +91,13 @@ class RoboCasaToolkit(Toolkit):
         }
         for spec in robocasa_tools.TOOLS_SPEC:
             name = spec["name"]
+            if (
+                self._primitives._perception_isolation
+                and name not in FORMAL_PRIMITIVE_TOOLS
+                and name not in state_handlers
+                and name != "finish"
+            ):
+                continue
             if name in state_handlers:
                 handler = state_handlers[name]
             elif name == "finish":
@@ -139,18 +159,18 @@ class RoboCasaToolkit(Toolkit):
             check_cancelled=self.raise_if_cancelled,
             **primitives_kwargs,
         )
-        primitives.reset()
         primitives.start_recording()
         self._action_frame_cursor = primitives.recorded_frame_count()
         record = robocasa_tools.dump_state(primitives, self._state, log=None)
-        try:
-            self._state.save(
-                "success_criteria.md",
-                primitives.dump_success_criteria(),
-                step=None,
-            )
-        except Exception as e:
-            logger.warning("failed to save success_criteria.md: %s", e)
+        if not primitives._perception_isolation:
+            try:
+                self._state.save(
+                    "success_criteria.md",
+                    primitives.dump_success_criteria(),
+                    step=None,
+                )
+            except Exception as e:
+                logger.warning("failed to save success_criteria.md: %s", e)
         self._primitives = primitives
         self._publish_step(record)
 

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -33,7 +33,7 @@ from rpent.tools.toolkit import readonly
 if TYPE_CHECKING:
     from robots.robocasa.primitives import RoboCasaPrimitives
 
-# ---- TOOLS_SPEC: 17 Anthropic-shaped tool schemas ----
+# ---- Anthropic-shaped tool schemas ----
 
 TOOLS_SPEC = [
     # ---- primitive tools (11): dispatched by the toolkit base to primitives.<name> ----
@@ -180,6 +180,26 @@ TOOLS_SPEC = [
                     "description": "Number of env steps (default 10)",
                 },
             },
+        },
+    },
+    {
+        "name": "vla_act",
+        "description": (
+            "Run the unified VLA primitive using the current benchmark task "
+            "instruction. The prompt must equal state.task_language verbatim. "
+            "Its chunk budget, action horizon, base control, stopping rule, and "
+            "history reset semantics are fixed by the evaluation harness."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "The current state.task_language verbatim",
+                },
+            },
+            "required": ["prompt"],
+            "additionalProperties": False,
         },
     },
     {
@@ -454,7 +474,7 @@ TOOLS_SPEC = [
             "properties": {
                 "camera": {
                     "type": "string",
-                    "enum": ["agentview", "navview"],
+                    "enum": ["agentview", "navview", "wrist"],
                     "description": "Camera metadata to read (default agentview).",
                 },
                 "step": {
@@ -667,6 +687,74 @@ _CAMERA_WORLD_ARTIFACTS = {
     "wrist": ("wrist_world.npz", None),
 }
 
+_CAMERA_METADATA_ARTIFACTS = {
+    "agentview": "agentview_metadata.json",
+    "navview": "navview_metadata.json",
+    "wrist": "wrist_metadata.json",
+}
+
+MAX_BACK_PROJECT_PIXELS = 50
+
+
+def _resolve_step(state: EnvState, step: int | None):
+    if step is not None and (
+        isinstance(step, (bool, np.bool_))
+        or not isinstance(step, (int, np.integer))
+        or int(step) < 0
+    ):
+        raise ValueError("step must be null or a nonnegative integer")
+    return state.get(-1 if step is None else int(step))
+
+
+def _camera_and_resolution(camera, resolution):
+    if not isinstance(camera, str) or camera not in _CAMERA_WORLD_ARTIFACTS:
+        raise ValueError("camera must be one of: agentview, navview, wrist")
+    if resolution not in {"low", "high"}:
+        raise ValueError("resolution must be 'low' or 'high'")
+    low_name, hi_name = _CAMERA_WORLD_ARTIFACTS[camera]
+    artifact = hi_name if resolution == "high" else low_name
+    if artifact is None:
+        raise ValueError(f"{camera} has no {resolution}-resolution world map")
+    return artifact
+
+
+def _world_map_for(state, record, artifact):
+    if artifact not in record.artifacts:
+        raise FileNotFoundError(
+            f"{artifact} was not recorded for step {record.step_idx}"
+        )
+    world_map = np.asarray(state.load(artifact, step=record.step_idx))
+    if world_map.ndim != 3 or world_map.shape[2] < 3:
+        raise ValueError(
+            f"{artifact} must have shape (height, width, >=3), got {world_map.shape}"
+        )
+    if not np.issubdtype(world_map.dtype, np.number):
+        raise TypeError(f"{artifact} must contain numeric values")
+    return world_map
+
+
+def _finite_tool_number(value, name):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.number)
+    ):
+        raise TypeError(f"{name} must be numeric")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _ordered_range(value, name):
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"{name} must be null or [min, max]")
+    lower = _finite_tool_number(value[0], f"{name}[0]")
+    upper = _finite_tool_number(value[1], f"{name}[1]")
+    if lower > upper:
+        raise ValueError(f"{name} minimum must not exceed maximum")
+    return lower, upper
+
 
 def dump_state(
     primitives: RoboCasaPrimitives,
@@ -682,19 +770,21 @@ def dump_state(
     """
     state_dict = primitives.current_state_dict()
     log = log or {}
+    extras = {
+        "task_language": state_dict["task_language"],
+        "success": state_dict["success"],
+        "vla_desync": primitives._vla_desync,
+    }
+    if "task_progress" in state_dict:
+        extras["task_progress"] = state_dict["task_progress"]
     with env_state.record_step(
         state=state_dict["state"],
-        terminated=state_dict["robocasa_terminated"],
+        terminated=state_dict.get("robocasa_terminated", state_dict["success"]),
         truncated=False,
         command=log.get("command"),
         result=log.get("result"),
         elapsed_s=log.get("elapsed_s"),
-        extras={
-            "task_language": state_dict["task_language"],
-            "success": state_dict["success"],
-            "task_progress": state_dict["task_progress"],
-            "vla_desync": primitives._vla_desync,
-        },
+        extras=extras,
     ) as step_idx:
         _save_observation_artifacts(primitives, env_state, step_idx)
         _prune_heavy_artifacts(primitives, env_state, step_idx)
@@ -749,8 +839,15 @@ def _save_observation_artifacts(
     try:
         nrgb, _ = env.render_camera("navview", depth=True)
         nworld = env.world_map("navview").astype(np.float32)
+        if "navview" not in primitives._cam_meta_cache:
+            primitives._cam_meta_cache["navview"] = env.get_camera_meta("navview")
         env_state.save("navview.png", nrgb, step=step_idx)
         env_state.save("navview_world.npz", nworld, step=step_idx)
+        env_state.save(
+            "navview_metadata.json",
+            primitives._cam_meta_cache["navview"],
+            step=step_idx,
+        )
         floor = (nworld[:, :, 2] < 0.12) & (nworld[:, :, 2] > -0.2)
         overlay = nrgb.copy()
         overlay[floor] = [0, 255, 0]
@@ -790,7 +887,6 @@ def view_env_state(step: int | None = None, *, state: EnvState) -> dict:
     extras = record.extras
     out: dict = {
         "step": nn,
-        "task_progress": extras.get("task_progress", {}),
         "task_language": extras.get("task_language", ""),
         "state": record.state,
         "robocasa_terminated": record.terminated,
@@ -803,6 +899,8 @@ def view_env_state(step: int | None = None, *, state: EnvState) -> dict:
         },
         "images": [],
     }
+    if "task_progress" in extras:
+        out["task_progress"] = extras["task_progress"]
 
     for kind, candidates in (
         ("_image_cam_bytes", _CAMERA_IMAGE_ARTIFACTS["agentview"]),
@@ -840,8 +938,52 @@ def view_camera_meta(
     *,
     state: EnvState,
 ) -> dict:
-    """Read camera calibration metadata. Skeleton — returns error."""
-    return {"error": "not implemented"}
+    """Read and validate the calibration captured with one recorded frame."""
+    if not isinstance(camera, str) or camera not in _CAMERA_METADATA_ARTIFACTS:
+        return {"error": "camera must be one of: agentview, navview, wrist"}
+    try:
+        record = _resolve_step(state, step)
+    except Exception as exc:
+        return {"error": f"state step not available: {exc}"}
+    artifact = _CAMERA_METADATA_ARTIFACTS[camera]
+    if artifact not in record.artifacts:
+        return {"error": f"{artifact} not recorded for step {record.step_idx}"}
+    try:
+        meta = state.load(artifact, step=record.step_idx)
+    except Exception as exc:
+        return {"error": f"{artifact} not found for step {record.step_idx}: {exc}"}
+    if not isinstance(meta, dict):
+        return {"error": f"{artifact} must contain a JSON object"}
+    try:
+        intrinsic = np.asarray(meta["intrinsic"], dtype=np.float64)
+        extrinsic = np.asarray(meta["extrinsic_cam2world"], dtype=np.float64)
+        if intrinsic.shape != (3, 3) or not np.isfinite(intrinsic).all():
+            raise ValueError("intrinsic must be a finite 3x3 matrix")
+        if extrinsic.shape != (4, 4) or not np.isfinite(extrinsic).all():
+            raise ValueError("extrinsic_cam2world must be a finite 4x4 matrix")
+        height = meta["height"]
+        width = meta["width"]
+        if (
+            isinstance(height, bool)
+            or not isinstance(height, int)
+            or height <= 0
+            or isinstance(width, bool)
+            or not isinstance(width, int)
+            or width <= 0
+        ):
+            raise ValueError("height and width must be positive integers")
+        near = float(meta["depth_near"])
+        far = float(meta["depth_far"])
+        if not np.isfinite([near, far]).all() or not 0 < near < far:
+            raise ValueError("depth_near/depth_far must be finite and ordered")
+    except (KeyError, TypeError, ValueError) as exc:
+        return {"error": f"invalid {artifact}: {exc}"}
+    return {
+        **meta,
+        "step": record.step_idx,
+        "camera": camera,
+        "artifact": artifact,
+    }
 
 
 @readonly
@@ -854,8 +996,26 @@ def back_project(
     *,
     state: EnvState,
 ) -> dict:
-    """Back-project a single pixel to world XYZ. Skeleton — returns error."""
-    return {"error": "not implemented"}
+    """Back-project one pixel using the world map captured at the same step."""
+    batch = back_project_batch(
+        [[row, col]],
+        step=step,
+        camera=camera,
+        resolution=resolution,
+        state=state,
+    )
+    if "error" in batch:
+        return batch
+    result = dict(batch["results"][0])
+    result.update(
+        {
+            "step": batch["step"],
+            "camera": batch["camera"],
+            "resolution": batch["resolution"],
+            "source_artifact": batch["source_artifact"],
+        }
+    )
+    return result
 
 
 @readonly
@@ -872,29 +1032,24 @@ def back_project_batch(
     Loads the precomputed world map once and queries all *pixels*, returning
     each result individually plus a summary with the median of valid points.
     """
-    camera = camera or "agentview"
-    resolution = resolution or "low"
-    if camera not in _CAMERA_WORLD_ARTIFACTS:
-        return {"error": f"bad camera '{camera}' (use agentview, navview, or wrist)"}
-    low_name, hi_name = _CAMERA_WORLD_ARTIFACTS[camera]
-    source_artifact = hi_name if resolution == "high" else low_name
-    if source_artifact is None:
-        return {"error": f"{camera} has no {resolution}-resolution world map"}
+    if not isinstance(pixels, (list, tuple)):
+        return {"error": "pixels must be a list of [row, col] pairs"}
+    if not 1 <= len(pixels) <= MAX_BACK_PROJECT_PIXELS:
+        return {"error": f"pixels must contain 1-{MAX_BACK_PROJECT_PIXELS} entries"}
+    try:
+        source_artifact = _camera_and_resolution(camera, resolution)
+    except (TypeError, ValueError) as exc:
+        return {"error": str(exc)}
 
     try:
-        record = state.get(step if step is not None else -1)
+        record = _resolve_step(state, step)
     except Exception as exc:
         return {"error": f"state step not available: {exc}"}
     nn = record.step_idx
-    if source_artifact not in record.artifacts:
-        return {
-            "error": f"{camera} {resolution}-resolution world map not recorded for step {nn}"
-        }
-
     try:
-        world_map = state.load(source_artifact, step=nn)
+        world_map = _world_map_for(state, record, source_artifact)
     except Exception as exc:
-        return {"error": f"{source_artifact} not found for step {nn}: {exc}"}
+        return {"error": str(exc)}
 
     results = []
     valid_xyzs = []
@@ -906,6 +1061,20 @@ def back_project_batch(
                     "world_xyz": None,
                     "valid": False,
                     "error": "pixel must be [row, col]",
+                }
+            )
+            continue
+        if any(
+            isinstance(value, (bool, np.bool_))
+            or not isinstance(value, (int, np.integer))
+            for value in pixel
+        ):
+            results.append(
+                {
+                    "pixel": pixel,
+                    "world_xyz": None,
+                    "valid": False,
+                    "error": "row and col must be integers",
                 }
             )
             continue
@@ -922,7 +1091,7 @@ def back_project_batch(
             )
             continue
         xyz = world_map[row, col, :3]
-        if not np.isfinite(xyz).all() or abs(float(xyz.sum())) <= 1e-6:
+        if not np.isfinite(xyz).all() or float(np.linalg.norm(xyz)) <= 1e-6:
             results.append(
                 {
                     "pixel": pixel,
@@ -964,6 +1133,8 @@ def back_project_batch(
         "step": nn,
         "camera": camera,
         "resolution": resolution,
+        "source_artifact": source_artifact,
+        "world_map_shape": list(world_map.shape),
     }
 
 
@@ -980,35 +1151,39 @@ def query_world_map(
     state: EnvState,
 ) -> dict:
     """Query the world map by z-range and/or region to find objects."""
-    if camera not in _CAMERA_WORLD_ARTIFACTS:
-        return {"error": f"bad camera '{camera}' (use agentview, navview, or wrist)"}
-    low_name, hi_name = _CAMERA_WORLD_ARTIFACTS[camera]
-    source_artifact = hi_name if resolution == "high" else low_name
-    if source_artifact is None:
-        return {"error": f"{camera} has no {resolution}-resolution world map"}
+    try:
+        source_artifact = _camera_and_resolution(camera, resolution)
+        z_min = _finite_tool_number(z_min, "z_min")
+        z_max = _finite_tool_number(z_max, "z_max")
+        if z_min > z_max:
+            raise ValueError("z_min must not exceed z_max")
+        x_range = _ordered_range(x_range, "x_range")
+        y_range = _ordered_range(y_range, "y_range")
+        if (
+            isinstance(min_cluster_size, (bool, np.bool_))
+            or not isinstance(min_cluster_size, (int, np.integer))
+            or not 1 <= int(min_cluster_size) <= 10_000
+        ):
+            raise ValueError("min_cluster_size must be an integer in [1, 10000]")
+        min_cluster_size = int(min_cluster_size)
+    except (TypeError, ValueError) as exc:
+        return {"error": str(exc)}
 
     try:
         record = state.get(-1)
     except Exception:
         return {"error": "no state trace available"}
-    nn = record.step_idx
-    if source_artifact not in record.artifacts:
-        return {
-            "error": f"{camera} {resolution}-resolution world map not found for step {nn}"
-        }
     try:
-        world_map = state.load(source_artifact, step=nn)
-    except Exception:
-        return {
-            "error": f"{camera} {resolution}-resolution world map not found for step {nn}"
-        }
+        world_map = _world_map_for(state, record, source_artifact)
+    except Exception as exc:
+        return {"error": str(exc)}
 
     z = world_map[:, :, 2]
     mask = (z >= z_min) & (z <= z_max) & np.isfinite(z)
-    if x_range:
+    if x_range is not None:
         x = world_map[:, :, 0]
         mask &= (x >= x_range[0]) & (x <= x_range[1])
-    if y_range:
+    if y_range is not None:
         y = world_map[:, :, 1]
         mask &= (y >= y_range[0]) & (y <= y_range[1])
 
@@ -1092,6 +1267,7 @@ _PRIMITIVE_ACTIONS = frozenset(
         "rotate_pitch",
         "set_gripper",
         "release",
+        "vla_act",
         "scripted_grasp",
         "rldx_skill",
         "rldx_arm",

--- a/robots/robocasa/vla_client.py
+++ b/robots/robocasa/vla_client.py
@@ -16,35 +16,182 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
+import numpy as np
+
 from rpent.robots.components.vla_client_base import BaseVLAClient
+
+VLA_PROTOCOL_VERSION = 1
+EXPECTED_ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
 
 
 class RoboCasaVLAClient(BaseVLAClient):
     _TIMEOUT_S = BaseVLAClient._TIMEOUT_S
 
-    def __init__(self, client):
+    def __init__(
+        self,
+        client,
+        *,
+        expected_model_fingerprint: str | None = None,
+        require_verified_model: bool = False,
+    ):
         super().__init__(client)
+        self.runtime_info = self.get_runtime_info()
+        self._validate_runtime_info(
+            self.runtime_info,
+            expected_model_fingerprint=expected_model_fingerprint,
+            require_verified_model=require_verified_model,
+        )
+        self.runtime_id = self.runtime_info["runtime_id"]
+        self.action_schema = self.runtime_info["action_schema"]
+        self.model_identity = self.runtime_info["model"]
+
+    def get_runtime_info(self) -> dict:
+        return self._client.call(
+            "vla.get_runtime_info", timeout_s=self._TIMEOUT_S["default"]
+        )
+
+    @staticmethod
+    def _validate_runtime_info(
+        info,
+        *,
+        expected_model_fingerprint=None,
+        require_verified_model=False,
+    ):
+        if not isinstance(info, Mapping):
+            raise TypeError("VLA runtime handshake must return a mapping")
+        if info.get("protocol_version") != VLA_PROTOCOL_VERSION:
+            raise RuntimeError(
+                f"unsupported VLA protocol_version={info.get('protocol_version')!r}; "
+                f"expected {VLA_PROTOCOL_VERSION}"
+            )
+        if not isinstance(info.get("runtime_id"), str) or not info["runtime_id"]:
+            raise RuntimeError("VLA runtime handshake is missing runtime_id")
+        if info.get("backend") != "rldx":
+            raise RuntimeError(f"unsupported VLA backend {info.get('backend')!r}")
+        if info.get("warmed_up") is not True:
+            raise RuntimeError("VLA server has not completed model warmup")
+        model = info.get("model")
+        if not isinstance(model, Mapping) or not isinstance(
+            model.get("fingerprint"), str
+        ):
+            raise RuntimeError("VLA runtime handshake is missing model identity")
+        if require_verified_model and model.get("verified") is not True:
+            raise RuntimeError("VLA runtime handshake has no verified model identity")
+        if (
+            expected_model_fingerprint is not None
+            and model.get("fingerprint") != expected_model_fingerprint
+        ):
+            raise RuntimeError("VLA runtime model fingerprint mismatch")
+        schema = info.get("action_schema")
+        if not isinstance(schema, Mapping):
+            raise RuntimeError("VLA runtime handshake is missing action_schema")
+        if schema.get("batch_size") != 1 or schema.get("flat_dim") != sum(
+            EXPECTED_ACTION_FIELDS.values()
+        ):
+            raise RuntimeError(f"incompatible VLA action schema: {schema!r}")
+        fields = schema.get("fields")
+        if not isinstance(fields, list):
+            raise RuntimeError("VLA action schema fields must be a list")
+        actual_fields = {
+            field.get("name"): field.get("size")
+            for field in fields
+            if isinstance(field, Mapping)
+        }
+        if actual_fields != EXPECTED_ACTION_FIELDS:
+            raise RuntimeError(
+                f"incompatible VLA action fields: expected={EXPECTED_ACTION_FIELDS!r}, "
+                f"actual={actual_fields!r}"
+            )
+        horizon = schema.get("max_horizon")
+        if isinstance(horizon, bool) or not isinstance(horizon, int) or horizon <= 0:
+            raise RuntimeError(f"invalid VLA max_horizon={horizon!r}")
 
     def get_modality_config(self) -> dict:
-        return self._client.call(
-            "vla.get_modality_config",
-            timeout_s=self._TIMEOUT_S["default"],
+        config = self._client.call(
+            "vla.get_modality_config", timeout_s=self._TIMEOUT_S["default"]
         )
+        if not isinstance(config, Mapping):
+            raise TypeError("VLA modality config must be a mapping")
+        indices = np.asarray(config.get("video_delta_indices"))
+        hist_maxlen = config.get("hist_maxlen")
+        if (
+            indices.ndim != 1
+            or indices.size == 0
+            or not np.issubdtype(indices.dtype, np.integer)
+            or np.any(np.diff(indices) <= 0)
+            or int(indices[-1]) != 0
+        ):
+            raise RuntimeError(f"invalid VLA video_delta_indices={indices!r}")
+        expected_hist = int(indices.max() - indices.min()) + 2
+        if (
+            isinstance(hist_maxlen, bool)
+            or not isinstance(hist_maxlen, int)
+            or hist_maxlen != expected_hist
+        ):
+            raise RuntimeError(
+                f"invalid VLA hist_maxlen={hist_maxlen!r}; expected {expected_hist}"
+            )
+        return dict(config)
 
     def predict(self, obs_dict: dict, options: dict) -> dict:
         """Run inference; returns raw actions dict.
 
         Actions are numpy arrays.
         """
-        return self._client.call(
+        actions = self._client.call(
             "vla.predict",
             args=(obs_dict, options),
             timeout_s=self._TIMEOUT_S["predict"],
         )
+        if not isinstance(actions, Mapping):
+            raise TypeError("VLA predict response must be an action mapping")
+        normalized = dict(actions)
+        horizon = None
+        max_horizon = int(self.action_schema["max_horizon"])
+        for name, size in EXPECTED_ACTION_FIELDS.items():
+            if name not in actions:
+                raise RuntimeError(f"VLA predict response is missing {name!r}")
+            array = np.asarray(actions[name])
+            if array.ndim != 3 or array.shape[0] != 1 or array.shape[2] != size:
+                raise ValueError(
+                    f"{name} must have shape (1, horizon, {size}), got {array.shape}"
+                )
+            if not 0 < array.shape[1] <= max_horizon:
+                raise ValueError(f"{name} has invalid horizon {array.shape[1]}")
+            if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+                array.dtype, np.bool_
+            ):
+                raise TypeError(f"{name} must contain numeric values")
+            if not np.isfinite(array).all():
+                raise ValueError(f"{name} must contain only finite values")
+            if horizon is None:
+                horizon = array.shape[1]
+            elif array.shape[1] != horizon:
+                raise ValueError("VLA action fields have inconsistent horizons")
+            normalized[name] = array
+        return normalized
 
     def reset_session(self, session_id: str) -> dict:
-        return self._client.call(
+        if not isinstance(session_id, str) or not session_id:
+            raise TypeError("session_id must be a non-empty string")
+        result = self._client.call(
             "vla.reset_session",
             args=(session_id,),
             timeout_s=self._TIMEOUT_S["default"],
         )
+        if (
+            not isinstance(result, Mapping)
+            or result.get("ok") is not True
+            or result.get("runtime_id") != self.runtime_id
+            or result.get("session_id") != session_id
+        ):
+            raise RuntimeError(f"invalid VLA reset_session response: {result!r}")
+        return dict(result)

--- a/robots/robocasa/vla_server.py
+++ b/robots/robocasa/vla_server.py
@@ -15,7 +15,13 @@
 """RoboCasa VLA server — loads RLDX model and exposes inference calls via RPC."""
 
 import argparse
+import hashlib
+import json
 import os
+import re
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
 
 import numpy as np
 
@@ -24,12 +30,115 @@ from rpent.utils.logging import get_logger
 
 logger = get_logger("vla_server")
 
+VLA_PROTOCOL_VERSION = 1
+MAX_ACTION_HORIZON = 512
+MAX_SESSION_ID_LENGTH = 192
+ACTION_FIELDS = {
+    "action.end_effector_position": 3,
+    "action.end_effector_rotation": 3,
+    "action.gripper_close": 1,
+    "action.base_motion": 4,
+    "action.control_mode": 1,
+}
+STATE_FIELDS = {
+    "state.gripper_qpos": 2,
+    "state.base_position": 3,
+    "state.base_rotation": 4,
+    "state.end_effector_position_relative": 3,
+    "state.end_effector_rotation_relative": 4,
+}
+VIDEO_FIELDS = (
+    "video.robot0_agentview_left",
+    "video.robot0_agentview_right",
+    "video.robot0_eye_in_hand",
+)
+ANNOTATION_FIELD = "annotation.human.task_description"
+_SESSION_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _model_identity(model_path):
+    if not isinstance(model_path, (str, os.PathLike)) or not str(model_path).strip():
+        raise TypeError("model_path must be a non-empty path or model id")
+    requested = str(model_path)
+    path = Path(requested).expanduser()
+    if not path.exists():
+        return {
+            "kind": "remote",
+            "requested": requested,
+            "fingerprint": f"remote:{requested}",
+        }
+    if not path.is_dir():
+        raise ValueError(f"model_path must be a checkpoint directory, got {path}")
+    path = path.resolve()
+    config_path = path / "config.json"
+    index_path = path / "model.safetensors.index.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"checkpoint config is missing: {config_path}")
+    files = {"config.json": _sha256_file(config_path)}
+    total_size = None
+    if index_path.is_file():
+        files[index_path.name] = _sha256_file(index_path)
+        try:
+            with open(index_path, encoding="utf-8") as stream:
+                index = json.load(stream)
+            total_size = index.get("metadata", {}).get("total_size")
+        except (OSError, TypeError, ValueError):
+            total_size = None
+    digest = hashlib.sha256()
+    for name, value in sorted(files.items()):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(value.encode("ascii"))
+        digest.update(b"\0")
+    return {
+        "kind": "local",
+        "requested": requested,
+        "resolved_path": str(path),
+        "fingerprint": digest.hexdigest(),
+        "files": files,
+        "total_size": total_size,
+    }
+
+
+def _session_id(value):
+    if not isinstance(value, str) or not value:
+        raise TypeError("session_id must be a non-empty string")
+    if len(value) > MAX_SESSION_ID_LENGTH or _SESSION_RE.fullmatch(value) is None:
+        raise ValueError(
+            "session_id must be at most 192 characters and contain only "
+            "letters, digits, '_', '-', '.', or ':'"
+        )
+    return value
+
+
+def _numeric_array(value, name, *, shape):
+    array = np.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise TypeError(f"{name} must contain numeric values")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
 
 class RoboCasaVLAFacade(BaseVLAFacade):
     """Loads RLDX model and exposes inference-only RPC methods."""
 
     def __init__(self, model_path):
         super().__init__()
+        self._runtime_id = uuid.uuid4().hex
+        self._model_identity = _model_identity(model_path)
         from rldx.data.embodiment_tags import EmbodimentTag
         from rldx.eval.rollout_policy import create_rldx_sim_policy
 
@@ -39,9 +148,23 @@ class RoboCasaVLAFacade(BaseVLAFacade):
             "",
             None,
         )
+        loaded_identity = _model_identity(model_path)
+        if loaded_identity != self._model_identity:
+            raise RuntimeError("checkpoint identity changed while loading the VLA")
         mod = self.policy.get_modality_config()
         self._vdi = np.asarray(mod["video"].delta_indices)
+        if (
+            self._vdi.ndim != 1
+            or self._vdi.size == 0
+            or not np.issubdtype(self._vdi.dtype, np.integer)
+            or np.any(np.diff(self._vdi) <= 0)
+            or int(self._vdi[-1]) != 0
+        ):
+            raise RuntimeError(f"invalid model video delta indices: {self._vdi!r}")
+        self._vdi = self._vdi.astype(np.int64, copy=False)
         self._hist_maxlen = int(self._vdi.max() - self._vdi.min()) + 2
+        self._warmed_up = False
+        self._warmup()
         print(
             f"[vla_server] policy loaded; video_delta_indices={self._vdi.tolist()} "
             f"hist_maxlen={self._hist_maxlen}",
@@ -53,7 +176,42 @@ class RoboCasaVLAFacade(BaseVLAFacade):
         self._rpc["vla.get_modality_config"] = self.get_modality_config
         self._rpc["vla.predict"] = self.predict
         self._rpc["vla.reset_session"] = self.reset_session
-        self._readonly_methods.add("vla.get_modality_config")
+        self._rpc["vla.get_runtime_info"] = self.get_runtime_info
+        self._readonly_methods.update(
+            {
+                "vla.get_modality_config",
+                "vla.get_runtime_info",
+            }
+        )
+
+    def get_runtime_info(self):
+        return {
+            "protocol_version": VLA_PROTOCOL_VERSION,
+            "runtime_id": self._runtime_id,
+            "backend": "rldx",
+            "model": self._model_identity,
+            "warmed_up": self._warmed_up,
+            "action_schema": {
+                "name": "rldx.robocasa.action.v1",
+                "batch_size": 1,
+                "max_horizon": MAX_ACTION_HORIZON,
+                "flat_dim": sum(ACTION_FIELDS.values()),
+                "fields": [
+                    {"name": name, "size": size} for name, size in ACTION_FIELDS.items()
+                ],
+            },
+            "observation_schema": {
+                "name": "rldx.robocasa.observation.v1",
+                "batch_size": 1,
+                "video_frames": int(self._vdi.size),
+                "video_height": 256,
+                "video_width": 256,
+                "state_fields": dict(STATE_FIELDS),
+                "video_fields": list(VIDEO_FIELDS),
+                "annotation_field": ANNOTATION_FIELD,
+            },
+            "modality": self.get_modality_config(),
+        }
 
     def get_modality_config(self):
         return {
@@ -61,18 +219,119 @@ class RoboCasaVLAFacade(BaseVLAFacade):
             "hist_maxlen": self._hist_maxlen,
         }
 
+    def _validate_observation(self, obs_dict):
+        if not isinstance(obs_dict, Mapping):
+            raise TypeError("obs_dict must be a mapping")
+        for name, size in STATE_FIELDS.items():
+            if name not in obs_dict:
+                raise ValueError(f"obs_dict is missing {name!r}")
+            _numeric_array(obs_dict[name], name, shape=(1, 1, size))
+        video_shape = (1, int(self._vdi.size), 256, 256, 3)
+        for name in VIDEO_FIELDS:
+            if name not in obs_dict:
+                raise ValueError(f"obs_dict is missing {name!r}")
+            video = np.asarray(obs_dict[name])
+            if video.shape != video_shape or video.dtype != np.uint8:
+                raise ValueError(
+                    f"{name} must be uint8 with shape {video_shape}, "
+                    f"got dtype={video.dtype}, shape={video.shape}"
+                )
+        annotation = obs_dict.get(ANNOTATION_FIELD)
+        if (
+            not isinstance(annotation, (list, tuple))
+            or len(annotation) != 1
+            or not isinstance(annotation[0], str)
+            or not annotation[0].strip()
+        ):
+            raise ValueError(f"{ANNOTATION_FIELD} must contain one non-empty string")
+
+    @staticmethod
+    def _validate_options(options):
+        if not isinstance(options, Mapping):
+            raise TypeError("options must be a mapping")
+        unknown = set(options).difference({"session_ids", "reset_memory"})
+        if unknown:
+            raise ValueError(f"unsupported VLA options: {sorted(unknown)}")
+        sessions = options.get("session_ids")
+        resets = options.get("reset_memory")
+        if not isinstance(sessions, (list, tuple)) or len(sessions) != 1:
+            raise ValueError("options.session_ids must contain exactly one session id")
+        if not isinstance(resets, (list, tuple)) or len(resets) != 1:
+            raise ValueError("options.reset_memory must contain exactly one boolean")
+        _session_id(sessions[0])
+        if not isinstance(resets[0], (bool, np.bool_)):
+            raise TypeError("options.reset_memory[0] must be boolean")
+
+    @staticmethod
+    def _validate_actions(actions):
+        if not isinstance(actions, Mapping):
+            raise TypeError("RLDX policy must return an action mapping")
+        normalized = dict(actions)
+        horizon = None
+        for name, size in ACTION_FIELDS.items():
+            if name not in actions:
+                raise ValueError(f"RLDX action output is missing {name!r}")
+            array = np.asarray(actions[name])
+            if array.ndim != 3 or array.shape[0] != 1 or array.shape[2] != size:
+                raise ValueError(
+                    f"{name} must have shape (1, horizon, {size}), got {array.shape}"
+                )
+            if array.shape[1] <= 0 or array.shape[1] > MAX_ACTION_HORIZON:
+                raise ValueError(f"{name} has invalid horizon {array.shape[1]}")
+            if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+                array.dtype, np.bool_
+            ):
+                raise TypeError(f"{name} must contain numeric values")
+            if not np.isfinite(array).all():
+                raise ValueError(f"{name} must contain only finite values")
+            if horizon is None:
+                horizon = array.shape[1]
+            elif array.shape[1] != horizon:
+                raise ValueError("RLDX action fields have inconsistent horizons")
+            normalized[name] = array
+        return normalized, horizon
+
     def predict(self, obs_dict, options):
         # policy.get_action returns dict[str, np.ndarray] because RLDX's
         # PolicyRuntime._decode already .cpu().numpy()s torch internally, and
         # _NumpyEncoder (http_rpc) tags numpy arrays at JSON time. If you ever
         # bypass _decode (e.g. call the model forward directly), you must
         # .cpu().numpy() the result here — _NumpyEncoder raises on torch.Tensor.
-        actions, info = self.policy.get_action(obs_dict, options=options)
+        self._validate_observation(obs_dict)
+        self._validate_options(options)
+        actions, info = self.policy.get_action(obs_dict, options=dict(options))
+        actions, _ = self._validate_actions(actions)
         return actions
 
+    def _warmup(self):
+        frames = int(self._vdi.size)
+        obs = {
+            name: np.zeros((1, 1, size), dtype=np.float32)
+            for name, size in STATE_FIELDS.items()
+        }
+        obs["state.base_rotation"][0, 0, 3] = 1.0
+        obs["state.end_effector_rotation_relative"][0, 0, 3] = 1.0
+        obs.update(
+            {
+                name: np.zeros((1, frames, 256, 256, 3), dtype=np.uint8)
+                for name in VIDEO_FIELDS
+            }
+        )
+        obs[ANNOTATION_FIELD] = ["warm up the robocasa policy"]
+        session_id = f"warmup:{self._runtime_id}"
+        try:
+            self.predict(
+                obs,
+                {"session_ids": [session_id], "reset_memory": [True]},
+            )
+        finally:
+            self.policy.reset({"session_ids": [session_id]})
+        self._warmed_up = True
+
     def reset_session(self, session_id):
+        session_id = _session_id(session_id)
         self.policy.reset({"session_ids": [session_id]})
-        return {"ok": True}
+        return {"ok": True, "runtime_id": self._runtime_id, "session_id": session_id}
 
 
 def main():

--- a/robots/robocasa/vla_server.py
+++ b/robots/robocasa/vla_server.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import numpy as np
 
+from robots.robocasa.checkpoint_identity import load_attestation
 from rpent.robots.components.vla_facade_base import BaseVLAFacade
 from rpent.utils.logging import get_logger
 
@@ -64,11 +65,37 @@ def _sha256_file(path):
     return digest.hexdigest()
 
 
-def _model_identity(model_path):
+def _model_identity(model_path, *, vlm_path=None, attestation_path=None):
     if not isinstance(model_path, (str, os.PathLike)) or not str(model_path).strip():
         raise TypeError("model_path must be a non-empty path or model id")
     requested = str(model_path)
     path = Path(requested).expanduser()
+    isolation = os.environ.get("RLDX_PERCEPTION_ISOLATION", "0")
+    if isolation not in {"0", "1"}:
+        raise ValueError("RLDX_PERCEPTION_ISOLATION must be 0 or 1")
+    formal = isolation == "1"
+    if attestation_path is not None:
+        if vlm_path is None:
+            raise ValueError(
+                "VLM metadata path is required with checkpoint attestation"
+            )
+        attestation = load_attestation(attestation_path, path, vlm_path)
+        expected = os.environ.get("RLDX_CHECKPOINT_FINGERPRINT")
+        if expected is not None and expected != attestation["fingerprint"]:
+            raise ValueError("checkpoint fingerprint differs from expected identity")
+        return {
+            "kind": "local",
+            "requested": requested,
+            "resolved_path": str(path.resolve()),
+            "fingerprint": attestation["fingerprint"],
+            "verified": True,
+            "checkpoint_id": attestation["checkpoint_id"],
+            "authority_manifest_sha256": attestation["authority_manifest_sha256"],
+        }
+    if formal:
+        raise ValueError(
+            "perception-isolated VLA server requires a checkpoint attestation"
+        )
     if not path.exists():
         return {
             "kind": "remote",
@@ -135,10 +162,16 @@ def _numeric_array(value, name, *, shape):
 class RoboCasaVLAFacade(BaseVLAFacade):
     """Loads RLDX model and exposes inference-only RPC methods."""
 
-    def __init__(self, model_path):
+    def __init__(self, model_path, *, vlm_path=None, attestation_path=None):
         super().__init__()
+        if vlm_path is not None:
+            os.environ["RLDX_VLM_PATH"] = str(Path(vlm_path).expanduser().resolve())
         self._runtime_id = uuid.uuid4().hex
-        self._model_identity = _model_identity(model_path)
+        self._model_identity = _model_identity(
+            model_path,
+            vlm_path=vlm_path,
+            attestation_path=attestation_path,
+        )
         from rldx.data.embodiment_tags import EmbodimentTag
         from rldx.eval.rollout_policy import create_rldx_sim_policy
 
@@ -148,7 +181,11 @@ class RoboCasaVLAFacade(BaseVLAFacade):
             "",
             None,
         )
-        loaded_identity = _model_identity(model_path)
+        loaded_identity = _model_identity(
+            model_path,
+            vlm_path=vlm_path,
+            attestation_path=attestation_path,
+        )
         if loaded_identity != self._model_identity:
             raise RuntimeError("checkpoint identity changed while loading the VLA")
         mod = self.policy.get_modality_config()
@@ -356,6 +393,11 @@ def main():
         help="GPU device exposed through CUDA_VISIBLE_DEVICES.",
     )
     p.add_argument("--model-path", required=True, help="RLDX checkpoint path")
+    p.add_argument("--vlm-path", help="RLDX VLM metadata path")
+    p.add_argument(
+        "--checkpoint-attestation",
+        help="private checkpoint attestation created by the reproduction preflight",
+    )
     args = p.parse_args()
 
     if args.cuda_device is not None:
@@ -371,7 +413,11 @@ def main():
             )
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_device)
 
-    facade = RoboCasaVLAFacade(args.model_path)
+    facade = RoboCasaVLAFacade(
+        args.model_path,
+        vlm_path=args.vlm_path,
+        attestation_path=args.checkpoint_attestation,
+    )
     facade.serve(
         transport=args.transport,
         host=args.host,

--- a/rpent/reproduce/__init__.py
+++ b/rpent/reproduce/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reproduction protocols and artifact contracts."""

--- a/rpent/reproduce/robocasa/__init__.py
+++ b/rpent/reproduce/robocasa/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frozen RoboCasa365 reproduction contract."""
+
+from .artifacts import CellResult, Completion, Integrity, Outcome
+from .memory import build_memory_pack, pack_memory, validate_memory_pack
+from .protocol import CELLS, EXPECTED_ROLLOUTS, SPLITS, Cell, Split
+
+__all__ = [
+    "CELLS",
+    "EXPECTED_ROLLOUTS",
+    "SPLITS",
+    "Cell",
+    "CellResult",
+    "Completion",
+    "Integrity",
+    "Outcome",
+    "Split",
+    "build_memory_pack",
+    "pack_memory",
+    "validate_memory_pack",
+]

--- a/rpent/reproduce/robocasa/__init__.py
+++ b/rpent/reproduce/robocasa/__init__.py
@@ -17,6 +17,7 @@
 from .artifacts import CellResult, Completion, Integrity, Outcome
 from .memory import build_memory_pack, pack_memory, validate_memory_pack
 from .protocol import CELLS, EXPECTED_ROLLOUTS, SPLITS, Cell, Split
+from .validator import summarize, validate_cell, validate_run
 
 __all__ = [
     "CELLS",
@@ -30,5 +31,8 @@ __all__ = [
     "Split",
     "build_memory_pack",
     "pack_memory",
+    "summarize",
+    "validate_cell",
     "validate_memory_pack",
+    "validate_run",
 ]

--- a/rpent/reproduce/robocasa/artifacts.py
+++ b/rpent/reproduce/robocasa/artifacts.py
@@ -1,0 +1,386 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical completed-cell artifacts and atomic publication."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import stat
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from .protocol import Cell, command_problem
+
+
+class Completion(str, Enum):
+    COMPLETED = "completed"
+    INCOMPLETE = "incomplete"
+
+
+class Outcome(str, Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"
+
+
+class Integrity(str, Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class CellResult:
+    completion: Completion
+    outcome: Outcome
+    integrity: Integrity
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.completion is not Completion.COMPLETED
+            and self.outcome is not Outcome.UNKNOWN
+        ):
+            raise ValueError("incomplete cells cannot claim a task outcome")
+        if (
+            self.completion is not Completion.COMPLETED
+            and self.integrity is Integrity.VALID
+        ):
+            raise ValueError("incomplete cells cannot be canonical")
+
+    @property
+    def canonical(self) -> bool:
+        return (
+            self.completion is Completion.COMPLETED
+            and self.integrity is Integrity.VALID
+        )
+
+
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+
+
+def _directory_problem(metadata: os.stat_result, label: str) -> str | None:
+    if not stat.S_ISDIR(metadata.st_mode):
+        return f"{label} must be a directory"
+    if metadata.st_uid != os.geteuid():
+        return f"{label} must be owned by the current user"
+    if metadata.st_mode & 0o022:
+        return f"{label} must not be writable by group or other"
+    return None
+
+
+def _component_name(value: str, label: str) -> str:
+    if not value or value in {".", ".."} or Path(value).name != value:
+        raise ValueError(f"artifact {label} is not one safe path component")
+    return value
+
+
+def _resolved_inside(path: Path, root: Path, label: str) -> Path:
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise ValueError(
+            f"artifact {label} escapes or cannot resolve inside root"
+        ) from exc
+    return resolved
+
+
+def _open_root(root: Path) -> tuple[int, Path]:
+    try:
+        descriptor = os.open(root, _DIRECTORY_FLAGS)
+    except OSError as exc:
+        raise ValueError(
+            f"artifact root must be a real safe directory: {root}"
+        ) from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if problem := _directory_problem(metadata, "artifact root"):
+            raise ValueError(problem)
+        resolved = root.resolve(strict=True)
+        resolved_metadata = resolved.stat()
+        if (metadata.st_dev, metadata.st_ino) != (
+            resolved_metadata.st_dev,
+            resolved_metadata.st_ino,
+        ):
+            raise ValueError("artifact root changed while it was being opened")
+        return descriptor, resolved
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _open_child(
+    parent_descriptor: int,
+    parent_path: Path,
+    name: str,
+    root: Path,
+    label: str,
+    *,
+    create: bool,
+) -> int | None:
+    try:
+        descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_descriptor)
+    except FileNotFoundError:
+        if not create:
+            return None
+        try:
+            os.mkdir(name, mode=0o700, dir_fd=parent_descriptor)
+        except FileExistsError:
+            pass
+        try:
+            descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_descriptor)
+        except OSError as exc:
+            raise ValueError(f"artifact {label} could not be created safely") from exc
+    except OSError as exc:
+        raise ValueError(f"artifact {label} must be a real safe directory") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if problem := _directory_problem(metadata, f"artifact {label}"):
+            raise ValueError(problem)
+        path = parent_path / name
+        resolved = _resolved_inside(path, root, label)
+        resolved_metadata = resolved.stat()
+        if (metadata.st_dev, metadata.st_ino) != (
+            resolved_metadata.st_dev,
+            resolved_metadata.st_ino,
+        ):
+            raise ValueError(f"artifact {label} changed while it was being opened")
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+@contextmanager
+def _secure_artifact_directory(
+    root: Path, cell: Cell, *, create: bool
+) -> Iterator[tuple[Path, int | None]]:
+    """Open the task directory through checked, non-symlink directory handles."""
+    root_path = Path(root)
+    split_name = _component_name(cell.split.value, "split")
+    task_name = _component_name(cell.task, "task")
+    directory = root_path / split_name / task_name
+    root_descriptor, resolved_root = _open_root(root_path)
+    split_descriptor: int | None = None
+    task_descriptor: int | None = None
+    try:
+        try:
+            directory.resolve(strict=False).relative_to(resolved_root)
+        except (OSError, ValueError) as exc:
+            raise ValueError("artifact directory escapes root") from exc
+        split_descriptor = _open_child(
+            root_descriptor,
+            root_path,
+            split_name,
+            resolved_root,
+            "split",
+            create=create,
+        )
+        if split_descriptor is None:
+            yield directory, None
+            return
+        task_descriptor = _open_child(
+            split_descriptor,
+            root_path / split_name,
+            task_name,
+            resolved_root,
+            "task",
+            create=create,
+        )
+        yield directory, task_descriptor
+    finally:
+        if task_descriptor is not None:
+            os.close(task_descriptor)
+        if split_descriptor is not None:
+            os.close(split_descriptor)
+        os.close(root_descriptor)
+
+
+def _atomic_write(directory_descriptor: int, name: str, data: bytes) -> None:
+    name = _component_name(name, "file")
+    temporary = f".{name}.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(temporary, flags, 0o600, dir_fd=directory_descriptor)
+    try:
+        os.fchmod(descriptor, 0o600)
+        remaining = memoryview(data)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(
+            temporary,
+            name,
+            src_dir_fd=directory_descriptor,
+            dst_dir_fd=directory_descriptor,
+        )
+        os.fsync(directory_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary, dir_fd=directory_descriptor)
+        except FileNotFoundError:
+            pass
+
+
+def artifact_directory(root: Path, cell: Cell) -> Path:
+    """Return the cell path after validating every existing directory component."""
+    with _secure_artifact_directory(root, cell, create=False) as (
+        directory,
+        _descriptor,
+    ):
+        return directory
+
+
+@contextmanager
+def secure_artifact_directory(
+    root: Path, cell: Cell, *, create: bool = True
+) -> Iterator[tuple[Path, int | None]]:
+    """Yield a checked task-directory path and an open non-following handle."""
+    with _secure_artifact_directory(root, cell, create=create) as opened:
+        yield opened
+
+
+@contextmanager
+def secure_artifact_subdirectory(
+    root: Path, cell: Cell, *components: str
+) -> Iterator[tuple[Path, int]]:
+    """Create and hold a checked descendant directory under one task."""
+    with _secure_artifact_directory(root, cell, create=True) as (
+        directory,
+        task_descriptor,
+    ):
+        assert task_descriptor is not None
+        root_resolved = Path(root).resolve(strict=True)
+        current_path = directory
+        current_descriptor = task_descriptor
+        children: list[int] = []
+        try:
+            for index, raw_name in enumerate(components):
+                name = _component_name(raw_name, f"subdirectory {index + 1}")
+                descriptor = _open_child(
+                    current_descriptor,
+                    current_path,
+                    name,
+                    root_resolved,
+                    f"subdirectory {index + 1}",
+                    create=True,
+                )
+                assert descriptor is not None
+                children.append(descriptor)
+                current_descriptor = descriptor
+                current_path = current_path / name
+            yield current_path, current_descriptor
+        finally:
+            for descriptor in reversed(children):
+                os.close(descriptor)
+
+
+def atomic_write_artifact_file(
+    directory_descriptor: int, name: str, data: bytes
+) -> None:
+    """Atomically publish one regular file through an open artifact dirfd."""
+    _atomic_write(directory_descriptor, name, data)
+
+
+def publish_completed_cell(
+    root: Path,
+    cell: Cell,
+    result: CellResult,
+    audit: dict[str, Any],
+    commands: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Publish audit, normalized JSONL and commit manifest, commit marker last."""
+    if not result.canonical:
+        raise ValueError("only completed, valid cells may be published canonically")
+    commands = list(commands)
+    task_language = audit.get("task_language")
+    for number, command in enumerate(commands, 1):
+        if problem := command_problem(command, task_language=task_language):
+            raise ValueError(f"command trace line {number} is invalid: {problem}")
+    if (
+        audit.get("task") != cell.task
+        or type(audit.get("seed")) is not int
+        or audit["seed"] != cell.seed
+    ):
+        raise ValueError("audit identity does not match cell")
+    if audit.get("success") is not (result.outcome is Outcome.SUCCESS):
+        raise ValueError("audit success disagrees with CellResult")
+    run_config_sha256 = audit.get("run_config_sha256")
+    if (
+        not isinstance(run_config_sha256, str)
+        or len(run_config_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in run_config_sha256)
+    ):
+        raise ValueError("audit must contain a valid run_config_sha256")
+    audit_name = f"{cell.tag}.json"
+    trace_name = f"{cell.tag}.jsonl"
+    commit_name = f"{cell.tag}.completed.json"
+    audit_bytes = (
+        json.dumps(audit, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    trace_bytes = b"".join(
+        (json.dumps(command, ensure_ascii=False, separators=(",", ":")) + "\n").encode()
+        for command in commands
+    )
+    commit = {
+        "schema_version": 1,
+        "run_config_sha256": run_config_sha256,
+        "cell": {"split": cell.split.value, "task": cell.task, "seed": cell.seed},
+        "result": {
+            key: value.value if isinstance(value, Enum) else value
+            for key, value in asdict(result).items()
+        },
+        "files": {
+            audit_name: hashlib.sha256(audit_bytes).hexdigest(),
+            trace_name: hashlib.sha256(trace_bytes).hexdigest(),
+        },
+    }
+    with _secure_artifact_directory(root, cell, create=True) as (
+        _directory,
+        directory_descriptor,
+    ):
+        assert directory_descriptor is not None
+        _atomic_write(directory_descriptor, audit_name, audit_bytes)
+        _atomic_write(directory_descriptor, trace_name, trace_bytes)
+        _atomic_write(
+            directory_descriptor,
+            commit_name,
+            (
+                json.dumps(commit, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+            ).encode(),
+        )
+    return commit

--- a/rpent/reproduce/robocasa/deadline_supervisor.py
+++ b/rpent/reproduce/robocasa/deadline_supervisor.py
@@ -1,0 +1,910 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bind planner timeout and driver commits to one monotonic deadline."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import secrets
+import signal
+import stat
+import subprocess as _subprocess
+import sys
+import threading
+import time as _time
+from pathlib import Path
+from typing import Any, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from rpent.reproduce.robocasa.secure_script import _read_source  # noqa: E402
+
+DEADLINE_PROTOCOL = "monotonic_commit_gate_v1"
+CONTRACT_NAME = "_deadline_contract.json"
+GATE_NAME = "_deadline_commit.gate"
+SEAL_NAME = "_deadline_seal.json"
+FREEZE_NAME = "_deadline_freeze.json"
+RECEIPT_PREFIX = "_deadline_commit_"
+EXIT_DEADLINE = 20
+EXIT_WRAPPER_ERROR = 70
+DRIVER_STOP_FIELDS = frozenset(
+    {"observed_state", "supervisor_stopped", "kill_sent", "kill_observed"}
+)
+DRIVER_STOP_STATES = frozenset({"exited", "T", "t", "Z", "X"})
+DRIVER_ADAPTER_DEADLINE_EXIT = 75
+RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "step",
+        "deadline_monotonic_ns",
+        "done_published_monotonic_ns",
+        "contract_sha256",
+    }
+)
+
+
+class DeadlineError(RuntimeError):
+    """The deadline boundary could not be established or attested."""
+
+
+def driver_stop_problem(value: Any) -> str | None:
+    """Validate the frozen driver termination proof shared by all consumers."""
+    if not isinstance(value, dict) or set(value) != DRIVER_STOP_FIELDS:
+        return "driver stop proof has an invalid schema"
+    state = value.get("observed_state")
+    stopped = value.get("supervisor_stopped")
+    kill_sent = value.get("kill_sent")
+    kill_observed = value.get("kill_observed")
+    if state not in DRIVER_STOP_STATES:
+        return "driver stop proof has an invalid observed state"
+    if any(type(item) is not bool for item in (stopped, kill_sent, kill_observed)):
+        return "driver stop proof flags must be booleans"
+    if stopped is not (state in {"T", "t"}):
+        return "driver stop proof disagrees with the observed state"
+    if kill_sent is not stopped:
+        return "driver stop proof does not bind SIGKILL to supervisor stop"
+    if kill_observed is not True:
+        return "driver stop proof does not confirm driver termination"
+    return None
+
+
+def timeout_driver_exit_problem(
+    driver_stop: Any,
+    return_code: Any,
+    *,
+    success_latched: Any,
+) -> str | None:
+    """Bind a timeout's observed process exit to its frozen stop proof."""
+    if problem := driver_stop_problem(driver_stop):
+        return problem
+    if type(return_code) is not int:
+        return "driver return code must be an integer"
+    if type(success_latched) is not bool:
+        return "deadline success latch must be a boolean"
+    assert isinstance(driver_stop, dict)
+    passive_exit = driver_stop["observed_state"] in {"exited", "Z", "X"}
+    if return_code == DRIVER_ADAPTER_DEADLINE_EXIT:
+        return (
+            None if passive_exit else "adapter deadline exit lacks a passive stop proof"
+        )
+    if return_code == -signal.SIGKILL:
+        return (
+            None
+            if not passive_exit
+            else "supervisor SIGKILL lacks a stopped-driver proof"
+        )
+    if return_code == 0 and success_latched:
+        return (
+            None
+            if passive_exit
+            else "successful driver exit lacks a passive stop proof"
+        )
+    return "driver return code is not a canonical timeout exit"
+
+
+def normalize_deadline_outcome(
+    raw_cause: Any,
+    raw_rc: Any,
+    *,
+    supervisor_fired: bool,
+    provider_violation: Any,
+    forbidden_web_search_event_count: Any,
+) -> tuple[Any, Any]:
+    """Apply the shared outer-deadline precedence to a raw planner outcome."""
+    if not supervisor_fired:
+        return raw_cause, raw_rc
+    provider_protocol_error = raw_cause == "planner_protocol_error" and (
+        provider_violation is not None or forbidden_web_search_event_count != 0
+    )
+    if raw_cause in {"operator_interrupted", "wrapper_error"} or (
+        provider_protocol_error
+    ):
+        return raw_cause, raw_rc
+    return "planner_timeout", EXIT_DEADLINE
+
+
+def deadline_receipt_problem(
+    value: Any,
+    *,
+    step: int,
+    contract: dict[str, Any],
+    contract_sha256: str,
+    require_before_deadline: bool,
+) -> str | None:
+    """Validate one post-publication receipt against its frozen contract."""
+    if type(step) is not int or step <= 0:
+        return "is not for a positive command step"
+    if not isinstance(value, dict) or set(value) != RECEIPT_FIELDS:
+        return "has an invalid schema"
+    published_ns = value.get("done_published_monotonic_ns")
+    started_ns = contract.get("started_monotonic_ns")
+    deadline_ns = contract.get("deadline_monotonic_ns")
+    if (
+        value.get("schema_version") != 1
+        or value.get("protocol") != DEADLINE_PROTOCOL
+        or value.get("run_id") != contract.get("run_id")
+        or value.get("nonce") != contract.get("nonce")
+        or value.get("step") != step
+        or value.get("deadline_monotonic_ns") != deadline_ns
+        or value.get("contract_sha256") != contract_sha256
+        or type(published_ns) is not int
+        or type(started_ns) is not int
+        or type(deadline_ns) is not int
+    ):
+        return "disagrees with the deadline contract"
+    if published_ns < started_ns:
+        return "claims publication before the deadline contract started"
+    if require_before_deadline and published_ns >= deadline_ns:
+        return "was published after the deadline"
+    return None
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("ascii")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_parent(path: Path) -> int:
+    parent = path.parent
+    metadata = parent.lstat()
+    if (
+        parent.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_mode & 0o022
+    ):
+        raise DeadlineError(f"unsafe deadline directory: {parent}")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return os.open(parent, flags)
+
+
+def _atomic_json(path: Path, value: Any) -> str:
+    payload = _canonical_bytes(value)
+    directory_fd = _safe_parent(path)
+    temporary = f".{path.name}.tmp.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = -1
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+        written = 0
+        while written < len(payload):
+            written += os.write(descriptor, payload[written:])
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(
+            temporary, path.name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd
+        )
+        os.fsync(directory_fd)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        os.close(directory_fd)
+    return _sha256_bytes(payload)
+
+
+def _open_gate(path: Path, *, create: bool) -> int:
+    flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    metadata = os.fstat(descriptor)
+    path_metadata = path.lstat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_nlink != 1
+        or (metadata.st_dev, metadata.st_ino)
+        != (path_metadata.st_dev, path_metadata.st_ino)
+    ):
+        os.close(descriptor)
+        raise DeadlineError("deadline commit gate is unsafe")
+    return descriptor
+
+
+def _read_trusted_json(path: Path) -> tuple[dict[str, Any], str]:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != os.geteuid()
+            or before.st_mode & 0o022
+            or before.st_nlink != 1
+            or before.st_size <= 0
+            or before.st_size > 2 * 1024 * 1024
+        ):
+            raise DeadlineError(f"unsafe deadline evidence: {path.name}")
+        payload = b""
+        while len(payload) <= before.st_size:
+            chunk = os.read(descriptor, min(65536, before.st_size - len(payload)))
+            if not chunk:
+                break
+            payload += chunk
+        after = os.fstat(descriptor)
+        if len(payload) != before.st_size or (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        ) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+            raise DeadlineError(f"deadline evidence changed while reading: {path.name}")
+    finally:
+        os.close(descriptor)
+    try:
+        value = json.loads(payload)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise DeadlineError(f"invalid deadline evidence JSON: {path.name}") from exc
+    if not isinstance(value, dict):
+        raise DeadlineError(f"deadline evidence must be an object: {path.name}")
+    return value, _sha256_bytes(payload)
+
+
+def process_identity(pid: int) -> dict[str, int | str] | None:
+    """Read the Linux PID identity fields needed before signaling a process group."""
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+    except FileNotFoundError:
+        return None
+    close = raw.rfind(")")
+    if close < 0:
+        raise DeadlineError("driver /proc identity is malformed")
+    fields = raw[close + 2 :].split()
+    if len(fields) < 20:
+        raise DeadlineError("driver /proc identity is truncated")
+    return {
+        "pid": pid,
+        "state": fields[0],
+        "pgid": int(fields[2]),
+        "start_time_ticks": int(fields[19]),
+    }
+
+
+def _validate_process_identity(expected: dict[str, int]) -> dict[str, int | str] | None:
+    observed = process_identity(expected["pid"])
+    if observed is None:
+        return None
+    for key in ("pid", "pgid", "start_time_ticks"):
+        if observed[key] != expected[key]:
+            raise DeadlineError(f"driver process identity changed at {key}")
+    return observed
+
+
+def _journal_digest(path: Path, *, allow_empty: bool = False) -> str:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_mode & 0o022
+        or metadata.st_nlink != 1
+        or (not allow_empty and metadata.st_size <= 0)
+    ):
+        raise DeadlineError(f"unsafe committed journal file: {path.name}")
+    return _sha256_file(path)
+
+
+def _read_journal_json(path: Path) -> dict[str, Any]:
+    _journal_digest(path)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DeadlineError(f"invalid committed journal JSON: {path.name}") from exc
+    if not isinstance(value, dict):
+        raise DeadlineError(f"committed journal must be an object: {path.name}")
+    return value
+
+
+def scan_committed_prefix(workdir: Path) -> dict[str, Any]:
+    """Hash the exact contiguous prefix visible after the commit gate is sealed."""
+    done_steps: set[int] = set()
+    for path in workdir.glob("done_*.flag"):
+        raw = path.name[5:-5]
+        try:
+            step = int(raw)
+        except ValueError as exc:
+            raise DeadlineError(f"invalid done marker name: {path.name}") from exc
+        if path.name != f"done_{step:02d}.flag" or step in done_steps:
+            raise DeadlineError(f"non-canonical done marker: {path.name}")
+        done_steps.add(step)
+    if not done_steps or 0 not in done_steps:
+        raise DeadlineError("deadline freeze is missing done_00.flag")
+    prefix_step = max(done_steps)
+    if done_steps != set(range(prefix_step + 1)):
+        raise DeadlineError("deadline freeze found non-contiguous done markers")
+
+    files: dict[str, str] = {}
+    commands: list[dict[str, Any]] = []
+    final_state: dict[str, Any] | None = None
+    for step in range(prefix_step + 1):
+        suffix = f"{step:02d}"
+        done = workdir / f"done_{suffix}.flag"
+        state_path = workdir / f"state_{suffix}.json"
+        files[done.name] = _journal_digest(done, allow_empty=True)
+        state = _read_journal_json(state_path)
+        files[state_path.name] = _journal_digest(state_path)
+        if state.get("step") != step:
+            raise DeadlineError(f"state_{suffix}.json has the wrong step")
+        final_state = state
+        if step:
+            log_path = workdir / f"log_{suffix}.json"
+            receipt_path = workdir / f"{RECEIPT_PREFIX}{suffix}.json"
+            log = _read_journal_json(log_path)
+            files[log_path.name] = _journal_digest(log_path)
+            _read_journal_json(receipt_path)
+            files[receipt_path.name] = _journal_digest(receipt_path)
+            command = log.get("command")
+            if not isinstance(command, dict) or not isinstance(
+                command.get("action"), str
+            ):
+                raise DeadlineError(f"log_{suffix}.json has no command object")
+            commands.append(command)
+    assert final_state is not None
+    trace = b"".join(
+        (json.dumps(command, ensure_ascii=False, separators=(",", ":")) + "\n").encode(
+            "utf-8"
+        )
+        for command in commands
+    )
+    raw_trace = workdir / "command_trace.jsonl"
+    return {
+        "prefix_step": prefix_step,
+        "success": final_state.get("success") is True,
+        "final_state_sha256": files[f"state_{prefix_step:02d}.json"],
+        "command_trace_sha256": _sha256_bytes(trace),
+        "raw_command_trace_sha256": _journal_digest(raw_trace, allow_empty=True),
+        "files_sha256": files,
+    }
+
+
+def _remove_done_marker(path: Path) -> None:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_mode & 0o022
+        or metadata.st_nlink != 1
+    ):
+        raise DeadlineError(f"unsafe late commit marker: {path.name}")
+    path.unlink()
+    directory_fd = _safe_parent(path)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _read_deadline_receipt(
+    path: Path,
+    *,
+    step: int,
+    contract: dict[str, Any],
+    contract_sha256: str,
+) -> int:
+    if step <= 0:
+        raise DeadlineError("deadline receipts are only valid for command steps")
+    if path.name != f"{RECEIPT_PREFIX}{step:02d}.json":
+        raise DeadlineError(f"non-canonical deadline receipt: {path.name}")
+    receipt, _digest = _read_trusted_json(path)
+    published_ns = receipt.get("done_published_monotonic_ns")
+    if deadline_receipt_problem(
+        receipt,
+        step=step,
+        contract=contract,
+        contract_sha256=contract_sha256,
+        require_before_deadline=False,
+    ):
+        raise DeadlineError(f"invalid deadline receipt for step {step}")
+    assert type(published_ns) is int
+    return published_ns
+
+
+def _seal_committed_prefix(
+    workdir: Path, contract: dict[str, Any], contract_sha256: str
+) -> list[int]:
+    """Drop only a final marker whose post-publication receipt is late or absent."""
+    done_steps = sorted(
+        int(path.name[5:-5])
+        for path in workdir.glob("done_*.flag")
+        if path.name[5:-5].isdigit()
+    )
+    dropped: list[int] = []
+    rejecting = False
+    for step in done_steps:
+        if step == 0:
+            continue
+        marker = workdir / f"done_{step:02d}.flag"
+        receipt_path = workdir / f"{RECEIPT_PREFIX}{step:02d}.json"
+        try:
+            published_ns = _read_deadline_receipt(
+                receipt_path,
+                step=step,
+                contract=contract,
+                contract_sha256=contract_sha256,
+            )
+        except FileNotFoundError:
+            rejecting = True
+            published_ns = None
+        if (
+            published_ns is not None
+            and published_ns >= contract["deadline_monotonic_ns"]
+        ):
+            rejecting = True
+        if rejecting:
+            _remove_done_marker(marker)
+            dropped.append(step)
+
+    remaining = {
+        int(path.name[5:-5])
+        for path in workdir.glob("done_*.flag")
+        if path.name[5:-5].isdigit()
+    }
+    prefix_step = max(remaining, default=-1)
+    for receipt_path in workdir.glob(f"{RECEIPT_PREFIX}*.json"):
+        raw = receipt_path.name[len(RECEIPT_PREFIX) : -5]
+        if not raw.isdigit():
+            raise DeadlineError(f"invalid deadline receipt name: {receipt_path.name}")
+        step = int(raw)
+        if step <= 0:
+            raise DeadlineError("deadline receipts are only valid for command steps")
+        if receipt_path.name != f"{RECEIPT_PREFIX}{step:02d}.json":
+            raise DeadlineError(f"non-canonical deadline receipt: {receipt_path.name}")
+        if step <= prefix_step:
+            continue
+        published_ns = _read_deadline_receipt(
+            receipt_path,
+            step=step,
+            contract=contract,
+            contract_sha256=contract_sha256,
+        )
+        if published_ns < contract["deadline_monotonic_ns"]:
+            raise DeadlineError("an on-time receipt is missing its done marker")
+    return dropped
+
+
+class DeadlineController:
+    def __init__(
+        self,
+        *,
+        workdir: Path,
+        run_id: str,
+        driver_identity: dict[str, int],
+        timeout_seconds: float,
+        kill_after_seconds: float,
+        external_sha256: str,
+    ) -> None:
+        self.workdir = workdir
+        self.run_id = run_id
+        self.driver_identity = driver_identity
+        self.timeout_ns = int(timeout_seconds * 1_000_000_000)
+        self.kill_after_seconds = kill_after_seconds
+        self.external_sha256 = external_sha256
+        self.nonce = secrets.token_hex(16)
+        self.cancelled = threading.Event()
+        self.started = threading.Event()
+        self.fired = False
+        self.error: str | None = None
+        self.cancelled_monotonic_ns: int | None = None
+        self.contract: dict[str, Any] | None = None
+        self.contract_sha256: str | None = None
+        self.freeze_sha256: str | None = None
+        self._thread: threading.Thread | None = None
+        self._start_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+
+    def start(self, started_monotonic: float) -> None:
+        with self._start_lock:
+            if self.started.is_set():
+                return
+            gate = self.workdir / GATE_NAME
+            descriptor = _open_gate(gate, create=True)
+            os.close(descriptor)
+            started_ns = int(started_monotonic * 1_000_000_000)
+            deadline_ns = started_ns + self.timeout_ns
+            self.contract = {
+                "schema_version": 1,
+                "protocol": DEADLINE_PROTOCOL,
+                "run_id": self.run_id,
+                "nonce": self.nonce,
+                "started_monotonic_ns": started_ns,
+                "deadline_monotonic_ns": deadline_ns,
+                "timeout_ns": self.timeout_ns,
+                "driver": self.driver_identity,
+                "external_deadline_sha256": self.external_sha256,
+            }
+            self.contract_sha256 = _atomic_json(
+                self.workdir / CONTRACT_NAME, self.contract
+            )
+            self.started.set()
+            self._thread = threading.Thread(
+                target=self._watch, name="robocasa-deadline", daemon=True
+            )
+            self._thread.start()
+
+    def _watch(self) -> None:
+        assert self.contract is not None
+        deadline_ns = self.contract["deadline_monotonic_ns"]
+        while True:
+            remaining = max(0.0, (deadline_ns - _time.monotonic_ns()) / 1e9)
+            self.cancelled.wait(remaining)
+            observed_ns = _time.monotonic_ns()
+            with self._state_lock:
+                cancelled_ns = self.cancelled_monotonic_ns
+                if cancelled_ns is not None and cancelled_ns < deadline_ns:
+                    return
+                if observed_ns >= deadline_ns:
+                    self.fired = True
+                    fire = True
+                else:
+                    fire = False
+                    cancelled = self.cancelled.is_set()
+            if fire:
+                try:
+                    self._freeze()
+                except BaseException as exc:
+                    self.error = f"{type(exc).__name__}: {exc}"
+                return
+            if cancelled:
+                return
+
+    def _acquire_gate(self, descriptor: int) -> None:
+        lock_deadline = _time.monotonic() + self.kill_after_seconds
+        while True:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return
+            except BlockingIOError:
+                if _time.monotonic() >= lock_deadline:
+                    raise DeadlineError("timed out sealing the deadline commit gate")
+                _time.sleep(0.01)
+
+    @staticmethod
+    def _driver_stop(state: str, *, supervisor_stopped: bool) -> dict[str, Any]:
+        return {
+            "observed_state": state,
+            "supervisor_stopped": supervisor_stopped,
+            "kill_sent": False,
+            "kill_observed": state in {"exited", "Z", "X"},
+        }
+
+    def _stop_driver(self) -> dict[str, Any]:
+        observed = _validate_process_identity(self.driver_identity)
+        if observed is None:
+            return self._driver_stop("exited", supervisor_stopped=False)
+        state = str(observed["state"])
+        if state in {"Z", "X"}:
+            return self._driver_stop(state, supervisor_stopped=False)
+        try:
+            os.killpg(self.driver_identity["pgid"], signal.SIGSTOP)
+        except ProcessLookupError:
+            return self._driver_stop("exited", supervisor_stopped=False)
+        stop_deadline = _time.monotonic() + self.kill_after_seconds
+        while _time.monotonic() < stop_deadline:
+            observed = _validate_process_identity(self.driver_identity)
+            if observed is None:
+                return self._driver_stop("exited", supervisor_stopped=False)
+            state = str(observed["state"])
+            if state in {"T", "t", "Z", "X"}:
+                return self._driver_stop(state, supervisor_stopped=state in {"T", "t"})
+            _time.sleep(0.01)
+        raise DeadlineError("driver did not stop at the planner deadline")
+
+    def _kill_driver(self, driver_stop: dict[str, Any]) -> None:
+        if not driver_stop["supervisor_stopped"]:
+            return
+        observed = _validate_process_identity(self.driver_identity)
+        if observed is None or observed["state"] not in {"T", "t"}:
+            raise DeadlineError("stopped driver identity changed before SIGKILL")
+        try:
+            os.killpg(self.driver_identity["pgid"], signal.SIGKILL)
+        except ProcessLookupError:
+            raise DeadlineError("stopped driver exited before supervisor SIGKILL")
+        driver_stop["kill_sent"] = True
+        kill_deadline = _time.monotonic() + self.kill_after_seconds
+        while _time.monotonic() < kill_deadline:
+            observed = _validate_process_identity(self.driver_identity)
+            if observed is None or observed["state"] in {"Z", "X"}:
+                driver_stop["kill_observed"] = True
+                return
+            _time.sleep(0.01)
+        raise DeadlineError("supervisor SIGKILL did not terminate the driver")
+
+    def _freeze(self) -> None:
+        assert self.contract is not None and self.contract_sha256 is not None
+        gate_descriptor = _open_gate(self.workdir / GATE_NAME, create=False)
+        try:
+            self._acquire_gate(gate_descriptor)
+            seal = {
+                "schema_version": 1,
+                "protocol": DEADLINE_PROTOCOL,
+                "run_id": self.run_id,
+                "nonce": self.nonce,
+                "deadline_monotonic_ns": self.contract["deadline_monotonic_ns"],
+                "sealed_monotonic_ns": _time.monotonic_ns(),
+                "contract_sha256": self.contract_sha256,
+            }
+            seal_sha256 = _atomic_json(self.workdir / SEAL_NAME, seal)
+            driver_stop = self._stop_driver()
+            dropped_done_steps = _seal_committed_prefix(
+                self.workdir, self.contract, self.contract_sha256
+            )
+            prefix = scan_committed_prefix(self.workdir)
+            self._kill_driver(driver_stop)
+            freeze = {
+                "schema_version": 1,
+                "protocol": DEADLINE_PROTOCOL,
+                "run_id": self.run_id,
+                "nonce": self.nonce,
+                "deadline_monotonic_ns": self.contract["deadline_monotonic_ns"],
+                "frozen_monotonic_ns": _time.monotonic_ns(),
+                "contract_sha256": self.contract_sha256,
+                "seal_sha256": seal_sha256,
+                "driver": self.driver_identity,
+                "driver_stop": driver_stop,
+                "dropped_done_steps": dropped_done_steps,
+                **prefix,
+            }
+            self.freeze_sha256 = _atomic_json(self.workdir / FREEZE_NAME, freeze)
+        finally:
+            try:
+                fcntl.flock(gate_descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(gate_descriptor)
+
+    def finish(self) -> None:
+        self.note_planner_terminal()
+        if self._thread is not None:
+            self._thread.join(timeout=self.kill_after_seconds * 2 + 5)
+            if self._thread.is_alive():
+                self.error = "deadline supervisor thread did not terminate"
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "protocol": DEADLINE_PROTOCOL,
+            "run_id": self.run_id,
+            "nonce": self.nonce,
+            "fired": self.fired,
+            "contract_sha256": self.contract_sha256,
+            "freeze_sha256": self.freeze_sha256,
+            "error": self.error,
+        }
+
+    def note_planner_terminal(self, observed_monotonic_ns: int | None = None) -> None:
+        with self._state_lock:
+            if self.fired:
+                return
+            observed = (
+                _time.monotonic_ns()
+                if observed_monotonic_ns is None
+                else observed_monotonic_ns
+            )
+            if (
+                self.cancelled_monotonic_ns is None
+                or observed < self.cancelled_monotonic_ns
+            ):
+                self.cancelled_monotonic_ns = observed
+            self.cancelled.set()
+
+
+class _TimeProxy:
+    def __init__(self, controller: DeadlineController) -> None:
+        self._controller = controller
+
+    def monotonic(self) -> float:
+        value = _time.monotonic()
+        self._controller.start(value)
+        return value
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(_time, name)
+
+
+class _ObservedProcess:
+    def __init__(self, process: Any, controller: DeadlineController) -> None:
+        self._process = process
+        self._controller = controller
+
+    def poll(self) -> int | None:
+        value = self._process.poll()
+        if value is not None:
+            self._controller.note_planner_terminal()
+        return value
+
+    def wait(self, *args: Any, **kwargs: Any) -> int:
+        value = self._process.wait(*args, **kwargs)
+        self._controller.note_planner_terminal()
+        return value
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._process, name)
+
+
+class _SubprocessProxy:
+    def __init__(self, controller: DeadlineController) -> None:
+        self._controller = controller
+
+    def Popen(self, *args: Any, **kwargs: Any) -> _ObservedProcess:  # noqa: N802
+        return _ObservedProcess(
+            _subprocess.Popen(*args, **kwargs),
+            self._controller,
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(_subprocess, name)
+
+
+def _normalize_status(
+    status_path: Path, controller: DeadlineController, external_rc: int
+) -> int:
+    try:
+        status, _digest = _read_trusted_json(status_path)
+    except (OSError, DeadlineError):
+        status = {"state": "finished", "termination_cause": "wrapper_error"}
+    supervisor = controller.status()
+    status["external_deadline_fired"] = status.get("deadline_fired")
+    status["deadline_supervisor"] = supervisor
+    rc = external_rc
+    if controller.error is not None or not controller.started.is_set():
+        status["termination_cause"] = "wrapper_error"
+        status["wrapper_rc"] = EXIT_WRAPPER_ERROR
+        status["supervision_error"] = controller.error or "deadline did not start"
+        rc = EXIT_WRAPPER_ERROR
+    elif controller.fired:
+        cause, wrapper_rc = normalize_deadline_outcome(
+            status.get("termination_cause"),
+            status.get("wrapper_rc"),
+            supervisor_fired=True,
+            provider_violation=status.get("provider_protocol_violation"),
+            forbidden_web_search_event_count=status.get(
+                "forbidden_web_search_event_count"
+            ),
+        )
+        status["termination_cause"] = cause
+        status["wrapper_rc"] = wrapper_rc
+        if cause == "planner_timeout":
+            status["deadline_fired"] = True
+        rc = wrapper_rc
+    _atomic_json(status_path, status)
+    return rc
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--workdir", type=Path, required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--driver-pid", type=int, required=True)
+    parser.add_argument("--driver-pgid", type=int, required=True)
+    parser.add_argument("--driver-start-time", type=int, required=True)
+    parser.add_argument("script_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if not args.script_args or args.script_args[0] != "--":
+        parser.error("expected external deadline arguments after --")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    source = _read_source(args.source, args.sha256)
+    namespace: dict[str, Any] = {
+        "__name__": "_rpent_external_deadline",
+        "__file__": str(args.source),
+        "__package__": None,
+        "__builtins__": __builtins__,
+    }
+    exec(compile(source, str(args.source), "exec", dont_inherit=True), namespace)
+    external_args = namespace["parse_args"](args.script_args[1:])
+    workdir = args.workdir.resolve(strict=True)
+    status_path = Path(external_args.status).resolve(strict=False)
+    if status_path != workdir / "planner_status.json":
+        raise DeadlineError(
+            "external planner status must stay inside the rollout workdir"
+        )
+    driver_identity = {
+        "pid": args.driver_pid,
+        "pgid": args.driver_pgid,
+        "start_time_ticks": args.driver_start_time,
+    }
+    observed = _validate_process_identity(driver_identity)
+    if observed is None:
+        raise DeadlineError("driver exited before the planner deadline was established")
+    controller = DeadlineController(
+        workdir=workdir,
+        run_id=args.run_id,
+        driver_identity=driver_identity,
+        timeout_seconds=external_args.timeout_seconds,
+        kill_after_seconds=external_args.kill_after_seconds,
+        external_sha256=args.sha256,
+    )
+    namespace["time"] = _TimeProxy(controller)
+    namespace["subprocess"] = _SubprocessProxy(controller)
+    previous = sys.argv
+    try:
+        sys.argv = [str(args.source), *args.script_args[1:]]
+        external_rc = int(namespace["main"](args.script_args[1:]))
+    finally:
+        sys.argv = previous
+        controller.finish()
+    return _normalize_status(status_path, controller, external_rc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rpent/reproduce/robocasa/executor.py
+++ b/rpent/reproduce/robocasa/executor.py
@@ -1,0 +1,1881 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execute one frozen RoboCasa cell through the audited local RLDX harness."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import time
+import uuid
+import xml.etree.ElementTree as ET
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import ProxyHandler, Request, build_opener
+
+from robots.robocasa.checkpoint_identity import (
+    expected_fingerprint,
+    load_attestation,
+)
+from robots.robocasa.checkpoint_identity import (
+    verify_checkpoint as verify_checkpoint_identity,
+)
+
+from .artifacts import (
+    CellResult,
+    Completion,
+    Integrity,
+    Outcome,
+    atomic_write_artifact_file,
+    publish_completed_cell,
+    secure_artifact_directory,
+    secure_artifact_subdirectory,
+)
+from .deadline_supervisor import (
+    CONTRACT_NAME,
+    DEADLINE_PROTOCOL,
+    FREEZE_NAME,
+    SEAL_NAME,
+    _read_trusted_json,
+    driver_stop_problem,
+    process_identity,
+    scan_committed_prefix,
+    timeout_driver_exit_problem,
+)
+from .formal_prompt import render_formal_prompt
+from .memory import validate_memory_pack
+from .planner_transport import (
+    CHATGPT_BROKER_PROFILE,
+    CODEX_REQUEST_MAX_RETRIES,
+    CODEX_STREAM_IDLE_TIMEOUT_MS,
+    CODEX_STREAM_MAX_RETRIES,
+    PlannerTransport,
+    normalize_responses_base_url,
+)
+from .profiles import PlannerAdapter, PlannerProfile, is_audited_profile
+from .protocol import EMPTY_MEMORY_TASKS, SPLITS, Cell, Split
+from .provenance import ensure_run_manifest
+
+EXIT_CANONICAL = 0
+EXIT_RETRYABLE_INFRA = 75
+EXIT_ARTIFACT = 76
+EXIT_CONFIGURATION = 78
+
+PROTOCOL_ID = "robocasa-harness-vla-v1"
+RETRYABLE_TERMINATIONS = frozenset(
+    {
+        "driver_startup_failed",
+        "driver_runtime_failed",
+        "planner_failed",
+        "wrapper_error",
+    }
+)
+BUILDER_TERMINATIONS = frozenset(
+    {
+        "planner_completed",
+        "planner_timeout",
+        "planner_failed",
+        "planner_protocol_error",
+        "driver_startup_failed",
+        "driver_runtime_failed",
+        "configuration_failed",
+        "operator_interrupted",
+    }
+)
+
+CHECKPOINT_SHA256 = {
+    "model-00001-of-00003.safetensors": (
+        "2a2f48bd2d2979979700c85c44051c37c3256de528842d82883ba756b070e541"
+    ),
+    "model-00002-of-00003.safetensors": (
+        "4bb91b9038d7825809c09da425d5dbd6a52ba1a1af25de09bc94ff218e1f80fc"
+    ),
+    "model-00003-of-00003.safetensors": (
+        "f348bb0aee031e6fd32cad2ff51aa5e4eaf74fa42299dae051f7e3ca0b8adf53"
+    ),
+}
+PINNED_CODEX_VERSION = "codex-cli 0.147.0"
+PINNED_CODEX_SHA256 = "cb0a15567e9a60a5820d54b0f6ae86d504dc3805c1eab21a47f70e3eb7b73a40"
+PINNED_CODEX_PATH = Path("/usr/local/libexec/rpent/codex-0.147.0")
+FROZEN_RUNTIME_SHA256 = {
+    "driver": "e776ad2b09f0060d1926ddf081e427626b1f3db03f99ec96e04b3862ca3f2531",
+    "readiness": "22153c6b41946bad1500023361034e35d12601fe293e59355ec62340c67a30c3",
+    "deadline": "ae9a7b65b68e6d1a61dace0c15f273aa742f53ce2143b8d6dde92471c2b14c0b",
+    "isolation_launcher": (
+        "6f0173f39753a8268b0b73aac2b729066f9798a0679c07e705a7c22f45cf81cb"
+    ),
+    "artifact_builder": (
+        "724f53794887c609be94a2c2a7fd8323ee4b9ad480d7d731721e82f633f41232"
+    ),
+    "interactive_env": (
+        "f42908f22ccc0db88610d35d314d14c903829cdd2de8ca53057c35c651ece634"
+    ),
+    "rldx_skill": ("f1c5b16cff92d938adcdb3929d8c5f8ba595b640de9105c36aa87d7d39e0b56b"),
+}
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    """Paths supplied by the preliminary local RLDX runtime snapshot."""
+
+    root: Path
+    sim_python: Path
+    driver: Path
+    readiness: Path
+    deadline: Path
+    isolation_launcher: Path
+    artifact_builder: Path
+    model: Path
+    vlm_metadata: Path
+    navview_xml: Path
+
+    @classmethod
+    def discover(cls, root: Path) -> "RuntimePaths":
+        root = Path(root).expanduser().resolve()
+        migration = root / "migration"
+        robosuite = (
+            root / "external_dependencies" / "robocasa365" / "robosuite" / "robosuite"
+        )
+        return cls(
+            root=root,
+            sim_python=(
+                root / "rldx/eval/sim/robocasa365/robocasa365_uv/.venv/bin/python"
+            ),
+            driver=migration / "robocasa_interactive_driver.py",
+            readiness=migration / "wait_for_driver_ready.py",
+            deadline=migration / "run_planner_with_deadline.py",
+            isolation_launcher=migration / "launch_isolated_codex.py",
+            artifact_builder=migration / "build_rollout_artifacts.py",
+            model=root / "checkpoints/RLDX-1-FT-RC365",
+            vlm_metadata=root / "checkpoints/RLDX-1-VLM-metadata",
+            navview_xml=robosuite / "models/assets/bases/omron_mobile_base.xml",
+        )
+
+
+@dataclass(frozen=True)
+class ExecutorConfig:
+    """Immutable inputs shared by every cell in one reproduction run."""
+
+    runtime: RuntimePaths
+    results_root: Path
+    rollout_root: Path
+    memory_root: Path
+    planner_profile: PlannerProfile
+    planner_transport: PlannerTransport
+    codex_bin: Path = PINNED_CODEX_PATH
+    startup_timeout_seconds: int = 2400
+    kill_after_seconds: int = 15
+    keep_workdirs: bool = False
+    preliminary_local_runtime: bool = False
+    memory_source: str = "local"
+    memory_revision: str | None = None
+
+
+@dataclass(frozen=True)
+class Execution:
+    """One executor attempt before scheduler retry policy is applied."""
+
+    cell: Cell
+    return_code: int
+    termination_cause: str
+    canonical: bool
+    workdir: Path
+    message: str | None = None
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def checkpoint_attestation_path(config: ExecutorConfig) -> Path:
+    return config.results_root / "_preflight" / "checkpoint-attestation.json"
+
+
+def _write_private_json(path: Path, value: dict[str, Any]) -> None:
+    parent = path.parent
+    if parent.exists() or parent.is_symlink():
+        metadata = parent.lstat()
+        if parent.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(
+                f"private output parent must be a real directory: {parent}"
+            )
+        if metadata.st_uid != os.geteuid() or metadata.st_mode & 0o077:
+            raise ValueError(f"private output parent has unsafe permissions: {parent}")
+    else:
+        parent.mkdir(parents=True, mode=0o700)
+        parent.chmod(0o700)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_checkpoint_attestation(config: ExecutorConfig) -> dict[str, Any]:
+    return load_attestation(
+        checkpoint_attestation_path(config),
+        config.runtime.model,
+        config.runtime.vlm_metadata,
+    )
+
+
+def _trusted_credential(path: Path) -> str | None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect planner credential file: {exc}"
+    if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        return "planner credential path must be a regular non-symlink file"
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        return "planner credential file mode must be 0600"
+    if metadata.st_uid != os.geteuid():
+        return "planner credential file must be owned by the reproduction user"
+    if metadata.st_size <= 1:
+        return "planner credential file is empty"
+    if metadata.st_size > 16 * 1024:
+        return "planner credential file is unexpectedly large"
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        return f"cannot securely open planner credential file: {exc}"
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            return "planner credential file changed while it was being opened"
+        raw = os.read(descriptor, metadata.st_size + 1)
+    finally:
+        os.close(descriptor)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeError:
+        return "planner credential file must contain UTF-8 text"
+    if len(text.splitlines()) != 1 or not text.strip():
+        return "planner credential file must contain exactly one non-empty line"
+    return None
+
+
+def _broker_health_problem(config: ExecutorConfig) -> str | None:
+    """Verify the provider-neutral subscription broker admission contract."""
+    transport = config.planner_transport
+    if not transport.uses_broker:
+        return None
+    if transport.broker_health_url is None or transport.broker_protocol is None:
+        return "subscription transport is missing its broker health contract"
+    request = Request(
+        transport.broker_health_url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rpent-robocasa-preflight",
+        },
+    )
+    try:
+        opener = build_opener(ProxyHandler({}))
+        with opener.open(request, timeout=5.0) as response:
+            payload = response.read(64 * 1024 + 1)
+    except (HTTPError, URLError, OSError, TimeoutError) as exc:
+        return f"subscription broker health check failed: {type(exc).__name__}"
+    if len(payload) > 64 * 1024:
+        return "subscription broker health response is too large"
+    try:
+        value = json.loads(payload.decode("utf-8", errors="strict"))
+    except (UnicodeError, ValueError):
+        return "subscription broker health response is not valid JSON"
+    expected = {
+        "provider_profile": CHATGPT_BROKER_PROFILE,
+        "auth_mode": "chatgpt_broker",
+        "credential_broker": True,
+        "credential_broker_ready": True,
+        "credential_broker_protocol": transport.broker_protocol,
+        "model": config.planner_profile.model,
+        "reasoning_effort": config.planner_profile.reasoning_effort,
+    }
+    if not isinstance(value, dict) or any(
+        value.get(key) != expected_value for key, expected_value in expected.items()
+    ):
+        return "subscription broker health identity differs from the frozen contract"
+    return None
+
+
+def _private_directory_problem(path: Path, label: str) -> str | None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect {label}: {exc}"
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+        return f"{label} must be a real directory: {path}"
+    if metadata.st_uid != os.geteuid():
+        return f"{label} must be owned by the reproduction user: {path}"
+    if metadata.st_mode & 0o077:
+        return f"{label} must not be accessible by group or other: {path}"
+    return None
+
+
+def _rollout_directory_problem(path: Path) -> str | None:
+    """Require a non-listable root that isolated planner UIDs can traverse."""
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect rollout root: {exc}"
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+        return f"rollout root must be a real directory: {path}"
+    if metadata.st_uid != os.geteuid():
+        return f"rollout root must be owned by the reproduction user: {path}"
+    if stat.S_IMODE(metadata.st_mode) != 0o711:
+        return "rollout root must have exact mode 0711"
+    resolved = path.resolve()
+    for parent in reversed(resolved.parents):
+        try:
+            parent_metadata = parent.stat()
+        except OSError as exc:
+            return f"cannot inspect rollout ancestor {parent}: {exc}"
+        if not stat.S_ISDIR(parent_metadata.st_mode):
+            return f"rollout ancestor must be a directory: {parent}"
+        if parent_metadata.st_mode & stat.S_IXOTH == 0:
+            return f"rollout ancestor must be traversable by the planner: {parent}"
+    return None
+
+
+def _roots_overlap(first: Path, second: Path) -> bool:
+    left = first.resolve()
+    right = second.resolve()
+    return left == right or left in right.parents or right in left.parents
+
+
+def _trusted_codex_problem(path: Path) -> str | None:
+    """Accept the standard root-owned /usr/bin symlink to an immutable CLI file."""
+    try:
+        link = path.lstat()
+        resolved = path.resolve(strict=True)
+        target = resolved.stat()
+    except OSError as exc:
+        return f"cannot inspect codex_bin: {exc}"
+    if not (stat.S_ISREG(link.st_mode) or stat.S_ISLNK(link.st_mode)):
+        return "codex_bin must be a regular file or a controlled symlink"
+    if link.st_uid != os.geteuid():
+        return "codex_bin entry must be owned by the run user"
+    if stat.S_ISREG(link.st_mode) and link.st_mode & 0o022:
+        return "codex_bin entry must not be writable by group or other"
+    if not stat.S_ISREG(target.st_mode):
+        return "codex_bin must resolve to a regular file"
+    if target.st_uid != os.geteuid() or target.st_mode & 0o022:
+        return "codex_bin target must be owned by the run user and not writable"
+    if resolved.name == "codex.js" and resolved.parent.name == "bin":
+        package_root = resolved.parent.parent
+        package_json = package_root / "package.json"
+        native = sorted(
+            package_root.glob("node_modules/@openai/codex-*/vendor/*/bin/codex")
+        )
+        if not package_json.is_file() or package_json.is_symlink() or len(native) != 1:
+            return "Codex package must contain one immutable native binary"
+        for component in (package_json, native[0]):
+            metadata = component.lstat()
+            if (
+                component.is_symlink()
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or metadata.st_mode & 0o022
+            ):
+                return "Codex package inputs must be owned, regular, and immutable"
+    return None
+
+
+def _pinned_codex_identity(path: Path) -> tuple[dict[str, str], str | None]:
+    identity: dict[str, str] = {}
+    try:
+        resolved = path.resolve(strict=True)
+        digest = sha256_file(resolved)
+    except OSError as exc:
+        return identity, f"cannot hash codex_bin: {exc}"
+    identity["path"] = str(resolved)
+    identity["sha256"] = digest
+    if digest != PINNED_CODEX_SHA256:
+        return identity, "codex_bin does not match the pinned 0.147.0 SHA-256"
+    environment = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "NO_COLOR": "1",
+    }
+    try:
+        result = subprocess.run(
+            [str(resolved), "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=environment,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return identity, f"cannot query codex_bin version: {type(exc).__name__}"
+    version = result.stdout.strip()
+    identity["version"] = version
+    if result.returncode != 0 or version != PINNED_CODEX_VERSION:
+        return identity, f"codex_bin version must be exactly {PINNED_CODEX_VERSION}"
+    return identity, None
+
+
+def _managed_codex_config_problem(path: Path = Path("/etc/codex")) -> str | None:
+    """Managed config can override CLI policy, so the frozen run permits none."""
+    if not path.exists() and not path.is_symlink():
+        return None
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect managed Codex config root: {exc}"
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+        return f"managed Codex config root must be absent: {path}"
+    try:
+        entries = list(path.iterdir())
+    except OSError as exc:
+        return f"cannot enumerate managed Codex config root: {exc}"
+    if entries:
+        return f"managed Codex config root must be empty: {path}"
+    return None
+
+
+def _frozen_runtime_problem(label: str, path: Path) -> str | None:
+    expected = FROZEN_RUNTIME_SHA256[label]
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect frozen {label}: {exc}"
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_mode & 0o022
+    ):
+        return f"frozen {label} must be owned, regular, and immutable"
+    try:
+        actual = sha256_file(path)
+    except OSError as exc:
+        return f"cannot hash frozen {label}: {exc}"
+    if actual != expected:
+        return f"frozen {label} does not match its approved SHA-256"
+    return None
+
+
+def _git_snapshot(root: Path) -> dict[str, Any]:
+    value: dict[str, Any] = {"root": str(root)}
+    try:
+        value["commit"] = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        value["dirty"] = bool(
+            subprocess.run(
+                ["git", "-C", str(root), "status", "--porcelain"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+    except (OSError, subprocess.CalledProcessError):
+        value["commit"] = None
+        value["dirty"] = None
+    return value
+
+
+def _navview_problem(path: Path) -> str | None:
+    try:
+        root = ET.parse(path).getroot()
+    except Exception as exc:
+        return f"cannot parse robosuite Omron XML: {exc}"
+    all_cameras = [
+        item for item in root.findall(".//camera") if item.get("name") == "navview"
+    ]
+    direct_cameras = root.findall(
+        "./worldbody/body[@name='base']/camera[@name='navview']"
+    )
+    if len(all_cameras) != 1 or len(direct_cameras) != 1:
+        return (
+            "robosuite Omron base must contain exactly one navview camera as a "
+            "direct child of worldbody/body[@name='base']"
+        )
+    camera = direct_cameras[0]
+    expected = {
+        "mode": "fixed",
+        "pos": "0.2 0 1.6",
+        "xyaxes": "0 -1 0 0.643 0 0.766",
+        "fovy": "75",
+    }
+    mismatches = {
+        key: camera.get(key)
+        for key, value in expected.items()
+        if camera.get(key) != value
+    }
+    return f"navview camera attributes differ: {mismatches}" if mismatches else None
+
+
+def _runtime_import_identity(
+    runtime: RuntimePaths,
+) -> tuple[dict[str, str], str | None]:
+    marker = "RPENT_IMPORT_IDENTITY="
+    robocasa_source = runtime.root / "external_dependencies/robocasa365"
+    robosuite_source = robocasa_source / "robosuite"
+    probe = (
+        "import json, sys; "
+        f"sys.path[:0] = {json.dumps([str(robocasa_source), str(robosuite_source)])}; "
+        "import robocasa, robosuite; "
+        f"print('{marker}' + json.dumps({{'robocasa': robocasa.__file__, "
+        "'robosuite': robosuite.__file__}, sort_keys=True))"
+    )
+    environment = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "MUJOCO_GL": "egl",
+        "PYOPENGL_PLATFORM": "egl",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONSAFEPATH": "1",
+    }
+    try:
+        result = subprocess.run(
+            [str(runtime.sim_python), "-c", probe],
+            cwd=runtime.root,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {}, f"cannot probe simulator imports: {type(exc).__name__}"
+    lines = [line for line in result.stdout.splitlines() if line.startswith(marker)]
+    if result.returncode != 0 or len(lines) != 1:
+        return {}, "simulator import identity probe failed"
+    try:
+        identity = json.loads(lines[0][len(marker) :])
+        expected = {
+            "robocasa": runtime.root
+            / "external_dependencies/robocasa365/robocasa/__init__.py",
+            "robosuite": runtime.root
+            / "external_dependencies/robocasa365/robosuite/robosuite/__init__.py",
+        }
+        for name, expected_path in expected.items():
+            imported = Path(identity[name])
+            if not imported.samefile(expected_path):
+                return identity, f"simulator imports unexpected {name}: {imported}"
+    except (KeyError, OSError, TypeError, ValueError):
+        return {}, "simulator import identity is invalid"
+    return identity, None
+
+
+def doctor(
+    config: ExecutorConfig,
+    *,
+    verify_checkpoint: bool = False,
+    verify_isolation: bool = False,
+) -> dict[str, Any]:
+    """Return fail-closed runtime diagnostics without starting a simulator."""
+    problems: list[str] = []
+    runtime = config.runtime
+    if not config.preliminary_local_runtime:
+        problems.append(
+            "the external RLDX snapshot adapter is preliminary; pass the explicit "
+            "preliminary-local-runtime acknowledgement"
+        )
+    if os.geteuid() != 0:
+        problems.append("the audited local isolation launcher requires root")
+    if problem := _private_directory_problem(config.results_root, "results root"):
+        problems.append(problem)
+    if problem := _rollout_directory_problem(config.rollout_root):
+        problems.append(problem)
+    if _roots_overlap(config.results_root, config.rollout_root):
+        problems.append("results root and rollout root must not overlap")
+    transport = config.planner_transport
+    normalized_base_url = normalize_responses_base_url(transport.request_base_url)
+    planner_adapter: PlannerAdapter | None = None
+    planner_files: dict[str, Path] = {}
+    try:
+        planner_adapter = _planner_adapter(config.planner_profile)
+    except RuntimeError as exc:
+        problems.append(str(exc))
+    else:
+        planner_files = planner_adapter.required_files(config)
+    required_files = {
+        "sim_python": runtime.sim_python,
+        "driver": runtime.driver,
+        "readiness": runtime.readiness,
+        "deadline": runtime.deadline,
+        "isolation_launcher": runtime.isolation_launcher,
+        "artifact_builder": runtime.artifact_builder,
+        "interactive_env": runtime.root / "migration/robocasa_interactive_env.py",
+        "rldx_skill": runtime.root / "migration/rldx_skill.py",
+        "preliminary_driver_adapter": Path(__file__).with_name("preliminary_driver.py"),
+        "deadline_supervisor_adapter": Path(__file__).with_name(
+            "deadline_supervisor.py"
+        ),
+        "secure_script_adapter": Path(__file__).with_name("secure_script.py"),
+        "navview_patch": (
+            Path(__file__).resolve().parents[3]
+            / "robots/robocasa/patches/robosuite_navview.patch"
+        ),
+    }
+    required_files.update(planner_files)
+    trusted_symlink_labels = {"sim_python"}
+    if planner_adapter is not None:
+        trusted_symlink_labels.update(planner_adapter.trusted_symlink_labels)
+    for label, path in required_files.items():
+        if path.is_symlink() and label not in trusted_symlink_labels:
+            problems.append(f"{label} must not be a symlink: {path}")
+        if not path.is_file():
+            problems.append(f"missing {label}: {path}")
+    for label in FROZEN_RUNTIME_SHA256:
+        path = required_files[label]
+        if path.is_file() and (problem := _frozen_runtime_problem(label, path)):
+            problems.append(problem)
+    codex_identity: dict[str, str] = {}
+    managed_config = {"path": "/etc/codex", "empty_or_absent": False}
+    if planner_adapter is not None and planner_adapter.backend == "codex":
+        if problem := _trusted_codex_problem(config.codex_bin):
+            problems.append(problem)
+        codex_identity, identity_problem = _pinned_codex_identity(config.codex_bin)
+        if identity_problem is not None:
+            problems.append(identity_problem)
+        if problem := _managed_codex_config_problem():
+            problems.append(problem)
+        else:
+            managed_config["empty_or_absent"] = True
+    if not runtime.model.is_dir():
+        problems.append(f"missing RLDX checkpoint: {runtime.model}")
+    if not runtime.vlm_metadata.is_dir():
+        problems.append(f"missing VLM metadata: {runtime.vlm_metadata}")
+    if problem := _navview_problem(runtime.navview_xml):
+        problems.append(problem)
+    runtime_imports, import_problem = _runtime_import_identity(runtime)
+    if import_problem is not None:
+        problems.append(import_problem)
+    if problem := _trusted_credential(transport.credential_file):
+        problems.append(problem)
+    broker_health_problem = _broker_health_problem(config)
+    if broker_health_problem is not None:
+        problems.append(broker_health_problem)
+    problems.extend(validate_memory_pack(config.memory_root))
+
+    shard_rows: dict[str, dict[str, Any]] = {}
+    for name, expected in CHECKPOINT_SHA256.items():
+        path = runtime.model / name
+        row: dict[str, Any] = {"path": str(path), "expected_sha256": expected}
+        if not path.is_file():
+            problems.append(f"missing checkpoint shard: {path}")
+        else:
+            row["size"] = path.stat().st_size
+        shard_rows[name] = row
+    attestation = None
+    attestation_source = None
+    if verify_checkpoint:
+        try:
+            attestation = _load_checkpoint_attestation(config)
+        except (OSError, UnicodeError, ValueError):
+            try:
+                attestation = verify_checkpoint_identity(
+                    runtime.model,
+                    runtime.vlm_metadata,
+                )
+            except (OSError, UnicodeError, ValueError) as exc:
+                problems.append(f"checkpoint verification failed: {exc}")
+            else:
+                attestation_source = "full_hash"
+        else:
+            attestation_source = "reused_attestation"
+        if attestation is not None:
+            for name, row in shard_rows.items():
+                row["sha256"] = attestation["files"][f"model/{name}"]["sha256"]
+    scripts = {
+        label: sha256_file(path)
+        for label, path in required_files.items()
+        if label not in planner_files and path.is_file()
+    }
+    if attestation is not None and attestation_source == "full_hash" and not problems:
+        try:
+            _write_private_json(checkpoint_attestation_path(config), attestation)
+        except (OSError, ValueError) as exc:
+            problems.append(f"cannot publish checkpoint attestation: {exc}")
+    isolation_attestation = None
+    if verify_isolation and not problems:
+        from .preflight import run_isolation_preflight
+
+        try:
+            isolation_attestation = run_isolation_preflight(config)
+        except (OSError, RuntimeError, ValueError) as exc:
+            problems.append(f"isolation preflight failed: {exc}")
+    return {
+        "ok": not problems,
+        "release_ready": False,
+        "runtime_kind": "preliminary_external_snapshot",
+        "problems": problems,
+        "runtime_root": str(runtime.root),
+        "runtime_imports": runtime_imports,
+        "planner_profile": config.planner_profile.name,
+        "planner_transport": {
+            **transport.manifest_identity(),
+            "request_base_url": normalized_base_url,
+            "broker_health_verified": (
+                transport.uses_broker and broker_health_problem is None
+            ),
+        },
+        "codex": codex_identity,
+        "managed_codex_config": managed_config,
+        "isolation_preflight": {
+            "verified": isolation_attestation is not None,
+            "attestation_sha256": (
+                isolation_attestation.get("attestation_sha256")
+                if isolation_attestation is not None
+                else None
+            ),
+        },
+        "navview_xml": str(runtime.navview_xml),
+        "scripts": scripts,
+        "runtime_git": _git_snapshot(runtime.root),
+        "robosuite_git": _git_snapshot(runtime.navview_xml.parents[4]),
+        "rpent_git": _git_snapshot(Path(__file__).resolve().parents[3]),
+        "memory": {
+            "source": config.memory_source,
+            "revision": config.memory_revision,
+            "manifest_sha256": sha256_file(config.memory_root / "manifest.json")
+            if (config.memory_root / "manifest.json").is_file()
+            else None,
+        },
+        "checkpoint": {
+            "verified": attestation is not None and not problems,
+            "verification_source": attestation_source,
+            "fingerprint": (
+                attestation["fingerprint"]
+                if attestation is not None
+                else expected_fingerprint()
+            ),
+            "attestation": str(checkpoint_attestation_path(config)),
+            "shards": shard_rows,
+        },
+    }
+
+
+def _stage_memory(config: ExecutorConfig, cell: Cell, workdir: Path) -> bool:
+    if problems := validate_memory_pack(config.memory_root):
+        raise RuntimeError(
+            "memory pack changed after preflight: " + "; ".join(problems)
+        )
+    manifest = _read_json(config.memory_root / "manifest.json")
+    entries = manifest.get("entries")
+    entry = (
+        next(
+            (
+                item
+                for item in entries
+                if isinstance(item, dict) and item.get("task") == cell.task
+            ),
+            None,
+        )
+        if isinstance(entries, list)
+        else None
+    )
+    if not isinstance(entry, dict) or not isinstance(entry.get("files"), dict):
+        raise RuntimeError(f"memory manifest has no valid entry for {cell.task}")
+    expected_hashes = entry["files"]
+    source = config.memory_root / cell.task
+    destination = workdir / "task_memory"
+    destination.mkdir(mode=0o700)
+    files = sorted(source.iterdir())
+    missing = cell.task in EMPTY_MEMORY_TASKS
+    if missing and files:
+        raise RuntimeError(f"empty-memory task has staged files: {cell.task}")
+    if not missing and {path.name for path in files} != {
+        f"{cell.task}_s0.json",
+        f"{cell.task}_s0.jsonl",
+    }:
+        raise RuntimeError(f"task memory is not an exact pair: {cell.task}")
+    for source_path in files:
+        if source_path.is_symlink() or not source_path.is_file():
+            raise RuntimeError(f"unsafe task memory source: {source_path}")
+        target = destination / source_path.name
+        shutil.copyfile(source_path, target)
+        if sha256_file(target) != expected_hashes.get(source_path.name):
+            raise RuntimeError(f"task memory changed while staging: {cell.task}")
+        os.chown(target, 0, 0)
+        os.chmod(target, 0o444)
+    os.chown(destination, 0, 0)
+    os.chmod(destination, 0o555)
+    return not missing
+
+
+def _reset_seed(cell: Cell) -> int | None:
+    if cell.split is Split.COMPOSITE_SEEN:
+        return 4_200_000 + cell.seed
+    return None
+
+
+def _driver_environment(
+    config: ExecutorConfig, gpu: int, cell: Cell | None = None
+) -> dict[str, str]:
+    environment = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "LD_LIBRARY_PATH": "/usr/local/nvidia/lib:/usr/local/nvidia/lib64",
+        "VK_DRIVER_FILES": "/etc/vulkan/icd.d/nvidia_icd.json",
+        "VK_ICD_FILENAMES": "/etc/vulkan/icd.d/nvidia_icd.json",
+        "CUDA_VISIBLE_DEVICES": str(gpu),
+        "MUJOCO_GL": "egl",
+        "PYOPENGL_PLATFORM": "egl",
+        "PYTHONHASHSEED": "0",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONSAFEPATH": "1",
+        "NO_ALBUMENTATIONS_UPDATE": "1",
+        "HF_HUB_OFFLINE": "1",
+        "TRANSFORMERS_OFFLINE": "1",
+        "TOKENIZERS_PARALLELISM": "false",
+        "RLDX_MODEL_PATH": str(config.runtime.model),
+        "RLDX_VLM_PATH": str(config.runtime.vlm_metadata),
+        "RLDX_CHECKPOINT_ATTESTATION": str(checkpoint_attestation_path(config)),
+        "RLDX_CHECKPOINT_FINGERPRINT": expected_fingerprint(),
+        "RLDX_ATTN_IMPL": "sdpa",
+        "RLDX_PRELOAD_VLA": "1",
+        "RLDX_ALLOW_RESET": "0",
+        "RLDX_PERCEPTION_ISOLATION": "1",
+        "RLDX_MAX_CHUNKS": "40",
+        "RLDX_SETTLE_PATIENCE": "999",
+    }
+    if cell is not None and (reset_seed := _reset_seed(cell)) is not None:
+        environment["RLDX_RESET_SEED"] = str(reset_seed)
+    return environment
+
+
+def ensure_execution_run_manifest(
+    config: ExecutorConfig,
+    checkpoint_attestation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Re-attest immutable inputs and bind them to this results root."""
+    if checkpoint_attestation is None:
+        checkpoint_attestation = _load_checkpoint_attestation(config)
+    return ensure_run_manifest(
+        config,
+        checkpoint_attestation,
+    )
+
+
+def _stop_process(process: subprocess.Popen[Any], grace_seconds: float = 5.0) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=grace_seconds)
+
+
+def _navview_rollout_problem(workdir: Path) -> str | None:
+    done_steps: list[int] = []
+    for path in workdir.glob("done_*.flag"):
+        try:
+            done_steps.append(int(path.stem.split("_", 1)[1]))
+        except (IndexError, ValueError):
+            return f"unexpected navview commit marker: {path.name}"
+    if not done_steps or 0 not in done_steps:
+        return "initial navview commit is missing"
+    for step in done_steps:
+        suffix = f"{step:02d}"
+        for name in (f"image_nav_{suffix}.png", f"image_nav_floor_{suffix}.png"):
+            path = workdir / name
+            try:
+                metadata = path.lstat()
+            except OSError:
+                return f"committed step {step} is missing {name}"
+            if (
+                path.is_symlink()
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or metadata.st_size <= 0
+            ):
+                return f"committed step {step} has unsafe {name}"
+    latest = workdir / f"world_nav_{max(done_steps):02d}.npy"
+    try:
+        metadata = latest.lstat()
+    except OSError:
+        return "latest committed step has no navview world map"
+    if (
+        latest.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_size <= 0
+    ):
+        return "latest navview world map is unsafe"
+    return None
+
+
+def _latched_success_exit(workdir: Path, return_code: int | None) -> bool:
+    """Recognize only the adapter's committed, zero-exit success shutdown."""
+    if return_code != 0:
+        return False
+    steps: list[int] = []
+    for marker in workdir.glob("done_*.flag"):
+        try:
+            steps.append(int(marker.stem.split("_", 1)[1]))
+        except (IndexError, ValueError):
+            return False
+    if not steps:
+        return False
+    suffix = f"{max(steps):02d}"
+    state_path = workdir / f"state_{suffix}.json"
+    log_path = workdir / f"log_{suffix}.json"
+    trace_path = workdir / "command_trace.jsonl"
+    for path in (state_path, log_path, trace_path):
+        try:
+            metadata = path.lstat()
+        except OSError:
+            return False
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+            return False
+    try:
+        state = _read_json(state_path)
+    except (OSError, ValueError):
+        return False
+    return state.get("success") is True
+
+
+def _timeout_driver_exit_expected(
+    deadline_attestation: dict[str, Any] | None,
+) -> bool:
+    """Accept only the adapter deadline exit or an attested supervisor SIGKILL."""
+    if deadline_attestation is None:
+        return False
+    return (
+        timeout_driver_exit_problem(
+            deadline_attestation.get("driver_stop"),
+            deadline_attestation.get("driver_return_code_before_stop"),
+            success_latched=deadline_attestation.get("success_at_deadline"),
+        )
+        is None
+    )
+
+
+def _observe_driver_exit(
+    process: subprocess.Popen[Any],
+    *,
+    termination: str,
+    timeout_seconds: float,
+) -> int | None:
+    """Reap a timeout-killed driver before the fallback stop path can signal it."""
+    return_code = process.poll()
+    if return_code is not None or termination != "planner_timeout":
+        return return_code
+    try:
+        return process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return None
+
+
+@dataclass(frozen=True)
+class _CodexPlannerAdapter:
+    """Audited Codex CLI implementation of the formal planner boundary."""
+
+    backend: str = "codex"
+    audit_id: str = "codex-cli-0.147.0/outer-landlock-v1"
+    trusted_symlink_labels: frozenset[str] = frozenset({"codex_bin"})
+
+    def required_files(self, config: ExecutorConfig) -> dict[str, Path]:
+        return {"codex_bin": config.codex_bin}
+
+    def build_command(
+        self,
+        config: ExecutorConfig,
+        *,
+        workdir: Path,
+        run_id: str,
+        cell: Cell,
+    ) -> list[str]:
+        return _codex_planner_command(config, workdir=workdir, run_id=run_id, cell=cell)
+
+
+_PLANNER_ADAPTERS: dict[str, PlannerAdapter] = {
+    "codex": _CodexPlannerAdapter(),
+}
+
+
+def _planner_adapter(profile: PlannerProfile) -> PlannerAdapter:
+    if not is_audited_profile(profile):
+        raise RuntimeError(
+            f"planner profile {profile.name!r} ({profile.backend}) is declared "
+            "but not audited for formal cell execution"
+        )
+    try:
+        return _PLANNER_ADAPTERS[profile.backend]
+    except KeyError as exc:
+        raise RuntimeError(
+            f"no audited PlannerAdapter is registered for backend {profile.backend!r}"
+        ) from exc
+
+
+def _planner_command(
+    config: ExecutorConfig,
+    *,
+    workdir: Path,
+    run_id: str,
+    cell: Cell,
+) -> list[str]:
+    """Build a secret-free argv through the profile-selected adapter."""
+    return _planner_adapter(config.planner_profile).build_command(
+        config, workdir=workdir, run_id=run_id, cell=cell
+    )
+
+
+def _codex_planner_command(
+    config: ExecutorConfig,
+    *,
+    workdir: Path,
+    run_id: str,
+    cell: Cell,
+) -> list[str]:
+    identity = zlib.crc32(f"{run_id}|{cell.tag}".encode())
+    uid = 100000 + identity % 2_000_000_000
+    prompt = render_formal_prompt(
+        task=cell.task,
+        workdir=".",
+        task_memory_dir="task_memory",
+    )
+    transport = config.planner_transport
+    base_url = transport.request_base_url
+    provider_id = transport.provider_id
+    # The launcher applies an irreversible outer Landlock boundary before
+    # Codex starts.  A full-write Codex filesystem view avoids stacking bwrap
+    # or a second Landlock layer; the explicit network restriction still makes
+    # Codex install seccomp on every generated command.
+    return [
+        str(config.runtime.sim_python),
+        str(Path(__file__).with_name("sandbox.py")),
+        "--launcher",
+        str(config.runtime.isolation_launcher),
+        "--launcher-sha256",
+        FROZEN_RUNTIME_SHA256["isolation_launcher"],
+        "--rollout-root",
+        str(config.rollout_root),
+        "--",
+        "--uid",
+        str(uid),
+        "--gid",
+        str(uid),
+        "--workdir",
+        str(workdir),
+        "--key-file",
+        str(transport.credential_file),
+        "--",
+        str(config.codex_bin),
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--strict-config",
+        "--ephemeral",
+        "--json",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--skip-git-repo-check",
+        "--disable",
+        "browser_use",
+        "--disable",
+        "browser_use_external",
+        "--disable",
+        "browser_use_full_cdp_access",
+        "--disable",
+        "in_app_browser",
+        "--disable",
+        "image_generation",
+        "--disable",
+        "multi_agent",
+        "--disable",
+        "multi_agent_v2",
+        "--disable",
+        "standalone_web_search",
+        "--disable",
+        "apps",
+        "--disable",
+        "plugins",
+        "--disable",
+        "remote_plugin",
+        "--disable",
+        "plugin_sharing",
+        "--disable",
+        "recommended_plugins",
+        "--disable",
+        "skill_search",
+        "--disable",
+        "skill_mcp_dependency_install",
+        "--disable",
+        "tool_suggest",
+        "-C",
+        ".",
+        "-c",
+        'default_permissions="rpent_outer_landlock"',
+        "-c",
+        'permissions.rpent_outer_landlock.filesystem={":root"="write"}',
+        "-c",
+        "permissions.rpent_outer_landlock.network.enabled=false",
+        "-c",
+        'web_search="disabled"',
+        "-c",
+        "allow_login_shell=false",
+        "-c",
+        "analytics.enabled=false",
+        "-c",
+        "feedback.enabled=false",
+        "-c",
+        "check_for_update_on_startup=false",
+        "-c",
+        'otel.trace_exporter="none"',
+        "-c",
+        "tools.experimental_request_user_input.enabled=false",
+        "-c",
+        f"model_provider={provider_id}",
+        "-c",
+        f"model={config.planner_profile.model}",
+        "-c",
+        f"model_reasoning_effort={config.planner_profile.reasoning_effort}",
+        "-c",
+        "memories.use_memories=false",
+        "-c",
+        "memories.generate_memories=false",
+        "-c",
+        "skills.bundled.enabled=false",
+        "-c",
+        "skills.include_instructions=false",
+        "-c",
+        "shell_environment_policy.inherit=core",
+        "-c",
+        "shell_environment_policy.ignore_default_excludes=false",
+        "-c",
+        'shell_environment_policy.exclude=["RLDX_PLANNER_API_KEY"]',
+        "-c",
+        f"model_providers.{provider_id}.name={json.dumps(transport.provider_name)}",
+        "-c",
+        f"model_providers.{provider_id}.base_url={json.dumps(base_url)}",
+        "-c",
+        f"model_providers.{provider_id}.wire_api=responses",
+        "-c",
+        f"model_providers.{provider_id}.env_key=RLDX_PLANNER_API_KEY",
+        "-c",
+        f"model_providers.{provider_id}.requires_openai_auth=false",
+        "-c",
+        (
+            f"model_providers.{provider_id}.request_max_retries="
+            f"{CODEX_REQUEST_MAX_RETRIES}"
+        ),
+        "-c",
+        (
+            f"model_providers.{provider_id}.stream_max_retries="
+            f"{CODEX_STREAM_MAX_RETRIES}"
+        ),
+        "-c",
+        (
+            f"model_providers.{provider_id}.stream_idle_timeout_ms="
+            f"{CODEX_STREAM_IDLE_TIMEOUT_MS}"
+        ),
+        prompt,
+    ]
+
+
+def _external_script_command(
+    config: ExecutorConfig, label: str, arguments: list[str]
+) -> list[str]:
+    source = {
+        "readiness": config.runtime.readiness,
+        "deadline": config.runtime.deadline,
+        "artifact_builder": config.runtime.artifact_builder,
+    }[label]
+    return [
+        str(config.runtime.sim_python),
+        str(Path(__file__).with_name("secure_script.py")),
+        "--source",
+        str(source),
+        "--sha256",
+        FROZEN_RUNTIME_SHA256[label],
+        "--",
+        *arguments,
+    ]
+
+
+def _deadline_script_command(
+    config: ExecutorConfig,
+    *,
+    workdir: Path,
+    run_id: str,
+    driver_identity: dict[str, int | str],
+    arguments: list[str],
+) -> list[str]:
+    return [
+        str(config.runtime.sim_python),
+        str(Path(__file__).with_name("deadline_supervisor.py")),
+        "--source",
+        str(config.runtime.deadline),
+        "--sha256",
+        FROZEN_RUNTIME_SHA256["deadline"],
+        "--workdir",
+        str(workdir),
+        "--run-id",
+        run_id,
+        "--driver-pid",
+        str(driver_identity["pid"]),
+        "--driver-pgid",
+        str(driver_identity["pgid"]),
+        "--driver-start-time",
+        str(driver_identity["start_time_ticks"]),
+        "--",
+        *arguments,
+    ]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _deadline_attestation(
+    workdir: Path,
+    *,
+    planner_status: dict[str, Any],
+    termination: str,
+    run_id: str,
+    driver_identity: dict[str, int | str],
+    driver_return_code_before_stop: int | None,
+    expected_timeout_seconds: int,
+    expected_external_deadline_sha256: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Validate the commit gate and, for timeout, its frozen journal prefix."""
+    try:
+        contract, contract_sha256 = _read_trusted_json(workdir / CONTRACT_NAME)
+    except Exception as exc:
+        return None, f"deadline contract is missing or invalid: {type(exc).__name__}"
+    supervisor = planner_status.get("deadline_supervisor")
+    expected_driver = {
+        key: driver_identity[key] for key in ("pid", "pgid", "start_time_ticks")
+    }
+    started_ns = contract.get("started_monotonic_ns")
+    deadline_ns = contract.get("deadline_monotonic_ns")
+    timeout_ns = contract.get("timeout_ns")
+    expected_contract_keys = {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "started_monotonic_ns",
+        "deadline_monotonic_ns",
+        "timeout_ns",
+        "driver",
+        "external_deadline_sha256",
+    }
+    expected_supervisor_keys = {
+        "protocol",
+        "run_id",
+        "nonce",
+        "fired",
+        "contract_sha256",
+        "freeze_sha256",
+        "error",
+    }
+    if (
+        set(contract) != expected_contract_keys
+        or contract.get("schema_version") != 1
+        or contract.get("protocol") != DEADLINE_PROTOCOL
+        or contract.get("run_id") != run_id
+        or not isinstance(contract.get("nonce"), str)
+        or len(contract["nonce"]) != 32
+        or any(character not in "0123456789abcdef" for character in contract["nonce"])
+        or contract.get("driver") != expected_driver
+        or contract.get("external_deadline_sha256") != expected_external_deadline_sha256
+        or type(started_ns) is not int
+        or type(deadline_ns) is not int
+        or type(timeout_ns) is not int
+        or timeout_ns != expected_timeout_seconds * 1_000_000_000
+        or deadline_ns != started_ns + timeout_ns
+        or not isinstance(supervisor, dict)
+        or set(supervisor) != expected_supervisor_keys
+        or supervisor.get("protocol") != DEADLINE_PROTOCOL
+        or supervisor.get("run_id") != run_id
+        or supervisor.get("nonce") != contract.get("nonce")
+        or supervisor.get("contract_sha256") != contract_sha256
+        or supervisor.get("error") is not None
+    ):
+        return None, "deadline contract disagrees with the planner supervisor"
+
+    timed_out = termination == "planner_timeout"
+    if supervisor.get("fired") is not timed_out:
+        return None, "deadline fired state disagrees with planner termination"
+    result = {
+        "protocol": DEADLINE_PROTOCOL,
+        "contract_sha256": contract_sha256,
+        "seal_sha256": None,
+        "freeze_sha256": None,
+        "deadline_monotonic_ns": deadline_ns,
+        "timeout_ns": timeout_ns,
+        "driver": expected_driver,
+        "driver_stop": None,
+        "driver_return_code_before_stop": None,
+        "prefix_step": None,
+        "success_at_deadline": None,
+    }
+    if not timed_out:
+        if supervisor.get("freeze_sha256") is not None:
+            return None, "completed planner unexpectedly has deadline freeze evidence"
+        for name in (SEAL_NAME, FREEZE_NAME):
+            if (workdir / name).exists() or (workdir / name).is_symlink():
+                return None, "completed planner has a sealed deadline gate"
+        return result, None
+
+    try:
+        seal, seal_sha256 = _read_trusted_json(workdir / SEAL_NAME)
+        freeze, freeze_sha256 = _read_trusted_json(workdir / FREEZE_NAME)
+        current_prefix = scan_committed_prefix(workdir)
+    except Exception as exc:
+        return None, f"deadline freeze is missing or invalid: {type(exc).__name__}"
+    frozen_ns = freeze.get("frozen_monotonic_ns")
+    sealed_ns = seal.get("sealed_monotonic_ns")
+    prefix_fields = {
+        "prefix_step",
+        "success",
+        "final_state_sha256",
+        "command_trace_sha256",
+        "raw_command_trace_sha256",
+        "files_sha256",
+    }
+    expected_seal_keys = {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "deadline_monotonic_ns",
+        "sealed_monotonic_ns",
+        "contract_sha256",
+    }
+    expected_freeze_keys = {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "deadline_monotonic_ns",
+        "frozen_monotonic_ns",
+        "contract_sha256",
+        "seal_sha256",
+        "driver",
+        "driver_stop",
+        "dropped_done_steps",
+        *prefix_fields,
+    }
+    driver_stop = freeze.get("driver_stop")
+    dropped_done_steps = freeze.get("dropped_done_steps")
+    if (
+        supervisor.get("freeze_sha256") != freeze_sha256
+        or set(seal) != expected_seal_keys
+        or seal.get("schema_version") != 1
+        or seal.get("protocol") != DEADLINE_PROTOCOL
+        or seal.get("run_id") != run_id
+        or seal.get("nonce") != contract.get("nonce")
+        or seal.get("contract_sha256") != contract_sha256
+        or seal.get("deadline_monotonic_ns") != deadline_ns
+        or type(sealed_ns) is not int
+        or sealed_ns < deadline_ns
+        or set(freeze) != expected_freeze_keys
+        or freeze.get("schema_version") != 1
+        or freeze.get("protocol") != DEADLINE_PROTOCOL
+        or freeze.get("run_id") != run_id
+        or freeze.get("nonce") != contract.get("nonce")
+        or freeze.get("driver") != expected_driver
+        or freeze.get("contract_sha256") != contract_sha256
+        or freeze.get("seal_sha256") != seal_sha256
+        or freeze.get("deadline_monotonic_ns") != deadline_ns
+        or type(frozen_ns) is not int
+        or frozen_ns < sealed_ns
+        or driver_stop_problem(driver_stop) is not None
+        or not isinstance(dropped_done_steps, list)
+        or any(type(step) is not int for step in dropped_done_steps)
+        or dropped_done_steps != sorted(set(dropped_done_steps))
+        or any(step <= current_prefix["prefix_step"] for step in dropped_done_steps)
+        or any(freeze.get(key) != current_prefix.get(key) for key in prefix_fields)
+    ):
+        return None, "deadline freeze does not match the sealed committed prefix"
+    result.update(
+        {
+            "freeze_sha256": freeze_sha256,
+            "seal_sha256": seal_sha256,
+            "driver_stop": driver_stop,
+            "driver_return_code_before_stop": driver_return_code_before_stop,
+            "prefix_step": freeze["prefix_step"],
+            "success_at_deadline": freeze["success"],
+        }
+    )
+    return result, None
+
+
+def _archive_workdir(workdir: Path, destination_descriptor: int) -> dict[str, str]:
+    allowed_prefixes = (
+        "state_",
+        "log_",
+        "done_",
+        "camera_meta",
+        "agent.",
+        "driver.",
+        "planner_",
+        "driver_ready_",
+        "_agent_audit",
+        "command_trace",
+        "_deadline_",
+    )
+    archived: dict[str, str] = {}
+    for path in workdir.iterdir():
+        if (
+            path.is_file()
+            and not path.is_symlink()
+            and path.name.startswith(allowed_prefixes)
+        ):
+            data = path.read_bytes()
+            atomic_write_artifact_file(destination_descriptor, path.name, data)
+            archived[path.name] = hashlib.sha256(data).hexdigest()
+    return archived
+
+
+def _remove_workdir(workdir: Path, rollout_root: Path) -> None:
+    resolved = workdir.resolve()
+    resolved.relative_to(rollout_root.resolve())
+    if resolved == rollout_root.resolve():
+        raise RuntimeError("refusing to remove the rollout root")
+    shutil.rmtree(resolved)
+
+
+def _prepare_rollout_parent(path: Path, rollout_root: Path) -> None:
+    """Create root-owned traverse-only intermediate rollout directories."""
+    root = rollout_root.resolve()
+    resolved = path.resolve(strict=False)
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError(f"rollout parent escapes rollout root: {path}") from exc
+    current = root
+    for component in relative.parts:
+        current = current / component
+        try:
+            current.mkdir(mode=0o711)
+        except FileExistsError:
+            pass
+        metadata = current.lstat()
+        if (
+            current.is_symlink()
+            or not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != 0
+            or stat.S_IMODE(metadata.st_mode) != 0o711
+        ):
+            raise RuntimeError(f"unsafe rollout parent: {current}")
+
+
+def execute_cell(config: ExecutorConfig, cell: Cell, *, gpu: int) -> Execution:
+    """Run one cell and publish a completion manifest only after validation."""
+    runtime = config.runtime
+    checkpoint_attestation = _load_checkpoint_attestation(config)
+    run_manifest = ensure_execution_run_manifest(
+        config, checkpoint_attestation=checkpoint_attestation
+    )
+    run_config_sha256 = run_manifest["run_config_sha256"]
+    with secure_artifact_directory(config.results_root, cell, create=True) as (
+        cell_dir,
+        _cell_descriptor,
+    ):
+        pass
+    run_id = f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}_{uuid.uuid4().hex[:12]}"
+    workdir_parent = config.rollout_root / cell.split.value / cell.tag
+    _prepare_rollout_parent(workdir_parent, config.rollout_root)
+    workdir = workdir_parent / run_id
+    workdir.mkdir(mode=0o700)
+    os.chown(workdir, 0, 0)
+    os.chmod(workdir, 0o700)
+    memory_available = _stage_memory(config, cell, workdir)
+    prompt = render_formal_prompt(
+        task=cell.task, workdir=str(workdir), task_memory_dir="task_memory"
+    )
+    (workdir / "_prompt.md").write_text(prompt + "\n", encoding="utf-8")
+    os.chmod(workdir / "_prompt.md", 0o600)
+
+    driver_log_path = workdir / "driver.log"
+    driver_log = driver_log_path.open("wb")
+    try:
+        driver = subprocess.Popen(
+            [
+                str(runtime.sim_python),
+                str(Path(__file__).with_name("preliminary_driver.py")),
+                "--driver-source",
+                str(runtime.driver),
+                "--driver-sha256",
+                FROZEN_RUNTIME_SHA256["driver"],
+                "--interactive-env-sha256",
+                FROZEN_RUNTIME_SHA256["interactive_env"],
+                "--rldx-skill-sha256",
+                FROZEN_RUNTIME_SHA256["rldx_skill"],
+                "--env",
+                cell.task,
+                "--split",
+                "target",
+                "--seed",
+                str(cell.seed),
+                "--workdir",
+                str(workdir),
+                "--run-id",
+                run_id,
+            ],
+            cwd=runtime.root,
+            env=_driver_environment(config, gpu, cell),
+            stdout=driver_log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    except BaseException:
+        driver_log.close()
+        raise
+    termination = "driver_startup_failed"
+    planner_rc = EXIT_RETRYABLE_INFRA
+    planner_status: dict[str, Any] = {}
+    deadline_attestation: dict[str, Any] | None = None
+    driver_return_code_before_stop: int | None = None
+    observed_driver = process_identity(driver.pid)
+    driver_identity = (
+        {key: observed_driver[key] for key in ("pid", "pgid", "start_time_ticks")}
+        if observed_driver is not None
+        else None
+    )
+    try:
+        startup_rc = (
+            subprocess.run(
+                _external_script_command(
+                    config,
+                    "readiness",
+                    [
+                        "--pid",
+                        str(driver.pid),
+                        "--workdir",
+                        str(workdir),
+                        "--timeout-seconds",
+                        str(config.startup_timeout_seconds),
+                        "--status",
+                        str(workdir / "driver_ready_status.json"),
+                    ],
+                ),
+                cwd=runtime.root,
+                check=False,
+            ).returncode
+            if driver_identity is not None
+            else EXIT_RETRYABLE_INFRA
+        )
+        if startup_rc == 0 and driver_identity is not None:
+            planner = _planner_command(
+                config, workdir=workdir, run_id=run_id, cell=cell
+            )
+            planner_rc = subprocess.run(
+                _deadline_script_command(
+                    config,
+                    workdir=workdir,
+                    run_id=run_id,
+                    driver_identity=driver_identity,
+                    arguments=[
+                        "--timeout-seconds",
+                        str(SPLITS[cell.split].timeout_seconds),
+                        "--kill-after-seconds",
+                        str(config.kill_after_seconds),
+                        "--stdout",
+                        str(workdir / "agent.log"),
+                        "--stderr",
+                        str(workdir / "agent.stderr.log"),
+                        "--status",
+                        str(workdir / "planner_status.json"),
+                        "--",
+                        *planner,
+                    ],
+                ),
+                cwd=runtime.root,
+                check=False,
+            ).returncode
+            planner_status = _read_json(workdir / "planner_status.json")
+            termination = str(
+                planner_status.get("termination_cause") or "wrapper_error"
+            )
+            driver_return_code_before_stop = _observe_driver_exit(
+                driver,
+                termination=termination,
+                timeout_seconds=config.kill_after_seconds,
+            )
+        else:
+            planner_rc = startup_rc
+    finally:
+        _stop_process(driver)
+        driver_log.close()
+
+    deadline_problem = None
+    if termination in {"planner_completed", "planner_timeout"}:
+        if driver_identity is None:
+            deadline_problem = "driver identity was unavailable"
+        else:
+            deadline_attestation, deadline_problem = _deadline_attestation(
+                workdir,
+                planner_status=planner_status,
+                termination=termination,
+                run_id=run_id,
+                driver_identity=driver_identity,
+                driver_return_code_before_stop=driver_return_code_before_stop,
+                expected_timeout_seconds=SPLITS[cell.split].timeout_seconds,
+                expected_external_deadline_sha256=FROZEN_RUNTIME_SHA256["deadline"],
+            )
+        if deadline_problem is not None:
+            termination = "wrapper_error"
+    supervised_timeout = (
+        termination == "planner_timeout" and deadline_attestation is not None
+    )
+    timeout_driver_exit_expected = supervised_timeout and _timeout_driver_exit_expected(
+        deadline_attestation
+    )
+    driver_exit_expected = (
+        timeout_driver_exit_expected
+        if supervised_timeout
+        else _latched_success_exit(workdir, driver_return_code_before_stop)
+    )
+    unexpected_driver_exit = (
+        not driver_exit_expected
+        if supervised_timeout
+        else driver_return_code_before_stop is not None and not driver_exit_expected
+    )
+    if unexpected_driver_exit and termination != "planner_protocol_error":
+        termination = "driver_runtime_failed"
+    if _navview_rollout_problem(workdir) is not None:
+        termination = "driver_runtime_failed"
+
+    build_dir = workdir / "_built_artifacts"
+    build_dir.mkdir(mode=0o700)
+    builder_termination = (
+        termination if termination in BUILDER_TERMINATIONS else "planner_failed"
+    )
+    build = _external_script_command(
+        config,
+        "artifact_builder",
+        [
+            "--workdir",
+            str(workdir),
+            "--output-dir",
+            str(build_dir),
+            "--task",
+            cell.task,
+            "--seed",
+            str(cell.seed),
+            "--agent-rc",
+            str(planner_rc),
+            "--termination-cause",
+            builder_termination,
+        ],
+    )
+    if not memory_available:
+        build.append("--task-memory-missing")
+    builder_rc = subprocess.run(build, cwd=runtime.root, check=False).returncode
+    with secure_artifact_subdirectory(
+        config.results_root, cell, "run_logs", cell.tag, run_id
+    ) as (log_dir, log_descriptor):
+        archived = _archive_workdir(workdir, log_descriptor)
+    evidence_names = {
+        "agent_log": "agent.log",
+        "planner_status": "planner_status.json",
+    }
+    if termination in {"planner_completed", "planner_timeout"}:
+        evidence_names["deadline_contract"] = CONTRACT_NAME
+    if termination == "planner_timeout":
+        evidence_names["deadline_seal"] = SEAL_NAME
+        evidence_names["deadline_freeze"] = FREEZE_NAME
+    evidence_ready = all(name in archived for name in evidence_names.values())
+    evidence = {
+        label: {
+            "path": str((log_dir / name).relative_to(cell_dir)),
+            "sha256": archived[name],
+        }
+        for label, name in evidence_names.items()
+        if name in archived
+    }
+
+    audit_path = build_dir / f"{cell.tag}.json"
+    trace_path = build_dir / f"{cell.tag}.jsonl"
+    audit = _read_json(audit_path)
+    valid = builder_rc == 0 and audit.get("valid") is True and evidence_ready
+    if valid and termination == "planner_timeout":
+        assert deadline_attestation is not None
+        try:
+            built_trace_sha256 = sha256_file(trace_path)
+        except OSError:
+            built_trace_sha256 = None
+        valid = (
+            audit.get("steps") == deadline_attestation["prefix_step"]
+            and audit.get("success") is deadline_attestation["success_at_deadline"]
+            and built_trace_sha256
+            == _read_json(workdir / FREEZE_NAME).get("command_trace_sha256")
+        )
+    canonical_termination = termination in {"planner_completed", "planner_timeout"}
+    if valid and canonical_termination:
+        audit.update(
+            {
+                "protocol_id": PROTOCOL_ID,
+                "split": cell.split.value,
+                "planner_profile": config.planner_profile.name,
+                "planner_backend": config.planner_profile.backend,
+                "planner_model": config.planner_profile.model,
+                "planner_reasoning_effort": config.planner_profile.reasoning_effort,
+                "planner_auth_mode": config.planner_transport.auth_mode,
+                "planner_provider": config.planner_transport.provider_id,
+                "planner_endpoint_identity": (
+                    config.planner_transport.endpoint_identity
+                ),
+                "infra_status": "ok",
+                "planner_status": (
+                    "timeout" if termination == "planner_timeout" else "completed"
+                ),
+                "environment_success": audit.get("success") is True,
+                "preliminary": True,
+                "release_ready": False,
+                "run_config_sha256": run_config_sha256,
+                "run_id": run_id,
+                "runtime_root": str(runtime.root),
+                "runtime_scripts": {
+                    "external_driver": sha256_file(runtime.driver),
+                    "external_deadline": sha256_file(runtime.deadline),
+                    "driver_adapter": sha256_file(
+                        Path(__file__).with_name("preliminary_driver.py")
+                    ),
+                    "deadline_supervisor": sha256_file(
+                        Path(__file__).with_name("deadline_supervisor.py")
+                    ),
+                    "artifact_builder": sha256_file(runtime.artifact_builder),
+                },
+                "deadline": deadline_attestation,
+                "global_memory": False,
+                "task_notes_available": False,
+                "reset_seed": _reset_seed(cell),
+                "memory_source": {
+                    "kind": config.memory_source,
+                    "revision": config.memory_revision,
+                    "manifest_sha256": sha256_file(
+                        config.memory_root / "manifest.json"
+                    ),
+                },
+                "navview": {
+                    "xml_sha256": sha256_file(runtime.navview_xml),
+                    "camera": "mobilebase0_navview",
+                    "mode": "fixed",
+                    "pos": "0.2 0 1.6",
+                    "xyaxes": "0 -1 0 0.643 0 0.766",
+                    "fovy": "75",
+                },
+                "checkpoint": {
+                    "checkpoint_id": checkpoint_attestation["checkpoint_id"],
+                    "authority_manifest_sha256": checkpoint_attestation[
+                        "authority_manifest_sha256"
+                    ],
+                    "fingerprint": checkpoint_attestation["fingerprint"],
+                    "files": {
+                        name: value["sha256"]
+                        for name, value in checkpoint_attestation["files"].items()
+                    },
+                },
+                "checkpoint_sha256": {
+                    name: checkpoint_attestation["files"][f"model/{name}"]["sha256"]
+                    for name in CHECKPOINT_SHA256
+                },
+                "evidence": evidence,
+            }
+        )
+        commands = [
+            json.loads(line)
+            for line in trace_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        result = CellResult(
+            Completion.COMPLETED,
+            Outcome.SUCCESS if audit["success"] else Outcome.FAILURE,
+            Integrity.VALID,
+        )
+        try:
+            publish_completed_cell(config.results_root, cell, result, audit, commands)
+        except (OSError, ValueError):
+            rc = EXIT_ARTIFACT
+            message = "artifact publication rejected the completed cell"
+        else:
+            from .validator import validate_cell
+
+            validation = validate_cell(
+                config.results_root,
+                cell,
+                expected_run_config_sha256=run_config_sha256,
+            )
+            if validation.result.canonical:
+                rc = EXIT_CANONICAL
+                message = None
+            else:
+                rc = EXIT_ARTIFACT
+                message = "published cell failed canonical validation"
+    elif termination in RETRYABLE_TERMINATIONS:
+        rc = EXIT_RETRYABLE_INFRA
+        message = (
+            termination
+            if builder_rc == 0
+            else f"{termination}; artifact builder rc={builder_rc}"
+        )
+    elif termination == "configuration_failed":
+        rc = EXIT_CONFIGURATION
+        message = termination
+    elif builder_rc != 0:
+        rc = EXIT_ARTIFACT
+        message = f"artifact builder failed with rc={builder_rc}"
+    elif not evidence_ready and canonical_termination:
+        rc = EXIT_ARTIFACT
+        message = "canonical attempt is missing agent/status evidence"
+    else:
+        rc = EXIT_ARTIFACT
+        message = f"non-canonical termination: {termination}"
+
+    if not config.keep_workdirs:
+        _remove_workdir(workdir, config.rollout_root)
+    return Execution(cell, rc, termination, rc == EXIT_CANONICAL, workdir, message)

--- a/rpent/reproduce/robocasa/formal_prompt.py
+++ b/rpent/reproduce/robocasa/formal_prompt.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frozen no-reset prompt for the RoboCasa Harness VLA protocol."""
+
+from __future__ import annotations
+
+FORMAL_PROMPT = r"""
+You are the high-level planner in a strict, no-reset Harness VLA evaluation on
+RoboCasa365. Control one live PandaOmron episode through the file-mediated
+primitive interface in {WORKDIR}. Continue until state.success is true or the
+rollout budget is exhausted.
+
+## Formal boundary
+
+- This is a held-out evaluation seed. Reset is disabled.
+- Use only files inside {WORKDIR}. Never inspect repositories, Python packages,
+  /proc, simulator source, task predicates, registries, or another rollout.
+- Never use web search, browsers, apps, plugins, external MCP servers, or any
+  external lookup.
+- Ground-truth object poses, progress counters, predicate internals, and
+  simulator state are prohibited.
+- The only memory is the task-matched seed-0 pair in {TASK_MEMORY_DIR}. If that
+  directory is empty, continue with no memory. Never seek a substitute.
+- There is no Global Memory, task Markdown, experience Markdown, or cross-task
+  memory in this protocol.
+
+The launcher enforces the filesystem boundary. Driver observations and journals
+are root-owned and read-only. Only fixed mailboxes plus .codex/, tmp/, and
+scratch/ are writable. Treat any other access error as intentional.
+
+## Observation and command protocol
+
+For step NN, allowed observations are state_NN.json, aligned RGB/depth/world-map
+files for agentview and wrist, high-resolution agentview files, navigation RGB
+and world-map files, camera metadata, log_NN.json, and done_NN.flag.
+
+Write exactly one compact JSON object followed by a newline to the existing
+command.json inode, then wait for the next done_NN.flag. Truncate the fixed file
+in place; never remove, rename, replace, or batch it. The driver records only
+completed primitives. Temporary crops and reasoning files belong in scratch/.
+
+Use RGB for identity and depth/world maps for metric localization. Select
+several interior pixels, reject edges and background, and use a robust median.
+Re-localize after navigation, base motion, object motion, or failed contact.
+Never replay seed-0 coordinates, pixels, poses, or other literal geometry.
+
+## Task memory
+
+If present, read {TASK}_s0.json and {TASK}_s0.jsonl. They are a procedural prior,
+not a trajectory to replay. Current task_language, RGB-D, primitive results, and
+state.success always take precedence. An empty directory is an intentional
+no-memory condition for this task.
+
+## Allowed primitive interface
+
+```json
+{"action":"navigate_to","xy":[0.0,0.0],"tol":0.20}
+{"action":"move_base","forward":0.2,"lateral":0.0,"turn":0.1,"steps":10}
+{"action":"move_to","xyz":[0.0,0.0,0.0],"step_clip":0.02,"tol":0.012}
+{"action":"move_delta","dxyz":[0.0,0.0,0.0]}
+{"action":"rotate_pitch","target_pitch":0.6}
+{"action":"set_gripper","gripper":-1,"steps":10}
+{"action":"release","steps":10}
+{"action":"vla_act","prompt":"<task_language verbatim>"}
+```
+
+Use analytic primitives for localization, navigation, staging, free-space
+transport, posture adjustment, release, verification, and recovery. Use vla_act
+for contact-rich grasping, insertion, seating, pressing, and articulated
+interaction. Do not invent scripted_grasp, low-level actions, joint targets,
+legacy RLDX aliases, or additional primitives.
+
+The vla_act prompt must equal the full task_language verbatim. Do not override
+the VLA chunk budget, stop configuration, or base/arm controls.
+
+After every vla_act, inspect its public result and refreshed observations. A
+no-contact attempt must be followed by observation, re-localization, one or more
+analytic re-staging primitives, verification, and then a new independent
+vla_act. Any analytic primitive deliberately ends the previous VLA attempt.
+
+## Workflow and completion
+
+1. Read state_00.json and current RGB-D observations.
+2. Read the available two-file task memory, or continue if the directory is empty.
+3. Identify task-relevant objects and destinations from current perception.
+4. Re-ground the seed-0 procedure in this seed's geometry.
+5. Execute one primitive at a time and inspect log, state, and observations.
+6. Stop physical execution only when state.success is true or the supervisor
+   terminates the rollout. Never reset.
+
+Before voluntarily exiting, truncate the existing _agent_audit.json in place
+and write one JSON object plus newline:
+
+```json
+{"strategy_notes":"concise grounding, staging and recovery summary","failure_reason":null}
+```
+
+The harness, not the planner, determines official success and builds canonical
+audit and command-trace artifacts. Begin with step 00.
+""".strip()
+
+
+def render_formal_prompt(*, task: str, workdir: str, task_memory_dir: str) -> str:
+    """Render only the three trusted rollout-local substitutions."""
+    return (
+        FORMAL_PROMPT.replace("{TASK}", task)
+        .replace("{WORKDIR}", workdir)
+        .replace("{TASK_MEMORY_DIR}", task_memory_dir)
+    )

--- a/rpent/reproduce/robocasa/memory.py
+++ b/rpent/reproduce/robocasa/memory.py
@@ -1,0 +1,400 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build a canonical, task-isolated seed-0 memory pack."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .protocol import (
+    EMPTY_MEMORY_TASKS,
+    MEMORY_PAIR_TASKS,
+    PROTOCOL_ID,
+    command_problem,
+)
+
+SCHEMA_VERSION = 3
+SOURCE_DIRS = {
+    "atomic": "explore_atomic_recipe",
+    "composite_seen": "exploration_seen_recipe",
+    "composite_unseen": "exploration_unseen_recipe",
+}
+ALIASES = frozenset({"rldx_skill", "rldx_arm", "vla_act"})
+LEGACY_NORMALIZATIONS = {
+    "rldx_skill,rldx_arm,vla_act": "vla_act with task_language only",
+    "set_gripper.width": "set_gripper.gripper",
+    "scripted_grasp": "open, hover, descend, close, lift",
+    "audit.command_sequence": "removed; paired JSONL is the sole command authority",
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except Exception as exc:
+        raise ValueError(f"invalid JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return value
+
+
+def _normalized_trace(
+    path: Path, task_language: str, *, normalize_vla: bool = True
+) -> bytes:
+    commands: list[dict[str, Any]] = []
+    for number, raw in enumerate(
+        path.read_text(encoding="utf-8", errors="strict").splitlines(), 1
+    ):
+        if not raw.strip():
+            raise ValueError(f"blank JSONL line {path}:{number}")
+        try:
+            command = json.loads(raw)
+        except Exception as exc:
+            raise ValueError(f"invalid JSONL {path}:{number}: {exc}") from exc
+        if not isinstance(command, dict) or not isinstance(command.get("action"), str):
+            raise ValueError(f"invalid command {path}:{number}")
+        normalized = (
+            _normalize_legacy_command(command, task_language, path, number)
+            if normalize_vla
+            else [command]
+        )
+        for item in normalized:
+            if problem := command_problem(item, task_language=task_language):
+                raise ValueError(f"invalid command {path}:{number}: {problem}")
+            commands.append(item)
+    if not commands:
+        raise ValueError(f"empty command trace: {path}")
+    return b"".join(
+        (json.dumps(command, ensure_ascii=False, separators=(",", ":")) + "\n").encode()
+        for command in commands
+    )
+
+
+def _commands_from_trace_bytes(trace: bytes) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in trace.decode("utf-8").splitlines()]
+
+
+def _audit_contains_command(value: Any) -> bool:
+    if isinstance(value, dict):
+        return "action" in value or any(
+            _audit_contains_command(item) for item in value.values()
+        )
+    if isinstance(value, list):
+        return any(_audit_contains_command(item) for item in value)
+    return False
+
+
+def _normalize_legacy_command(
+    command: dict[str, Any], task_language: str, path: Path, number: int
+) -> list[dict[str, Any]]:
+    action = command["action"]
+    if action in ALIASES:
+        return [{"action": "vla_act", "prompt": task_language}]
+    if action == "set_gripper" and "width" in command:
+        if set(command) - {"action", "width", "steps"}:
+            raise ValueError(f"invalid legacy set_gripper {path}:{number}")
+        normalized = {"action": "set_gripper", "gripper": command["width"]}
+        if "steps" in command:
+            normalized["steps"] = command["steps"]
+        return [normalized]
+    if action != "scripted_grasp":
+        return [command]
+    if set(command) - {
+        "action",
+        "xyz",
+        "approach_z",
+        "grasp_z_offset",
+        "step_clip",
+    }:
+        raise ValueError(f"invalid legacy scripted_grasp {path}:{number}")
+    xyz = command.get("xyz")
+    approach = command.get("approach_z", 0.10)
+    offset = command.get("grasp_z_offset", 0.0)
+    step_clip = command.get("step_clip", 0.02)
+    if (
+        not isinstance(xyz, list)
+        or len(xyz) != 3
+        or any(
+            isinstance(value, bool) or not isinstance(value, (int, float))
+            for value in xyz
+        )
+        or isinstance(approach, bool)
+        or not isinstance(approach, (int, float))
+        or isinstance(offset, bool)
+        or not isinstance(offset, (int, float))
+    ):
+        raise ValueError(f"invalid legacy scripted_grasp {path}:{number}")
+    x, y, z = xyz
+    return [
+        {"action": "set_gripper", "gripper": -1.0, "steps": 4},
+        {
+            "action": "move_to",
+            "xyz": [x, y, z + approach],
+            "gripper": -1.0,
+            "step_clip": step_clip,
+            "tol": 0.012,
+        },
+        {
+            "action": "move_to",
+            "xyz": [x, y, z + offset],
+            "gripper": -1.0,
+            "step_clip": 0.012,
+            "tol": 0.01,
+        },
+        {"action": "set_gripper", "gripper": 1.0, "steps": 14},
+        {
+            "action": "move_to",
+            "xyz": [x, y, z + approach + 0.05],
+            "gripper": "hold",
+            "step_clip": 0.015,
+            "tol": 0.012,
+        },
+    ]
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    descriptor, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(name, path)
+    finally:
+        try:
+            os.unlink(name)
+        except FileNotFoundError:
+            pass
+
+
+def build_memory_pack(migration_root: Path, destination: Path) -> dict[str, Any]:
+    """Pack exactly 43 successful audit/trace pairs plus seven empty entries."""
+    migration_root = Path(migration_root)
+    destination = Path(destination)
+    if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
+        raise ValueError(f"memory destination must be a real directory: {destination}")
+    if destination.exists() and any(destination.iterdir()):
+        raise ValueError(f"memory destination must be empty: {destination}")
+    destination.mkdir(parents=True, exist_ok=True)
+    entries: list[dict[str, Any]] = []
+    task_to_source = {
+        task: directory
+        for directory, name in SOURCE_DIRS.items()
+        for task in _tasks_for_directory(directory)
+    }
+    for task in sorted(MEMORY_PAIR_TASKS):
+        source = migration_root / SOURCE_DIRS[task_to_source[task]]
+        audit_source = source / f"{task}_s0.json"
+        trace_source = source / f"recipe_{task}_s0.jsonl"
+        for path in (audit_source, trace_source):
+            if path.is_symlink() or not path.is_file():
+                raise ValueError(f"missing or unsafe memory source: {path}")
+        audit = _read_json(audit_source)
+        if (
+            audit.get("task") != task
+            or type(audit.get("seed")) is not int
+            or audit["seed"] != 0
+        ):
+            raise ValueError(f"memory identity mismatch: {audit_source}")
+        if audit.get("success") is not True:
+            raise ValueError(
+                f"memory is not a successful seed-0 rollout: {audit_source}"
+            )
+        task_language = audit.get("task_language")
+        if not isinstance(task_language, str) or not task_language.strip():
+            raise ValueError(f"memory has no task language: {audit_source}")
+        task_dir = destination / task
+        task_dir.mkdir()
+        audit_dest = task_dir / f"{task}_s0.json"
+        trace_dest = task_dir / f"{task}_s0.jsonl"
+        trace_bytes = _normalized_trace(trace_source, task_language)
+        commands = _commands_from_trace_bytes(trace_bytes)
+        audit.pop("command_sequence", None)
+        if "n_commands" in audit:
+            audit["n_commands"] = len(commands)
+        if "manual_cmds" in audit:
+            audit["manual_cmds"] = sum(
+                command["action"] != "vla_act" for command in commands
+            )
+        if "vla_calls" in audit:
+            audit["vla_calls"] = sum(
+                command["action"] == "vla_act" for command in commands
+            )
+        audit_bytes = (
+            json.dumps(audit, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        _atomic_write(audit_dest, audit_bytes)
+        _atomic_write(trace_dest, trace_bytes)
+        entries.append(
+            {
+                "task": task,
+                "memory": "seed0_success",
+                "source": task_to_source[task],
+                "files": {
+                    audit_dest.name: hashlib.sha256(audit_bytes).hexdigest(),
+                    trace_dest.name: hashlib.sha256(trace_bytes).hexdigest(),
+                },
+            }
+        )
+    for task in sorted(EMPTY_MEMORY_TASKS):
+        (destination / task).mkdir()
+        entries.append({"task": task, "memory": "empty", "source": None, "files": {}})
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "protocol": PROTOCOL_ID,
+        "source": "RoboCasa seed-0 migration recipes",
+        "source_directories": SOURCE_DIRS,
+        "legacy_normalizations": LEGACY_NORMALIZATIONS,
+        "algorithm": "sha256",
+        "entries": entries,
+    }
+    _atomic_write(
+        destination / "manifest.json",
+        (
+            json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        ).encode(),
+    )
+    return manifest
+
+
+def _tasks_for_directory(label: str) -> frozenset[str]:
+    from .protocol import ATOMIC_TASKS, COMPOSITE_SEEN_TASKS, COMPOSITE_UNSEEN_TASKS
+
+    return {
+        "atomic": frozenset(ATOMIC_TASKS),
+        "composite_seen": frozenset(COMPOSITE_SEEN_TASKS),
+        "composite_unseen": frozenset(COMPOSITE_UNSEEN_TASKS),
+    }[label]
+
+
+def validate_memory_pack(root: Path) -> list[str]:
+    """Validate identities, exact file names, empty whitelist and manifest hashes."""
+    root = Path(root)
+    problems: list[str] = []
+    try:
+        manifest = _read_json(root / "manifest.json")
+    except ValueError as exc:
+        return [str(exc)]
+    entries = manifest.get("entries")
+    if (
+        manifest.get("schema_version") != SCHEMA_VERSION
+        or manifest.get("protocol") != PROTOCOL_ID
+        or manifest.get("source") != "RoboCasa seed-0 migration recipes"
+        or manifest.get("source_directories") != SOURCE_DIRS
+        or manifest.get("legacy_normalizations") != LEGACY_NORMALIZATIONS
+        or manifest.get("algorithm") != "sha256"
+    ):
+        problems.append("unsupported memory manifest")
+    if not isinstance(entries, list) or len(entries) != 50:
+        return problems + ["memory manifest must contain exactly 50 task entries"]
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("task"), str):
+            problems.append("invalid memory manifest entry")
+            continue
+        task = entry["task"]
+        if task in seen:
+            problems.append(f"duplicate memory task: {task}")
+        seen.add(task)
+        directory = root / task
+        if directory.is_symlink() or not directory.is_dir():
+            problems.append(f"missing or unsafe memory directory for {task}")
+            continue
+        actual = {path.name for path in directory.iterdir()}
+        expected_files = entry.get("files")
+        if not isinstance(expected_files, dict) or actual != set(expected_files):
+            problems.append(f"unexpected memory files for {task}: {sorted(actual)}")
+            continue
+        expected_kind = "empty" if task in EMPTY_MEMORY_TASKS else "seed0_success"
+        if entry.get("memory") != expected_kind:
+            problems.append(f"wrong memory kind for {task}")
+        expected_source = next(
+            (label for label in SOURCE_DIRS if task in _tasks_for_directory(label)),
+            None,
+        )
+        if task in EMPTY_MEMORY_TASKS:
+            expected_source = None
+        if entry.get("source") != expected_source:
+            problems.append(f"wrong memory provenance for {task}")
+        for name, digest in expected_files.items():
+            path = directory / name
+            if path.is_symlink() or not path.is_file() or sha256_file(path) != digest:
+                problems.append(f"memory hash mismatch: {task}/{name}")
+        if expected_kind == "seed0_success" and actual == {
+            f"{task}_s0.json",
+            f"{task}_s0.jsonl",
+        }:
+            try:
+                audit = _read_json(directory / f"{task}_s0.json")
+                if (
+                    audit.get("task") != task
+                    or type(audit.get("seed")) is not int
+                    or audit.get("seed") != 0
+                    or audit.get("success") is not True
+                ):
+                    problems.append(f"invalid seed-0 audit semantics for {task}")
+                language = audit.get("task_language")
+                if not isinstance(language, str) or not language.strip():
+                    problems.append(f"missing task language for {task}")
+                else:
+                    trace_bytes = _normalized_trace(
+                        directory / f"{task}_s0.jsonl", language, normalize_vla=False
+                    )
+                    commands = _commands_from_trace_bytes(trace_bytes)
+                    if _audit_contains_command(audit):
+                        problems.append(
+                            f"seed-0 audit embeds commands instead of using JSONL for {task}"
+                        )
+                    expected_stats = {
+                        "n_commands": len(commands),
+                        "manual_cmds": sum(
+                            command["action"] != "vla_act" for command in commands
+                        ),
+                        "vla_calls": sum(
+                            command["action"] == "vla_act" for command in commands
+                        ),
+                    }
+                    for key, expected_value in expected_stats.items():
+                        if key in audit and audit[key] != expected_value:
+                            problems.append(
+                                f"seed-0 audit {key} differs from JSONL for {task}"
+                            )
+            except (OSError, UnicodeError, ValueError) as exc:
+                problems.append(f"invalid memory semantics for {task}: {exc}")
+    expected = set(MEMORY_PAIR_TASKS) | set(EMPTY_MEMORY_TASKS)
+    if seen != expected:
+        problems.append("memory manifest task set differs from protocol")
+    allowed_root = seen | {"manifest.json"}
+    extras = {path.name for path in root.iterdir()} - allowed_root
+    if extras:
+        problems.append(f"unexpected pack entries: {sorted(extras)}")
+    return problems
+
+
+# Public action-oriented name used by runners; retain the descriptive builder name.
+pack_memory = build_memory_pack

--- a/rpent/reproduce/robocasa/planner_transport.py
+++ b/rpent/reproduce/robocasa/planner_transport.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Planner authentication and transport contracts for RoboCasa reproduction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+API_KEY_AUTH = "api-key"
+CHATGPT_SUBSCRIPTION_AUTH = "chatgpt-subscription"
+AUTH_MODES = (API_KEY_AUTH, CHATGPT_SUBSCRIPTION_AUTH)
+
+CHATGPT_BROKER_PROFILE = "chatgpt_subscription_broker"
+CHATGPT_BROKER_PROTOCOL = "root_oauth_injection_v1"
+CHATGPT_ENDPOINT_IDENTITY = "openai_chatgpt_subscription"
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
+
+# Keep transient provider failures inside the benchmark deadline instead of
+# prematurely consuming cell-level infrastructure retries. The deadline
+# supervisor remains the authoritative upper bound for every planner process.
+CODEX_REQUEST_MAX_RETRIES = 12
+CODEX_STREAM_MAX_RETRIES = 120
+CODEX_STREAM_IDLE_TIMEOUT_MS = 330_000
+
+
+def codex_provider_retry_policy() -> dict[str, int]:
+    """Return the frozen, credential-free Codex provider retry identity."""
+    return {
+        "request_max_retries": CODEX_REQUEST_MAX_RETRIES,
+        "stream_max_retries": CODEX_STREAM_MAX_RETRIES,
+        "stream_idle_timeout_ms": CODEX_STREAM_IDLE_TIMEOUT_MS,
+    }
+
+
+def normalize_responses_base_url(base_url: str) -> str:
+    """Validate and normalize one Responses-compatible API base URL."""
+    raw = base_url.strip().rstrip("/")
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("base URL must be an absolute http(s) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("base URL must not contain credentials, query, or fragment")
+    if parsed.scheme == "http" and parsed.hostname not in LOOPBACK_HOSTS:
+        raise ValueError("non-loopback planner base URL must use https")
+    path = parsed.path.rstrip("/")
+    if path.endswith("/responses"):
+        raise ValueError("base URL must identify the API base, not /responses")
+    if not path.endswith("/v1"):
+        path = f"{path}/v1"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def normalize_broker_health_url(raw_url: str) -> str:
+    """Accept only a loopback HTTP broker health endpoint."""
+    raw = raw_url.strip().rstrip("/")
+    parsed = urlsplit(raw)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in LOOPBACK_HOSTS
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"/health", "/lease-health"}
+    ):
+        raise ValueError(
+            "broker health URL must be loopback HTTP ending in /health or /lease-health"
+        )
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+@dataclass(frozen=True)
+class PlannerTransport:
+    """Secret-free transport identity plus a root-only client credential path."""
+
+    auth_mode: str
+    credential_file: Path
+    request_base_url: str
+    endpoint_identity: str
+    provider_id: str
+    provider_name: str
+    broker_health_url: str | None = None
+    broker_protocol: str | None = None
+
+    @classmethod
+    def api_key(cls, *, credential_file: Path, base_url: str) -> "PlannerTransport":
+        normalized = normalize_responses_base_url(base_url)
+        return cls(
+            auth_mode=API_KEY_AUTH,
+            credential_file=Path(credential_file),
+            request_base_url=normalized,
+            endpoint_identity=f"responses_api:{normalized}",
+            provider_id="rpent_responses_api",
+            provider_name="RPent Responses API",
+        )
+
+    @classmethod
+    def chatgpt_subscription(
+        cls,
+        *,
+        credential_file: Path,
+        broker_base_url: str,
+        broker_health_url: str,
+    ) -> "PlannerTransport":
+        normalized_base = normalize_responses_base_url(broker_base_url)
+        parsed = urlsplit(normalized_base)
+        if parsed.scheme != "http" or parsed.hostname not in LOOPBACK_HOSTS:
+            raise ValueError("ChatGPT subscription broker must use loopback HTTP")
+        normalized_health = normalize_broker_health_url(broker_health_url)
+        if urlsplit(normalized_health).netloc != parsed.netloc:
+            raise ValueError("broker base and health URLs must use the same listener")
+        return cls(
+            auth_mode=CHATGPT_SUBSCRIPTION_AUTH,
+            credential_file=Path(credential_file),
+            request_base_url=normalized_base,
+            endpoint_identity=CHATGPT_ENDPOINT_IDENTITY,
+            provider_id="rpent_chatgpt_broker",
+            provider_name="RPent ChatGPT Subscription Broker",
+            broker_health_url=normalized_health,
+            broker_protocol=CHATGPT_BROKER_PROTOCOL,
+        )
+
+    @property
+    def uses_broker(self) -> bool:
+        return self.auth_mode == CHATGPT_SUBSCRIPTION_AUTH
+
+    def manifest_identity(self) -> dict[str, str | bool | None]:
+        """Return the stable, credential-free transport identity."""
+        return {
+            "auth_mode": self.auth_mode,
+            "provider": self.provider_id,
+            "endpoint_identity": self.endpoint_identity,
+            "credential_broker": self.uses_broker,
+            "credential_broker_protocol": self.broker_protocol,
+        }

--- a/rpent/reproduce/robocasa/preflight.py
+++ b/rpent/reproduce/robocasa/preflight.py
@@ -1,0 +1,722 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Active, deterministic isolation preflight for the pinned Codex runtime."""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from .deadline_supervisor import CONTRACT_NAME, GATE_NAME, _open_gate
+from .executor import (
+    FROZEN_RUNTIME_SHA256,
+    PINNED_CODEX_SHA256,
+    PINNED_CODEX_VERSION,
+    ExecutorConfig,
+    _planner_command,
+    _prepare_rollout_parent,
+    _write_private_json,
+    sha256_file,
+)
+from .protocol import cell_for
+from .provenance import canonical_sha256
+
+ISOLATION_ATTESTATION_NAME = "isolation-attestation.json"
+EXPECTED_TOOL_NAMES = (
+    "apply_patch",
+    "exec_command",
+    "update_plan",
+    "view_image",
+    "write_stdin",
+)
+PASS_CHECKS = (
+    "scratch_write",
+    "root_create_blocked",
+    "rpent_read_blocked",
+    "runtime_read_blocked",
+    "proc_environ_read_blocked",
+    "shell_network_blocked",
+    "planner_secret_absent",
+    "usr_write_blocked",
+)
+
+
+def isolation_attestation_path(config: ExecutorConfig) -> Path:
+    return config.results_root / "_preflight" / ISOLATION_ATTESTATION_NAME
+
+
+def _landlock_abi() -> int:
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.syscall.restype = ctypes.c_long
+    abi = int(libc.syscall(444, 0, 0, 1))
+    if abi < 1:
+        raise RuntimeError("Landlock ABI 1 is unavailable")
+    return abi
+
+
+def _response_base(response_id: str, status: str, output: list[dict]) -> dict:
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": status,
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "model": "gpt-5.5",
+        "output": output,
+        "parallel_tool_calls": False,
+        "previous_response_id": None,
+        "reasoning": {"effort": "high", "summary": None},
+        "store": False,
+        "temperature": None,
+        "text": {"format": {"type": "text"}},
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": None,
+        "truncation": "disabled",
+        "usage": {
+            "input_tokens": 1,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 1,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 2,
+        },
+        "metadata": {},
+    }
+
+
+def _shell_probe(
+    *, port: int, marker: Path, repo_root: Path, runtime_probe: Path
+) -> str:
+    return f"""set +e
+scratch_ok=FAIL
+root_blocked=FAIL
+rpent_blocked=FAIL
+runtime_blocked=FAIL
+proc_blocked=FAIL
+network_blocked=FAIL
+secret_absent=FAIL
+usr_write_blocked=FAIL
+
+if : > scratch/isolation_preflight 2>/dev/null && test -f scratch/isolation_preflight; then scratch_ok=PASS; fi
+if : > root_should_not_exist 2>/dev/null; then :; else root_blocked=PASS; fi
+if /usr/bin/head -c 1 {shlex.quote(str(repo_root / "pyproject.toml"))} >/dev/null 2>&1; then :; else rpent_blocked=PASS; fi
+if /usr/bin/head -c 1 {shlex.quote(str(runtime_probe))} >/dev/null 2>&1; then :; else runtime_blocked=PASS; fi
+if /usr/bin/head -c 1 /proc/self/environ >/dev/null 2>&1; then :; else proc_blocked=PASS; fi
+if /usr/bin/curl -fsS --max-time 2 http://127.0.0.1:{port}/shell-probe >/dev/null 2>&1; then :; else network_blocked=PASS; fi
+if test -z "${{RLDX_PLANNER_API_KEY+x}}"; then secret_absent=PASS; fi
+if echo changed > {shlex.quote(str(marker))} 2>/dev/null; then :; else usr_write_blocked=PASS; fi
+
+echo "scratch_write=$scratch_ok"
+echo "root_create_blocked=$root_blocked"
+echo "rpent_read_blocked=$rpent_blocked"
+echo "runtime_read_blocked=$runtime_blocked"
+echo "proc_environ_read_blocked=$proc_blocked"
+echo "shell_network_blocked=$network_blocked"
+echo "planner_secret_absent=$secret_absent"
+echo "usr_write_blocked=$usr_write_blocked"
+"""
+
+
+def _handler(
+    state: dict[str, Any],
+    *,
+    shell_command: str,
+    apply_marker: Path | None = None,
+    escalation_marker: Path | None = None,
+    view_path: Path | None = None,
+):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *_args):
+            return
+
+        def do_GET(self):
+            if self.path == "/shell-probe":
+                state["shell_get_count"] += 1
+                self.send_response(204)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            self.send_error(404)
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            try:
+                request = json.loads(self.rfile.read(length))
+            except (UnicodeError, ValueError):
+                self.send_error(400)
+                return
+            state["post_count"] += 1
+            state["authorization_present"] = bool(
+                self.headers.get("Authorization", "").startswith("Bearer ")
+            )
+            if state["post_count"] == 1:
+                self._capture_tools(request.get("tools"))
+                if state.get("error") is not None:
+                    self._send_final_text("CAPABILITY_MISMATCH")
+                else:
+                    self._send_function_call(
+                        "exec_command",
+                        "shell_probe",
+                        {"cmd": shell_command, "yield_time_ms": 10000},
+                    )
+                return
+            pending = state.get("pending")
+            if isinstance(pending, str):
+                state["tool_outputs"][pending] = self._extract_tool_output(
+                    request.get("input")
+                )
+            if state["post_count"] == 2:
+                assert apply_marker is not None
+                patch = (
+                    "*** Begin Patch\n"
+                    f"*** Update File: {apply_marker}\n"
+                    "@@\n"
+                    "-unchanged\n"
+                    "+changed\n"
+                    "*** End Patch"
+                )
+                self._send_apply_patch(patch)
+            elif state["post_count"] == 3:
+                assert view_path is not None
+                self._send_function_call(
+                    "view_image", "view_image_outside", {"path": str(view_path)}
+                )
+            elif state["post_count"] == 4:
+                assert escalation_marker is not None
+                self._send_function_call(
+                    "exec_command",
+                    "exec_escalation",
+                    {
+                        "cmd": f"echo changed > {shlex.quote(str(escalation_marker))}",
+                        "sandbox_permissions": "require_escalated",
+                        "justification": "isolation preflight must reject escalation",
+                    },
+                )
+            elif state["post_count"] == 5:
+                self._send_final_text()
+            else:
+                state["error"] = "unexpected additional Responses request"
+                self.send_error(409)
+
+        @staticmethod
+        def _extract_tool_output(value):
+            if not isinstance(value, list):
+                return None
+            for item in reversed(value):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") in {
+                    "function_call_output",
+                    "custom_tool_call_output",
+                }:
+                    output = item.get("output")
+                    if isinstance(output, str):
+                        return output[-16000:]
+            return None
+
+        def _capture_tools(self, tools):
+            candidates = [item for item in tools or [] if isinstance(item, dict)]
+            names = [item.get("name") for item in candidates]
+            if (
+                len(names) != len(EXPECTED_TOOL_NAMES)
+                or any(not isinstance(name, str) for name in names)
+                or tuple(sorted(names)) != EXPECTED_TOOL_NAMES
+            ):
+                state["error"] = f"unexpected tool capability set: {names!r}"
+                return
+            by_name = {item["name"]: item for item in candidates}
+            if by_name["exec_command"].get("type", "function") != "function":
+                state["error"] = "exec_command must use the function tool schema"
+                return
+            state["tools"] = by_name
+            state["tool_names"] = sorted(names)
+            state["tool_schema_sha256"] = canonical_sha256(candidates)
+
+        def _send_apply_patch(self, patch: str):
+            selected = state["tools"]["apply_patch"]
+            if selected.get("type", "function") == "custom":
+                self._send_custom_call("apply_patch", "apply_patch_outside", patch)
+                return
+            properties = (
+                selected.get("parameters", {}).get("properties", {})
+                if isinstance(selected.get("parameters"), dict)
+                else {}
+            )
+            if "patch" in properties:
+                arguments = {"patch": patch}
+            elif "input" in properties:
+                arguments = {"input": patch}
+            else:
+                state["error"] = "apply_patch has an unsupported schema"
+                self._send_final_text("APPLY_PATCH_SCHEMA_MISMATCH")
+                return
+            self._send_function_call("apply_patch", "apply_patch_outside", arguments)
+
+        def _send_function_call(self, name: str, label: str, value: dict[str, Any]):
+            state["pending"] = label
+            arguments = json.dumps(value, separators=(",", ":"))
+            sequence = state["post_count"]
+            item = {
+                "id": f"fc_isolation_preflight_{sequence}",
+                "type": "function_call",
+                "status": "completed",
+                "call_id": f"call_isolation_preflight_{sequence}",
+                "name": name,
+                "arguments": arguments,
+            }
+            self._send_call_events(item, "arguments", arguments, custom=False)
+
+        def _send_custom_call(self, name: str, label: str, value: str):
+            state["pending"] = label
+            sequence = state["post_count"]
+            item = {
+                "id": f"fc_isolation_preflight_{sequence}",
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": f"call_isolation_preflight_{sequence}",
+                "name": name,
+                "input": value,
+            }
+            self._send_call_events(item, "input", value, custom=True)
+
+        def _send_call_events(
+            self, item: dict[str, Any], field: str, value: str, *, custom: bool
+        ):
+            sequence = state["post_count"]
+            response_id = f"resp_preflight_{sequence}"
+            events = [
+                {
+                    "type": "response.created",
+                    "sequence_number": 0,
+                    "response": _response_base(response_id, "in_progress", []),
+                },
+                {
+                    "type": "response.output_item.added",
+                    "sequence_number": 1,
+                    "output_index": 0,
+                    "item": item,
+                },
+                {
+                    "type": (
+                        "response.custom_tool_call_input.done"
+                        if custom
+                        else "response.function_call_arguments.done"
+                    ),
+                    "sequence_number": 2,
+                    "output_index": 0,
+                    "item_id": item["id"],
+                    field: value,
+                },
+                {
+                    "type": "response.output_item.done",
+                    "sequence_number": 3,
+                    "output_index": 0,
+                    "item": item,
+                },
+                {
+                    "type": "response.completed",
+                    "sequence_number": 4,
+                    "response": _response_base(response_id, "completed", [item]),
+                },
+            ]
+            self._send_sse(events)
+
+        def _send_final_text(self, text: str = "PREFLIGHT_COMPLETE"):
+            state["pending"] = None
+            sequence = state["post_count"]
+            response_id = f"resp_preflight_{sequence}"
+            item = {
+                "id": "msg_isolation_preflight_1",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+            events = [
+                {
+                    "type": "response.created",
+                    "sequence_number": 0,
+                    "response": _response_base(response_id, "in_progress", []),
+                },
+                {
+                    "type": "response.output_item.added",
+                    "sequence_number": 1,
+                    "output_index": 0,
+                    "item": item,
+                },
+                {
+                    "type": "response.content_part.added",
+                    "sequence_number": 2,
+                    "item_id": item["id"],
+                    "output_index": 0,
+                    "content_index": 0,
+                    "part": item["content"][0],
+                },
+                {
+                    "type": "response.output_text.done",
+                    "sequence_number": 3,
+                    "item_id": item["id"],
+                    "output_index": 0,
+                    "content_index": 0,
+                    "text": text,
+                },
+                {
+                    "type": "response.content_part.done",
+                    "sequence_number": 4,
+                    "item_id": item["id"],
+                    "output_index": 0,
+                    "content_index": 0,
+                    "part": item["content"][0],
+                },
+                {
+                    "type": "response.output_item.done",
+                    "sequence_number": 5,
+                    "output_index": 0,
+                    "item": item,
+                },
+                {
+                    "type": "response.completed",
+                    "sequence_number": 6,
+                    "response": _response_base(response_id, "completed", [item]),
+                },
+            ]
+            self._send_sse(events)
+
+        def _send_sse(self, events):
+            payload = (
+                b"".join(
+                    (
+                        "event: "
+                        + event["type"]
+                        + "\n"
+                        + "data: "
+                        + json.dumps(event, separators=(",", ":"))
+                        + "\n\n"
+                    ).encode("utf-8")
+                    for event in events
+                )
+                + b"data: [DONE]\n\n"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "close")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            self.wfile.flush()
+
+    return Handler
+
+
+def _private_dummy_key(directory: Path) -> Path:
+    if directory.exists() or directory.is_symlink():
+        metadata = directory.lstat()
+        if (
+            directory.is_symlink()
+            or not directory.is_dir()
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o077
+        ):
+            raise RuntimeError("preflight output directory is unsafe")
+    else:
+        directory.mkdir(parents=True, mode=0o700)
+        directory.chmod(0o700)
+    descriptor, name = tempfile.mkstemp(prefix=".isolation-key.", dir=directory)
+    try:
+        os.fchmod(descriptor, 0o600)
+        os.write(descriptor, b"rpent-isolation-preflight-key\n")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return Path(name)
+
+
+def _world_writable_marker() -> Path:
+    path = Path("/usr/local/share") / f"rpent-isolation-{uuid.uuid4().hex}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o666)
+    try:
+        os.fchmod(descriptor, 0o666)
+        os.write(descriptor, b"unchanged\n")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return path
+
+
+def _terminate(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        process.wait(timeout=5)
+
+
+def run_isolation_preflight(config: ExecutorConfig) -> dict[str, Any]:
+    """Exercise the exact production command against a local fake Responses API."""
+    if os.geteuid() != 0:
+        raise RuntimeError("isolation preflight requires root")
+    state: dict[str, Any] = {
+        "post_count": 0,
+        "shell_get_count": 0,
+        "authorization_present": False,
+        "error": None,
+        "tool_outputs": {},
+    }
+    shell_marker = _world_writable_marker()
+    apply_marker = _world_writable_marker()
+    escalation_marker = _world_writable_marker()
+    preflight_root = config.rollout_root / "_preflight"
+    _prepare_rollout_parent(preflight_root, config.rollout_root)
+    workdir = preflight_root / uuid.uuid4().hex
+    workdir.mkdir(mode=0o700)
+    os.chown(workdir, 0, 0)
+    os.chmod(workdir, 0o700)
+    gate_descriptor = _open_gate(workdir / GATE_NAME, create=True)
+    os.close(gate_descriptor)
+    _write_private_json(
+        workdir / CONTRACT_NAME,
+        {"schema_version": 1, "protocol": "isolation-preflight"},
+    )
+    control_inodes = {
+        name: (workdir / name).stat().st_ino for name in (GATE_NAME, CONTRACT_NAME)
+    }
+    key = _private_dummy_key(config.results_root / "_preflight")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler(state, shell_command=""))
+    server.daemon_threads = True
+    port = int(server.server_address[1])
+    server.RequestHandlerClass = _handler(
+        state,
+        shell_command=_shell_probe(
+            port=port,
+            marker=shell_marker,
+            repo_root=Path(__file__).resolve().parents[3],
+            runtime_probe=config.runtime.driver,
+        ),
+        apply_marker=apply_marker,
+        escalation_marker=escalation_marker,
+        view_path=config.runtime.model / "architecture.png",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    probe_transport = replace(
+        config.planner_transport,
+        credential_file=key,
+        request_base_url=f"http://127.0.0.1:{port}/v1",
+    )
+    probe_config = replace(
+        config,
+        planner_transport=probe_transport,
+    )
+    command = _planner_command(
+        probe_config,
+        workdir=workdir,
+        run_id="isolation-preflight",
+        cell=cell_for("atomic", "OpenDrawer", 1),
+    )
+    process: subprocess.Popen[str] | None = None
+    deadline_controls_protected = False
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=config.runtime.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=90)
+        except subprocess.TimeoutExpired as exc:
+            _terminate(process)
+            raise RuntimeError("isolation preflight timed out") from exc
+    finally:
+        if process is not None:
+            _terminate(process)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        key.unlink(missing_ok=True)
+        marker_bytes = {
+            "shell": shell_marker.read_bytes() if shell_marker.exists() else b"",
+            "apply_patch": (
+                apply_marker.read_bytes() if apply_marker.exists() else b""
+            ),
+            "escalation": (
+                escalation_marker.read_bytes() if escalation_marker.exists() else b""
+            ),
+        }
+        shell_marker.unlink(missing_ok=True)
+        apply_marker.unlink(missing_ok=True)
+        escalation_marker.unlink(missing_ok=True)
+        try:
+            deadline_controls_protected = all(
+                stat.S_ISREG((metadata := (workdir / name).lstat()).st_mode)
+                and metadata.st_ino == control_inodes[name]
+                and metadata.st_uid == 0
+                and metadata.st_gid == 0
+                and stat.S_IMODE(metadata.st_mode) == 0o600
+                and metadata.st_nlink == 1
+                for name in (GATE_NAME, CONTRACT_NAME)
+            )
+        except OSError:
+            deadline_controls_protected = False
+        if workdir.exists():
+            shutil.rmtree(workdir)
+    tool_outputs = state.get("tool_outputs", {})
+    output = tool_outputs.get("shell_probe")
+    checks = {
+        name: isinstance(output, str) and f"{name}=PASS" in output
+        for name in PASS_CHECKS
+    }
+    checks.update(
+        {
+            "apply_patch_outside_blocked": (
+                marker_bytes["apply_patch"] == b"unchanged\n"
+                and bool(tool_outputs.get("apply_patch_outside"))
+            ),
+            "view_image_outside_blocked": bool(tool_outputs.get("view_image_outside")),
+            "exec_escalation_rejected": (
+                marker_bytes["escalation"] == b"unchanged\n"
+                and bool(tool_outputs.get("exec_escalation"))
+            ),
+            "deadline_controls_root_only": deadline_controls_protected,
+        }
+    )
+    try:
+        events = [json.loads(line) for line in stdout.splitlines() if line.strip()]
+    except ValueError as exc:
+        raise RuntimeError("isolation preflight produced invalid JSONL") from exc
+    event_types = [event.get("type") for event in events if isinstance(event, dict)]
+    observed_item_types = sorted(
+        {
+            item["type"]
+            for event in events
+            if isinstance(event, dict)
+            and isinstance((item := event.get("item")), dict)
+            and isinstance(item.get("type"), str)
+        }
+    )
+    checks["view_image_outside_blocked"] = (
+        checks["view_image_outside_blocked"] and "image_view" not in observed_item_types
+    )
+    problems = []
+    assert process is not None
+    if process.returncode != 0:
+        problems.append(f"Codex exited {process.returncode}")
+    if state["post_count"] != 5 or state["shell_get_count"] != 0:
+        problems.append("Responses or generated-shell network counts differ")
+    if not state["authorization_present"]:
+        problems.append("Codex client omitted its API authorization")
+    if state.get("error") is not None:
+        problems.append(str(state["error"]))
+    if tuple(state.get("tool_names", ())) != EXPECTED_TOOL_NAMES:
+        problems.append("Codex direct tool capabilities differ")
+    if not all(checks.values()) or (isinstance(output, str) and "=FAIL" in output):
+        problems.append("one or more filesystem/network/secret checks failed")
+    if any(value != b"unchanged\n" for value in marker_bytes.values()):
+        problems.append("one or more /usr write markers changed")
+    allowed_events = {
+        "thread.started",
+        "turn.started",
+        "item.started",
+        "item.updated",
+        "item.completed",
+        "turn.completed",
+    }
+    if not event_types or set(event_types) - allowed_events:
+        problems.append("Codex emitted an unexpected JSONL event type")
+    if event_types.count("turn.completed") != 1:
+        problems.append("Codex did not complete exactly one preflight turn")
+    if problems:
+        stderr_digest = hashlib.sha256(stderr.encode("utf-8")).hexdigest()
+        raise RuntimeError(
+            "isolation preflight failed: "
+            + "; ".join(problems)
+            + f"; stderr_sha256={stderr_digest}"
+        )
+    codex_arguments = command[command.index(str(config.codex_bin)) + 1 : -1]
+    provider_base_prefix = (
+        f"model_providers.{config.planner_transport.provider_id}.base_url="
+    )
+    normalized_arguments = [
+        (
+            f"{provider_base_prefix}<loopback-preflight>"
+            if item.startswith(provider_base_prefix)
+            else item
+        )
+        for item in codex_arguments
+    ]
+    attestation: dict[str, Any] = {
+        "schema_version": 2,
+        "passed": True,
+        "codex": {
+            "version": PINNED_CODEX_VERSION,
+            "sha256": PINNED_CODEX_SHA256,
+        },
+        "launcher_sha256": FROZEN_RUNTIME_SHA256["isolation_launcher"],
+        "sandbox_adapter_sha256": sha256_file(Path(__file__).with_name("sandbox.py")),
+        "profile": {
+            "permission_profile": "rpent_outer_landlock",
+            "filesystem_authority": (
+                "outer_rldx_landlock_abi1_uid_gid_fixed_mailboxes"
+            ),
+            "codex_filesystem_view": "full_write_fast_path_no_inner_fs_sandbox",
+            "command_network_authority": ("codex_0.147_restricted_network_seccomp"),
+            "arguments_sha256": canonical_sha256(normalized_arguments),
+        },
+        "planner_transport": config.planner_transport.manifest_identity(),
+        "kernel_release": os.uname().release,
+        "landlock_abi": _landlock_abi(),
+        "tool_names": list(EXPECTED_TOOL_NAMES),
+        "tool_schema_sha256": state["tool_schema_sha256"],
+        "observed_item_types": observed_item_types,
+        "checks": checks,
+    }
+    attestation["attestation_sha256"] = canonical_sha256(attestation)
+    _write_private_json(isolation_attestation_path(config), attestation)
+    return attestation

--- a/rpent/reproduce/robocasa/preliminary_driver.py
+++ b/rpent/reproduce/robocasa/preliminary_driver.py
@@ -1,0 +1,388 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harden the external preliminary driver without modifying the source snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import stat
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+from PIL import Image
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _read_frozen_source(path: Path, expected_sha256: str) -> str:
+    from rpent.reproduce.robocasa.secure_script import _read_source
+
+    return _read_source(path, expected_sha256)
+
+
+def _configure_runtime_sources(driver_source: Path) -> None:
+    runtime_root = driver_source.resolve(strict=True).parent.parent
+    sources = (
+        runtime_root / "external_dependencies/robocasa365",
+        runtime_root / "external_dependencies/robocasa365/robosuite",
+    )
+    for source in reversed(sources):
+        metadata = source.lstat()
+        if (
+            source.is_symlink()
+            or not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o022
+        ):
+            raise RuntimeError(f"runtime dependency root is unsafe: {source}")
+        sys.path.insert(0, str(source))
+
+
+def _write_staged_source(path: Path, source: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o400)
+    try:
+        raw = source.encode("utf-8")
+        written = 0
+        while written < len(raw):
+            written += os.write(descriptor, raw[written:])
+        os.fchmod(descriptor, 0o400)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _load_driver(path: Path, source: str) -> ModuleType:
+    module = ModuleType("_rpent_external_driver")
+    module.__file__ = str(path)
+    module.__package__ = ""
+    exec(compile(source, str(path), "exec", dont_inherit=True), module.__dict__)
+    return module
+
+
+def _regular_nonempty(path: Path) -> None:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_size <= 0
+    ):
+        raise RuntimeError(f"missing or unsafe navview artifact: {path.name}")
+
+
+def _validate_navview(workdir: Path, step: int) -> None:
+    suffix = f"{step:02d}"
+    image_path = workdir / f"image_nav_{suffix}.png"
+    floor_path = workdir / f"image_nav_floor_{suffix}.png"
+    world_path = workdir / f"world_nav_{suffix}.npy"
+    for path in (image_path, floor_path, world_path):
+        _regular_nonempty(path)
+    with Image.open(image_path) as image:
+        image.load()
+        if image.mode != "RGB" or image.size != (256, 256):
+            raise RuntimeError("navview RGB must be a 256x256 image")
+    world = np.load(world_path, allow_pickle=False)
+    if (
+        world.shape != (256, 256, 3)
+        or world.dtype != np.float32
+        or not np.isfinite(world).all()
+    ):
+        raise RuntimeError("navview world map must be finite float32[256,256,3]")
+
+
+def _publish_done_before_deadline(
+    original_publish_done, path: str | Path, *, run_id: str
+) -> None:
+    from rpent.reproduce.robocasa.deadline_supervisor import (
+        CONTRACT_NAME,
+        DEADLINE_PROTOCOL,
+        GATE_NAME,
+        RECEIPT_PREFIX,
+        SEAL_NAME,
+        DeadlineError,
+        _atomic_json,
+        _open_gate,
+        _read_trusted_json,
+        _remove_done_marker,
+        process_identity,
+    )
+
+    marker = Path(path)
+    raw_step = marker.name[5:-5] if marker.name.startswith("done_") else ""
+    try:
+        step = int(raw_step)
+    except ValueError as exc:
+        raise DeadlineError(f"invalid commit marker name: {marker.name}") from exc
+    if marker.name != f"done_{step:02d}.flag":
+        raise DeadlineError(f"non-canonical commit marker name: {marker.name}")
+    if step == 0:
+        original_publish_done(path)
+        return
+
+    workdir = marker.parent
+    gate_descriptor = _open_gate(workdir / GATE_NAME, create=False)
+    try:
+        fcntl.flock(gate_descriptor, fcntl.LOCK_EX)
+        contract, contract_sha256 = _read_trusted_json(workdir / CONTRACT_NAME)
+        driver = contract.get("driver")
+        started_ns = contract.get("started_monotonic_ns")
+        deadline_ns = contract.get("deadline_monotonic_ns")
+        timeout_ns = contract.get("timeout_ns")
+        nonce = contract.get("nonce")
+        current_identity = process_identity(os.getpid())
+        expected_contract_keys = {
+            "schema_version",
+            "protocol",
+            "run_id",
+            "nonce",
+            "started_monotonic_ns",
+            "deadline_monotonic_ns",
+            "timeout_ns",
+            "driver",
+            "external_deadline_sha256",
+        }
+        expected_driver = (
+            {key: current_identity[key] for key in ("pid", "pgid", "start_time_ticks")}
+            if current_identity is not None
+            else None
+        )
+        external_sha256 = contract.get("external_deadline_sha256")
+        if (
+            set(contract) != expected_contract_keys
+            or contract.get("schema_version") != 1
+            or contract.get("protocol") != DEADLINE_PROTOCOL
+            or contract.get("run_id") != run_id
+            or driver != expected_driver
+            or not isinstance(nonce, str)
+            or len(nonce) != 32
+            or any(character not in "0123456789abcdef" for character in nonce)
+            or type(started_ns) is not int
+            or type(deadline_ns) is not int
+            or type(timeout_ns) is not int
+            or started_ns <= 0
+            or timeout_ns <= 0
+            or deadline_ns != started_ns + timeout_ns
+            or not isinstance(external_sha256, str)
+            or len(external_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in external_sha256)
+        ):
+            raise DeadlineError("deadline contract does not match this rollout driver")
+        try:
+            seal_metadata = (workdir / SEAL_NAME).lstat()
+        except FileNotFoundError:
+            seal_metadata = None
+        if seal_metadata is not None:
+            raise SystemExit(75)
+        commit_started_ns = time.monotonic_ns()
+        if commit_started_ns < started_ns:
+            raise DeadlineError("deadline contract starts in the future")
+        if commit_started_ns >= deadline_ns:
+            raise SystemExit(75)
+        receipt_path = workdir / f"{RECEIPT_PREFIX}{step:02d}.json"
+        if (
+            marker.exists()
+            or marker.is_symlink()
+            or receipt_path.exists()
+            or receipt_path.is_symlink()
+        ):
+            raise DeadlineError(f"deadline commit step {step} was already published")
+        # The marker's completed write, not the pre-write check, is the deadline
+        # receipt. The gate keeps the freezer out until a late marker is removed.
+        original_publish_done(path)
+        published_ns = time.monotonic_ns()
+        _atomic_json(
+            receipt_path,
+            {
+                "schema_version": 1,
+                "protocol": DEADLINE_PROTOCOL,
+                "run_id": run_id,
+                "nonce": nonce,
+                "step": step,
+                "deadline_monotonic_ns": deadline_ns,
+                "done_published_monotonic_ns": published_ns,
+                "contract_sha256": contract_sha256,
+            },
+        )
+        if published_ns >= deadline_ns:
+            _remove_done_marker(marker)
+            raise SystemExit(75)
+    finally:
+        try:
+            fcntl.flock(gate_descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(gate_descriptor)
+
+
+def _patch_driver(module: ModuleType, *, run_id: str | None = None) -> None:
+    from rpent.reproduce.robocasa.protocol import command_problem
+
+    class EpisodeSuccess(RuntimeError):
+        """Control-flow signal raised before any post-success simulator step."""
+
+    driver_class = module.RoboCasaDriver
+    original_dump = driver_class.dump_state
+    original_execute = driver_class.execute
+    original_publish_done = getattr(module, "_publish_done", None)
+
+    if original_publish_done is not None:
+
+        def publish_done(path):
+            marker = Path(path)
+            is_initial = marker.name == "done_00.flag"
+            if run_id is None and not is_initial:
+                raise RuntimeError("deadline run identity is unavailable")
+            if is_initial:
+                original_publish_done(path)
+            else:
+                assert run_id is not None
+                _publish_done_before_deadline(
+                    original_publish_done, path, run_id=run_id
+                )
+            if getattr(module, "_rpent_exit_after_done", False):
+                raise SystemExit(0)
+
+        module._publish_done = publish_done
+
+    environment_class = getattr(module, "RoboCasaInteractiveEnv", None)
+    if environment_class is not None:
+        original_reset = environment_class.reset
+        original_step = environment_class.step
+
+        def reset(self):
+            observation = original_reset(self)
+            self._terminated = bool(self.env._check_success())
+            return observation
+
+        def step(self, action):
+            if self._terminated:
+                raise EpisodeSuccess
+            return original_step(self, action)
+
+        environment_class.reset = reset
+        environment_class.step = step
+
+    def dump_state(self, step_idx, publish_done=True):
+        state = original_dump(self, step_idx, publish_done=False)
+        _validate_navview(Path(self.workdir), step_idx)
+        state["success"] = bool(self.env.terminated)
+        module._rpent_exit_after_done = state["success"]
+        module._atomic_write_json(
+            f"{self.workdir}/state_{step_idx:02d}.json", state, indent=2
+        )
+        if publish_done:
+            module._publish_done(f"{self.workdir}/done_{step_idx:02d}.flag")
+        return state
+
+    def execute(self, command):
+        task_language = self.env.current_raw_obs.get(
+            "language"
+        ) or self.env.env.get_ep_meta().get("lang", "")
+        if problem := command_problem(command, task_language=task_language):
+            return {"error": f"invalid command schema: {problem}"}
+        if self.env.terminated:
+            raise SystemExit(0)
+        action = command["action"]
+        try:
+            if action == "move_delta":
+                self._vla_desync = True
+                return self.move_delta(
+                    command["dxyz"],
+                    command.get("gripper", "hold"),
+                    command.get("step_clip", 0.02),
+                    command.get("max_steps", 80),
+                )
+            if action == "rotate_pitch":
+                self._vla_desync = True
+                return self.rotate_pitch(
+                    command.get("target_pitch", 0.6),
+                    command.get("gripper", 1),
+                    command.get("n", 12),
+                )
+            if action == "navigate_to":
+                self._vla_desync = True
+                return self.navigate_to(
+                    command["xy"],
+                    command.get("tol", 0.20),
+                    command.get("max_steps", 300),
+                    command.get("gripper", "hold"),
+                )
+            if action == "move_base":
+                self._vla_desync = True
+                return self.move_base(
+                    command.get("forward", 0),
+                    command.get("lateral", 0),
+                    command.get("turn", 0),
+                    command.get("steps", 10),
+                    command.get("gripper", "hold"),
+                )
+            return original_execute(self, command)
+        except EpisodeSuccess:
+            return {"status": "task_success", "success": True}
+
+    driver_class.dump_state = dump_state
+    driver_class.execute = execute
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--driver-source", type=Path, required=True)
+    parser.add_argument("--driver-sha256", required=True)
+    parser.add_argument("--interactive-env-sha256", required=True)
+    parser.add_argument("--rldx-skill-sha256", required=True)
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--split", choices=("target", "pretrain", "all"), required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--workdir", type=Path, required=True)
+    parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+    _configure_runtime_sources(args.driver_source)
+    driver_source = _read_frozen_source(args.driver_source, args.driver_sha256)
+    interactive_source = _read_frozen_source(
+        args.driver_source.parent / "robocasa_interactive_env.py",
+        args.interactive_env_sha256,
+    )
+    skill_source = _read_frozen_source(
+        args.driver_source.parent / "rldx_skill.py", args.rldx_skill_sha256
+    )
+    with tempfile.TemporaryDirectory(prefix="rpent-robocasa-runtime-") as temporary:
+        stage = Path(temporary)
+        driver_path = stage / "robocasa_interactive_driver.py"
+        _write_staged_source(stage / "robocasa_interactive_env.py", interactive_source)
+        _write_staged_source(stage / "rldx_skill.py", skill_source)
+        module = _load_driver(driver_path, driver_source)
+        _patch_driver(module, run_id=args.run_id)
+        module._die_with_parent()
+        module.RoboCasaDriver(
+            args.env,
+            args.split,
+            args.seed,
+            str(args.workdir),
+        ).run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rpent/reproduce/robocasa/profiles.py
+++ b/rpent/reproduce/robocasa/profiles.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frozen planner profiles for RoboCasa reference runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from .executor import ExecutorConfig
+    from .protocol import Cell
+
+
+@dataclass(frozen=True)
+class PlannerProfile:
+    """Immutable planner identity used in result provenance."""
+
+    name: str
+    backend: str
+    model: str
+    reasoning_effort: str
+
+
+class PlannerAdapter(Protocol):
+    """Construct one planner command behind the frozen isolation boundary."""
+
+    backend: str
+    audit_id: str
+    trusted_symlink_labels: frozenset[str]
+
+    def required_files(self, config: "ExecutorConfig") -> dict[str, Path]:
+        """Return backend-owned executable inputs for fail-closed doctor checks."""
+        ...
+
+    def build_command(
+        self,
+        config: "ExecutorConfig",
+        *,
+        workdir: Path,
+        run_id: str,
+        cell: "Cell",
+    ) -> list[str]:
+        """Return an argv vector without embedding planner credentials."""
+        ...
+
+
+PROFILES = {
+    "codex-gpt55-xhigh": PlannerProfile(
+        name="codex-gpt55-xhigh",
+        backend="codex",
+        model="gpt-5.5",
+        reasoning_effort="xhigh",
+    ),
+    "claude-opus48": PlannerProfile(
+        name="claude-opus48",
+        backend="claude_code",
+        model="claude-opus-4-8",
+        reasoning_effort="high",
+    ),
+}
+
+# Audit status is release metadata, not part of the frozen scientific profile.
+AUDITED_PROFILE_NAMES = frozenset({"codex-gpt55-xhigh"})
+
+
+def is_audited_profile(profile: PlannerProfile) -> bool:
+    """Return whether an exact frozen profile has a formal adapter audit."""
+    return (
+        profile.name in AUDITED_PROFILE_NAMES and PROFILES.get(profile.name) == profile
+    )
+
+
+def get_profile(name: str) -> PlannerProfile:
+    """Resolve one frozen profile without permitting field overrides."""
+    try:
+        return PROFILES[name]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown planner profile {name!r}; expected one of {sorted(PROFILES)}"
+        ) from exc

--- a/rpent/reproduce/robocasa/protocol.py
+++ b/rpent/reproduce/robocasa/protocol.py
@@ -1,0 +1,283 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The immutable RoboCasa365 paper-reproduction matrix."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class Split(str, Enum):
+    ATOMIC = "atomic"
+    COMPOSITE_SEEN = "composite_seen"
+    COMPOSITE_UNSEEN = "composite_unseen"
+
+
+ALLOWED_ACTIONS = frozenset(
+    {
+        "navigate_to",
+        "move_base",
+        "move_to",
+        "move_delta",
+        "rotate_pitch",
+        "set_gripper",
+        "release",
+        "vla_act",
+    }
+)
+
+ACTION_PARAMETERS = {
+    "navigate_to": (frozenset({"xy"}), frozenset({"tol", "max_steps", "gripper"})),
+    "move_base": (
+        frozenset(),
+        frozenset({"forward", "lateral", "turn", "steps", "gripper"}),
+    ),
+    "move_to": (
+        frozenset({"xyz"}),
+        frozenset({"gripper", "step_clip", "max_steps", "tol"}),
+    ),
+    "move_delta": (
+        frozenset({"dxyz"}),
+        frozenset({"gripper", "step_clip", "max_steps"}),
+    ),
+    "rotate_pitch": (
+        frozenset(),
+        frozenset({"target_pitch", "gripper", "n"}),
+    ),
+    "set_gripper": (frozenset(), frozenset({"gripper", "steps"})),
+    "release": (frozenset(), frozenset({"steps"})),
+    "vla_act": (frozenset({"prompt"}), frozenset()),
+}
+
+
+def _finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    )
+
+
+def _vector(value: Any, size: int) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) == size
+        and all(_finite_number(item) for item in value)
+    )
+
+
+def _positive_int(value: Any, maximum: int = 10_000) -> bool:
+    return type(value) is int and 1 <= value <= maximum
+
+
+def _gripper(value: Any) -> bool:
+    return value == "hold" or _finite_number(value)
+
+
+def command_problem(command: Any, *, task_language: str | None = None) -> str | None:
+    """Return why a formal command is invalid, or ``None`` when it is exact."""
+    if not isinstance(command, dict):
+        return "command must be an object"
+    action = command.get("action")
+    if action not in ALLOWED_ACTIONS:
+        return "disallowed primitive"
+    required, optional = ACTION_PARAMETERS[action]
+    keys = set(command) - {"action"}
+    missing = required - keys
+    extras = keys - required - optional
+    if missing:
+        return f"missing parameters: {sorted(missing)}"
+    if extras:
+        return f"unexpected parameters: {sorted(extras)}"
+
+    vector_fields = {"xy": 2, "xyz": 3, "dxyz": 3}
+    for name, size in vector_fields.items():
+        if name in command and not _vector(command[name], size):
+            return f"{name} must be a finite {size}-vector"
+    for name in ("max_steps", "steps", "n"):
+        if name in command and not _positive_int(command[name]):
+            return f"{name} must be an integer in [1, 10000]"
+    for name in ("forward", "lateral", "turn"):
+        if name in command and not _finite_number(command[name]):
+            return f"{name} must be finite"
+    if "gripper" in command:
+        if action in {"set_gripper", "rotate_pitch"} and not _finite_number(
+            command["gripper"]
+        ):
+            return f"{action} gripper must be finite"
+        if action not in {"set_gripper", "rotate_pitch"} and not _gripper(
+            command["gripper"]
+        ):
+            return "gripper must be finite or 'hold'"
+    if "step_clip" in command and not (
+        _finite_number(command["step_clip"]) and 0 < command["step_clip"] <= 0.30
+    ):
+        return "step_clip must be finite and in (0, 0.30]"
+    if "tol" in command:
+        maximum = 5.0 if action == "navigate_to" else 1.0
+        if not (_finite_number(command["tol"]) and 0 < command["tol"] <= maximum):
+            return f"{action} tol must be finite and in (0, {maximum}]"
+    if "target_pitch" in command and not (
+        _finite_number(command["target_pitch"])
+        and -1.5 <= command["target_pitch"] <= 1.5
+    ):
+        return "target_pitch must be finite and in [-1.5, 1.5]"
+    if action == "vla_act":
+        prompt = command.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return "vla_act prompt must be a non-empty string"
+        if task_language is not None and prompt != task_language:
+            return "vla_act prompt differs from task_language"
+    return None
+
+
+ATOMIC_TASKS = (
+    "CloseBlenderLid",
+    "CloseFridge",
+    "CloseToasterOvenDoor",
+    "CoffeeSetupMug",
+    "NavigateKitchen",
+    "OpenCabinet",
+    "OpenDrawer",
+    "OpenStandMixerHead",
+    "PickPlaceCounterToCabinet",
+    "PickPlaceCounterToStove",
+    "PickPlaceDrawerToCounter",
+    "PickPlaceSinkToCounter",
+    "PickPlaceToasterToCounter",
+    "SlideDishwasherRack",
+    "TurnOffStove",
+    "TurnOnElectricKettle",
+    "TurnOnMicrowave",
+    "TurnOnSinkFaucet",
+)
+COMPOSITE_SEEN_TASKS = (
+    "ScrubCuttingBoard",
+    "StackBowlsCabinet",
+    "WashLettuce",
+    "RinseSinkBasin",
+    "PreSoakPan",
+    "StirVegetables",
+    "LoadDishwasher",
+    "SteamInMicrowave",
+    "SetUpCuttingStation",
+    "GetToastedBread",
+    "DeliverStraw",
+    "KettleBoiling",
+    "PrepareCoffee",
+    "StoreLeftoversInBowl",
+    "SearingMeat",
+    "PackIdenticalLunches",
+)
+COMPOSITE_UNSEEN_TASKS = (
+    "ArrangeBreadBasket",
+    "ArrangeTea",
+    "BreadSelection",
+    "CategorizeCondiments",
+    "CuttingToolSelection",
+    "GarnishPancake",
+    "GatherTableware",
+    "HeatKebabSandwich",
+    "MakeIceLemonade",
+    "PanTransfer",
+    "PortionHotDogs",
+    "RecycleBottlesByType",
+    "SeparateFreezerRack",
+    "WaffleReheat",
+    "WashFruitColander",
+    "WeighIngredients",
+)
+EMPTY_MEMORY_TASKS = frozenset(
+    {
+        "HeatKebabSandwich",
+        "PanTransfer",
+        "PortionHotDogs",
+        "SeparateFreezerRack",
+        "WaffleReheat",
+        "WashFruitColander",
+        "WeighIngredients",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SplitSpec:
+    tasks: tuple[str, ...]
+    seeds: tuple[int, ...]
+    timeout_seconds: int
+
+
+@dataclass(frozen=True, order=True)
+class Cell:
+    split: Split
+    task: str
+    seed: int
+
+    @property
+    def tag(self) -> str:
+        return f"{self.task}_s{self.seed}"
+
+
+SPLITS = {
+    Split.ATOMIC: SplitSpec(ATOMIC_TASKS, tuple(range(1, 11)), 1800),
+    Split.COMPOSITE_SEEN: SplitSpec(COMPOSITE_SEEN_TASKS, tuple(range(1, 6)), 3600),
+    Split.COMPOSITE_UNSEEN: SplitSpec(COMPOSITE_UNSEEN_TASKS, tuple(range(1, 6)), 3600),
+}
+CELLS = tuple(
+    Cell(split, task, seed)
+    for split, spec in SPLITS.items()
+    for seed in spec.seeds
+    for task in spec.tasks
+)
+EXPECTED_ROLLOUTS = 340
+PROTOCOL_ID = "robocasa-harness-vla-v1"
+PAPER_REFERENCES = {
+    "RLDX-1": {"atomic": 60.0, "composite_seen": 21.3, "composite_unseen": 5.0},
+    "Harness VLA (Codex)": {
+        "atomic": 91.6,
+        "composite_seen": 56.3,
+        "composite_unseen": 13.8,
+    },
+    "Harness VLA (CC)": {
+        "atomic": 79.4,
+        "composite_seen": 47.5,
+        "composite_unseen": 15.0,
+    },
+}
+MEMORY_PAIR_TASKS = frozenset(
+    set(ATOMIC_TASKS)
+    | set(COMPOSITE_SEEN_TASKS)
+    | (set(COMPOSITE_UNSEEN_TASKS) - set(EMPTY_MEMORY_TASKS))
+)
+
+assert len(ALLOWED_ACTIONS) == 8
+assert set(ACTION_PARAMETERS) == set(ALLOWED_ACTIONS)
+assert len(CELLS) == EXPECTED_ROLLOUTS
+assert len(MEMORY_PAIR_TASKS) == 43
+assert len(EMPTY_MEMORY_TASKS) == 7
+
+
+def cell_for(split: Split | str, task: str, seed: int) -> Cell:
+    """Return a cell only when it belongs to the frozen matrix."""
+    split = Split(split)
+    spec = SPLITS[split]
+    if task not in spec.tasks or type(seed) is not int or seed not in spec.seeds:
+        raise ValueError(
+            f"cell is outside the frozen protocol: {split.value}/{task}/s{seed}"
+        )
+    return Cell(split, task, seed)

--- a/rpent/reproduce/robocasa/provenance.py
+++ b/rpent/reproduce/robocasa/provenance.py
@@ -1,0 +1,682 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Immutable run identity shared by execution, resume, and validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .planner_transport import (
+    API_KEY_AUTH,
+    CHATGPT_BROKER_PROTOCOL,
+    CHATGPT_ENDPOINT_IDENTITY,
+    CHATGPT_SUBSCRIPTION_AUTH,
+    codex_provider_retry_policy,
+)
+from .protocol import PROTOCOL_ID
+
+RUN_MANIFEST_NAME = "_run_manifest.json"
+RUN_MANIFEST_SCHEMA_VERSION = 3
+ISOLATION_ATTESTATION_NAME = "isolation-attestation.json"
+RUN_CONFIGURATION_FIELDS = frozenset(
+    {
+        "protocol_id",
+        "runtime_kind",
+        "preliminary",
+        "planner",
+        "memory",
+        "checkpoint",
+        "runtime",
+        "implementation_sha256",
+    }
+)
+
+
+def sha256_file(path: Path) -> str:
+    path = Path(path).resolve(strict=True)
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _implementation_hashes() -> dict[str, str]:
+    repo = Path(__file__).resolve().parents[3]
+    paths = {
+        *repo.glob("rpent/reproduce/robocasa/*.py"),
+        *repo.glob("robots/robocasa/**/*.py"),
+        *repo.glob("robots/robocasa/**/*.json"),
+        *repo.glob("robots/robocasa/**/*.patch"),
+    }
+    return {
+        path.relative_to(repo).as_posix(): sha256_file(path)
+        for path in sorted(paths)
+        if path.is_file() and not path.is_symlink()
+    }
+
+
+def _tree_identity(root: Path, suffixes: frozenset[str]) -> dict[str, Any]:
+    if not root.is_dir():
+        raise ValueError(f"required runtime source tree is missing: {root}")
+    files = {
+        path.relative_to(root).as_posix(): sha256_file(path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+        and not path.is_symlink()
+        and path.suffix in suffixes
+        and ".venv" not in path.parts
+        and "__pycache__" not in path.parts
+    }
+    return {
+        "root": str(root.resolve()),
+        "file_count": len(files),
+        "tree_sha256": canonical_sha256(files),
+    }
+
+
+def _git_identity(root: Path) -> dict[str, Any]:
+    try:
+        commit = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        diff = subprocess.run(
+            ["git", "-C", str(root), "diff", "--binary", "HEAD", "--"],
+            check=True,
+            capture_output=True,
+        ).stdout
+        status = subprocess.run(
+            ["git", "-C", str(root), "status", "--porcelain=v1"],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return {"root": str(root), "available": False}
+    return {
+        "root": str(root.resolve()),
+        "available": True,
+        "commit": commit,
+        "tracked_diff_sha256": hashlib.sha256(diff).hexdigest(),
+        "status_sha256": hashlib.sha256(status).hexdigest(),
+    }
+
+
+def _codex_identity(path: Path) -> dict[str, Any]:
+    entrypoint = Path(path).resolve(strict=True)
+    files = {"entrypoint": sha256_file(entrypoint)}
+    package_root = entrypoint.parent.parent if entrypoint.parent.name == "bin" else None
+    if package_root is not None:
+        package_json = package_root / "package.json"
+        if package_json.is_file() and not package_json.is_symlink():
+            files["package.json"] = sha256_file(package_json)
+        native = sorted(
+            package_root.glob("node_modules/@openai/codex-*/vendor/*/bin/codex")
+        )
+        if entrypoint.name == "codex.js" and len(native) != 1:
+            raise ValueError(
+                "Codex JS entrypoint must resolve to exactly one native binary"
+            )
+        for binary in native:
+            if binary.is_file() and not binary.is_symlink():
+                files[binary.relative_to(package_root).as_posix()] = sha256_file(binary)
+    return {
+        "entrypoint": str(entrypoint),
+        "files_sha256": files,
+    }
+
+
+def build_run_configuration(
+    config: Any,
+    checkpoint_attestation: dict[str, Any],
+    *,
+    isolation_attestation: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the secret-free scientific identity for one results root."""
+    runtime = config.runtime
+    runtime_inputs = {
+        "sim_python": runtime.sim_python,
+        "driver": runtime.driver,
+        "readiness": runtime.readiness,
+        "deadline": runtime.deadline,
+        "isolation_launcher": runtime.isolation_launcher,
+        "artifact_builder": runtime.artifact_builder,
+        "interactive_env": runtime.root / "migration/robocasa_interactive_env.py",
+        "rldx_skill": runtime.root / "migration/rldx_skill.py",
+        "preliminary_driver_adapter": Path(__file__).with_name("preliminary_driver.py"),
+        "deadline_supervisor_adapter": Path(__file__).with_name(
+            "deadline_supervisor.py"
+        ),
+        "secure_script_adapter": Path(__file__).with_name("secure_script.py"),
+        "navview_xml": runtime.navview_xml,
+    }
+    profile = config.planner_profile
+    transport = config.planner_transport
+    return {
+        "protocol_id": PROTOCOL_ID,
+        "runtime_kind": "preliminary_external_snapshot",
+        "preliminary": bool(config.preliminary_local_runtime),
+        "planner": {
+            "profile": profile.name,
+            "backend": profile.backend,
+            "model": profile.model,
+            "reasoning_effort": profile.reasoning_effort,
+            **transport.manifest_identity(),
+            "wire_api": "responses",
+            "provider_retry_policy": codex_provider_retry_policy(),
+            "credential_boundary": (
+                "root_broker_oauth_outside_cell"
+                if transport.uses_broker
+                else "cell_codex_only_generated_shell_excluded"
+            ),
+            "network_policy": {
+                "generated_shell_network": False,
+                "web_search": False,
+                "direct_tool_network": False,
+            },
+            "isolation": {
+                "filesystem_authority": (
+                    "outer_rldx_landlock_abi1_uid_gid_fixed_mailboxes"
+                ),
+                "codex_filesystem_view": "full_write_fast_path_no_inner_fs_sandbox",
+                "command_network_authority": ("codex_0.147_restricted_network_seccomp"),
+                "permission_profile": "rpent_outer_landlock",
+                "managed_config": "etc_codex_empty_or_absent",
+                "external_source_loading": "nofollow_fstat_sha256_open_bytes",
+            },
+            "codex": _codex_identity(config.codex_bin),
+            "isolation_preflight": isolation_attestation,
+        },
+        "memory": {
+            "source": config.memory_source,
+            "revision": config.memory_revision,
+            "manifest_sha256": sha256_file(config.memory_root / "manifest.json"),
+            "global_memory": False,
+            "task_notes": False,
+        },
+        "checkpoint": {
+            "checkpoint_id": checkpoint_attestation["checkpoint_id"],
+            "authority_manifest_sha256": checkpoint_attestation[
+                "authority_manifest_sha256"
+            ],
+            "fingerprint": checkpoint_attestation["fingerprint"],
+        },
+        "runtime": {
+            "root": str(runtime.root.resolve()),
+            "inputs_sha256": {
+                name: sha256_file(path) for name, path in runtime_inputs.items()
+            },
+            "navview": {
+                "camera": "mobilebase0_navview",
+                "mode": "fixed",
+                "pos": "0.2 0 1.6",
+                "xyaxes": "0 -1 0 0.643 0 0.766",
+                "fovy": "75",
+            },
+            "startup_timeout_seconds": config.startup_timeout_seconds,
+            "kill_after_seconds": config.kill_after_seconds,
+            "driver_policy": {
+                "perception_isolation": True,
+                "reset_enabled": False,
+                "initial_reset_seed": {
+                    "atomic": None,
+                    "composite_seen": "4200000 + protocol seed",
+                    "composite_unseen": None,
+                },
+                "max_chunks": 40,
+                "settle_patience": 999,
+                "attention_implementation": "sdpa",
+            },
+            "source_trees": {
+                "rldx": _tree_identity(
+                    runtime.root / "rldx",
+                    frozenset({".py", ".json", ".yaml", ".yml", ".jinja"}),
+                ),
+                "robocasa_python": _tree_identity(
+                    runtime.root / "external_dependencies/robocasa365/robocasa",
+                    frozenset({".py"}),
+                ),
+                "robosuite_python": _tree_identity(
+                    runtime.root
+                    / "external_dependencies/robocasa365/robosuite/robosuite",
+                    frozenset({".py"}),
+                ),
+            },
+            "source_git": {
+                "robocasa": _git_identity(
+                    runtime.root / "external_dependencies/robocasa365/robocasa"
+                ),
+                "robosuite": _git_identity(
+                    runtime.root / "external_dependencies/robocasa365/robosuite"
+                ),
+            },
+        },
+        "implementation_sha256": _implementation_hashes(),
+    }
+
+
+def make_run_manifest(configuration: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
+        "protocol_id": PROTOCOL_ID,
+        "run_config_sha256": canonical_sha256(configuration),
+        "config": configuration,
+    }
+
+
+def validate_run_manifest_value(value: Any) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version",
+        "protocol_id",
+        "run_config_sha256",
+        "config",
+    }:
+        return None, "run manifest must contain exactly the frozen fields"
+    if value.get("schema_version") != RUN_MANIFEST_SCHEMA_VERSION:
+        return None, "unsupported run manifest schema_version"
+    if value.get("protocol_id") != PROTOCOL_ID:
+        return None, "run manifest protocol_id mismatch"
+    configuration = value.get("config")
+    if not isinstance(configuration, dict):
+        return None, "run manifest config must be an object"
+    if set(configuration) != RUN_CONFIGURATION_FIELDS:
+        return None, "run manifest config must contain exactly the preliminary schema"
+    if configuration.get("protocol_id") != PROTOCOL_ID:
+        return None, "run manifest config protocol_id mismatch"
+    if configuration.get("runtime_kind") != "preliminary_external_snapshot":
+        return None, "only the preliminary external runtime is currently supported"
+    if configuration.get("preliminary") is not True:
+        return None, "formal publication runtime is not implemented"
+    nested_fields = {
+        "planner": {
+            "profile",
+            "backend",
+            "model",
+            "reasoning_effort",
+            "auth_mode",
+            "provider",
+            "endpoint_identity",
+            "credential_broker",
+            "credential_broker_protocol",
+            "wire_api",
+            "provider_retry_policy",
+            "credential_boundary",
+            "network_policy",
+            "isolation",
+            "codex",
+            "isolation_preflight",
+        },
+        "memory": {
+            "source",
+            "revision",
+            "manifest_sha256",
+            "global_memory",
+            "task_notes",
+        },
+        "checkpoint": {
+            "checkpoint_id",
+            "authority_manifest_sha256",
+            "fingerprint",
+        },
+        "runtime": {
+            "root",
+            "inputs_sha256",
+            "navview",
+            "startup_timeout_seconds",
+            "kill_after_seconds",
+            "driver_policy",
+            "source_trees",
+            "source_git",
+        },
+    }
+    for name, expected in nested_fields.items():
+        item = configuration.get(name)
+        if not isinstance(item, dict) or set(item) != expected:
+            return None, f"run manifest config.{name} does not match the frozen schema"
+    if (
+        configuration["planner"].get("provider_retry_policy")
+        != codex_provider_retry_policy()
+    ):
+        return None, "run manifest planner retry policy differs"
+    implementation = configuration.get("implementation_sha256")
+    if (
+        not isinstance(implementation, dict)
+        or not implementation
+        or any(
+            not isinstance(path, str)
+            or not path
+            or not isinstance(file_digest, str)
+            or len(file_digest) != 64
+            or any(character not in "0123456789abcdef" for character in file_digest)
+            for path, file_digest in implementation.items()
+        )
+    ):
+        return None, "run manifest implementation identity is invalid"
+    digest = value.get("run_config_sha256")
+    if not isinstance(digest, str) or digest != canonical_sha256(configuration):
+        return None, "run manifest config digest mismatch"
+    return value, None
+
+
+def load_run_manifest(root: Path) -> tuple[dict[str, Any] | None, str | None]:
+    path = Path(root) / RUN_MANIFEST_NAME
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None, "missing run manifest"
+    except OSError as exc:
+        return None, f"cannot inspect run manifest: {exc}"
+    if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        return None, "run manifest must be a regular non-symlink file"
+    if metadata.st_uid != os.geteuid() or stat.S_IMODE(metadata.st_mode) != 0o600:
+        return None, "run manifest must be owned by the run user with mode 0600"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeError, ValueError) as exc:
+        return None, f"invalid run manifest JSON: {exc}"
+    return validate_run_manifest_value(value)
+
+
+def _exclusive_write(path: Path, value: dict[str, Any]) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        payload = (
+            json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        os.write(descriptor, payload)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _load_isolation_attestation(root: Path) -> dict[str, Any]:
+    path = root / "_preflight" / ISOLATION_ATTESTATION_NAME
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"missing or unreadable isolation attestation: {exc}") from exc
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+    ):
+        raise ValueError("isolation attestation must be owned, regular, and mode 0600")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ValueError(f"invalid isolation attestation JSON: {exc}") from exc
+    required = {
+        "schema_version",
+        "passed",
+        "codex",
+        "launcher_sha256",
+        "sandbox_adapter_sha256",
+        "profile",
+        "planner_transport",
+        "kernel_release",
+        "landlock_abi",
+        "tool_names",
+        "tool_schema_sha256",
+        "observed_item_types",
+        "checks",
+        "attestation_sha256",
+    }
+    if not isinstance(value, dict) or set(value) != required:
+        raise ValueError("isolation attestation fields differ from the frozen schema")
+    digest = value.get("attestation_sha256")
+    payload = {key: item for key, item in value.items() if key != "attestation_sha256"}
+    if (
+        value.get("schema_version") != 2
+        or value.get("passed") is not True
+        or not isinstance(digest, str)
+        or digest != canonical_sha256(payload)
+    ):
+        raise ValueError("isolation attestation digest or pass state is invalid")
+
+    def is_sha256(item: Any) -> bool:
+        return (
+            isinstance(item, str)
+            and len(item) == 64
+            and all(character in "0123456789abcdef" for character in item)
+        )
+
+    codex = value.get("codex")
+    profile = value.get("profile")
+    planner_transport = value.get("planner_transport")
+    expected_profile = {
+        "permission_profile": "rpent_outer_landlock",
+        "filesystem_authority": ("outer_rldx_landlock_abi1_uid_gid_fixed_mailboxes"),
+        "codex_filesystem_view": "full_write_fast_path_no_inner_fs_sandbox",
+        "command_network_authority": "codex_0.147_restricted_network_seccomp",
+    }
+    expected_checks = {
+        "scratch_write",
+        "root_create_blocked",
+        "rpent_read_blocked",
+        "runtime_read_blocked",
+        "proc_environ_read_blocked",
+        "shell_network_blocked",
+        "planner_secret_absent",
+        "usr_write_blocked",
+        "apply_patch_outside_blocked",
+        "view_image_outside_blocked",
+        "exec_escalation_rejected",
+        "deadline_controls_root_only",
+    }
+    if codex != {
+        "version": "codex-cli 0.147.0",
+        "sha256": ("cb0a15567e9a60a5820d54b0f6ae86d504dc3805c1eab21a47f70e3eb7b73a40"),
+    }:
+        raise ValueError("isolation attestation Codex identity is not approved")
+    if value.get("launcher_sha256") != (
+        "6f0173f39753a8268b0b73aac2b729066f9798a0679c07e705a7c22f45cf81cb"
+    ):
+        raise ValueError("isolation attestation launcher identity is not approved")
+    if value.get("sandbox_adapter_sha256") != sha256_file(
+        Path(__file__).with_name("sandbox.py")
+    ):
+        raise ValueError("isolation attestation sandbox adapter identity differs")
+    if (
+        not isinstance(profile, dict)
+        or set(profile) != {*expected_profile, "arguments_sha256"}
+        or any(profile.get(key) != item for key, item in expected_profile.items())
+        or not is_sha256(profile.get("arguments_sha256"))
+    ):
+        raise ValueError("isolation attestation profile identity differs")
+    if not isinstance(planner_transport, dict) or set(planner_transport) != {
+        "auth_mode",
+        "provider",
+        "endpoint_identity",
+        "credential_broker",
+        "credential_broker_protocol",
+    }:
+        raise ValueError("isolation attestation planner transport is malformed")
+    auth_mode = planner_transport.get("auth_mode")
+    if auth_mode == API_KEY_AUTH:
+        valid_transport = (
+            planner_transport.get("provider") == "rpent_responses_api"
+            and isinstance(planner_transport.get("endpoint_identity"), str)
+            and planner_transport["endpoint_identity"].startswith("responses_api:")
+            and planner_transport.get("credential_broker") is False
+            and planner_transport.get("credential_broker_protocol") is None
+        )
+    elif auth_mode == CHATGPT_SUBSCRIPTION_AUTH:
+        valid_transport = planner_transport == {
+            "auth_mode": CHATGPT_SUBSCRIPTION_AUTH,
+            "provider": "rpent_chatgpt_broker",
+            "endpoint_identity": CHATGPT_ENDPOINT_IDENTITY,
+            "credential_broker": True,
+            "credential_broker_protocol": CHATGPT_BROKER_PROTOCOL,
+        }
+    else:
+        valid_transport = False
+    if not valid_transport:
+        raise ValueError("isolation attestation planner transport is not approved")
+    if (
+        not isinstance(value.get("kernel_release"), str)
+        or not value["kernel_release"]
+        or type(value.get("landlock_abi")) is not int
+        or value["landlock_abi"] < 1
+    ):
+        raise ValueError("isolation attestation kernel identity is invalid")
+    if value.get("tool_names") != [
+        "apply_patch",
+        "exec_command",
+        "update_plan",
+        "view_image",
+        "write_stdin",
+    ] or not is_sha256(value.get("tool_schema_sha256")):
+        raise ValueError("isolation attestation capability identity differs")
+    observed = value.get("observed_item_types")
+    if observed != ["agent_message", "command_execution", "file_change"]:
+        raise ValueError("isolation attestation item-event identity is invalid")
+    checks = value.get("checks")
+    if (
+        not isinstance(checks, dict)
+        or set(checks) != expected_checks
+        or any(item is not True for item in checks.values())
+    ):
+        raise ValueError("isolation attestation checks are incomplete")
+    return value
+
+
+def _only_approved_preflight(root: Path, entries: list[Path]) -> bool:
+    by_name = {entry.name: entry for entry in entries if entry.parent == root}
+    if (
+        len(by_name) != len(entries)
+        or not by_name
+        or not set(by_name)
+        <= {
+            "_preflight",
+            ".rpent-run.lock",
+        }
+    ):
+        return False
+    lock = by_name.get(".rpent-run.lock")
+    if lock is not None:
+        try:
+            lock_metadata = lock.lstat()
+        except OSError:
+            return False
+        if (
+            lock.is_symlink()
+            or not stat.S_ISREG(lock_metadata.st_mode)
+            or lock_metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(lock_metadata.st_mode) != 0o600
+            or lock_metadata.st_nlink != 1
+        ):
+            return False
+    directory = by_name.get("_preflight")
+    if directory is None:
+        return lock is not None
+    try:
+        metadata = directory.lstat()
+    except OSError:
+        return False
+    if (
+        directory.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        return False
+    children = list(directory.iterdir())
+    names = {child.name for child in children}
+    if len(names) != len(children) or names not in (
+        {ISOLATION_ATTESTATION_NAME},
+        {"checkpoint-attestation.json", ISOLATION_ATTESTATION_NAME},
+    ):
+        return False
+    for attestation in children:
+        try:
+            metadata = attestation.lstat()
+        except OSError:
+            return False
+        if (
+            attestation.is_symlink()
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            return False
+    return True
+
+
+def ensure_run_manifest(
+    config: Any,
+    checkpoint_attestation: dict[str, Any],
+) -> dict[str, Any]:
+    """Create one immutable run identity, or require an exact existing match."""
+    root = Path(config.results_root)
+    isolation_attestation = _load_isolation_attestation(root)
+    if (
+        isolation_attestation.get("planner_transport")
+        != config.planner_transport.manifest_identity()
+    ):
+        raise ValueError("isolation preflight belongs to a different planner transport")
+    candidate = make_run_manifest(
+        build_run_configuration(
+            config,
+            checkpoint_attestation,
+            isolation_attestation=isolation_attestation,
+        )
+    )
+    path = root / RUN_MANIFEST_NAME
+    existing, problem = load_run_manifest(root)
+    if existing is not None:
+        if existing != candidate:
+            raise ValueError(
+                "results root belongs to a different RoboCasa run configuration"
+            )
+        return existing
+    if problem != "missing run manifest":
+        raise ValueError(problem)
+    entries = list(root.iterdir())
+    if entries and not _only_approved_preflight(root, entries):
+        raise ValueError(
+            "refusing to attach a run manifest to a non-empty results root"
+        )
+    try:
+        _exclusive_write(path, candidate)
+    except FileExistsError:
+        existing, problem = load_run_manifest(root)
+        if problem is not None or existing != candidate:
+            raise ValueError(
+                "concurrent process created a different or invalid run manifest"
+            )
+        return existing
+    return candidate

--- a/rpent/reproduce/robocasa/sandbox.py
+++ b/rpent/reproduce/robocasa/sandbox.py
@@ -1,0 +1,426 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapt the audited RLDX Codex launcher to a configurable rollout root.
+
+The migration launcher is deliberately reused for the preliminary local parity
+run.  Its only machine-specific assumption is that workdirs live under /tmp;
+this adapter replaces that containment check with the explicit RPent run root.
+It also keeps the root-only deadline authority outside the launcher's planner
+read-sharing pass.  Fixed-mailbox, setuid, and Landlock logic remains in the
+audited launcher.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+from types import ModuleType
+
+DEADLINE_CONTROL_NAMES = frozenset({"_deadline_commit.gate", "_deadline_contract.json"})
+
+
+def _load_launcher(path: Path, expected_sha256: str) -> ModuleType:
+    """Execute the pinned launcher from one securely opened file description."""
+    if len(expected_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in expected_sha256
+    ):
+        raise SystemExit("isolation launcher SHA-256 must be lowercase hexadecimal")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise SystemExit(f"cannot securely open isolation launcher: {exc}") from exc
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != os.geteuid()
+            or before.st_mode & 0o022
+            or before.st_size <= 0
+            or before.st_size > 1024 * 1024
+        ):
+            raise SystemExit(
+                "isolation launcher must be owned, regular, immutable, and bounded"
+            )
+        chunks: list[bytes] = []
+        remaining = before.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 64 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        source = b"".join(chunks)
+        after = os.fstat(descriptor)
+        identity = lambda value: (  # noqa: E731 - compact immutable identity tuple
+            value.st_dev,
+            value.st_ino,
+            value.st_uid,
+            value.st_gid,
+            value.st_mode,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        )
+        if identity(before) != identity(after) or len(source) != before.st_size:
+            raise SystemExit("isolation launcher changed while it was being read")
+    finally:
+        os.close(descriptor)
+    if hashlib.sha256(source).hexdigest() != expected_sha256:
+        raise SystemExit("isolation launcher does not match its frozen SHA-256")
+    try:
+        text = source.decode("utf-8")
+    except UnicodeError as exc:
+        raise SystemExit("isolation launcher must be UTF-8 source") from exc
+    module = ModuleType("_rpent_rldx_isolation")
+    module.__file__ = str(path)
+    module.__package__ = ""
+    exec(compile(text, str(path), "exec", dont_inherit=True), module.__dict__)
+    return module
+
+
+def _inside(path: Path, parent: Path, label: str) -> Path:
+    resolved = path.resolve()
+    root = parent.resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise SystemExit(f"{label} must be inside {root}: {resolved}") from exc
+    if not relative.parts:
+        raise SystemExit(f"{label} cannot be the rollout root itself: {resolved}")
+    return resolved
+
+
+def _rollout_root_problem(path: Path) -> str | None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        return f"cannot inspect rollout root: {exc}"
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+        return f"rollout root must be a real directory: {path}"
+    if metadata.st_uid != os.geteuid():
+        return "rollout root must be owned by the caller"
+    if stat.S_IMODE(metadata.st_mode) != 0o711:
+        return "rollout root must have exact mode 0711"
+    resolved = path.resolve()
+    for parent in reversed(resolved.parents):
+        try:
+            parent_metadata = parent.stat()
+        except OSError as exc:
+            return f"cannot inspect rollout ancestor {parent}: {exc}"
+        if parent_metadata.st_mode & stat.S_IXOTH == 0:
+            return f"rollout ancestor is not planner-traversable: {parent}"
+    return None
+
+
+def _deadline_control_metadata(
+    path: Path,
+    descriptor: int,
+    *,
+    owner_uid: int,
+    owner_gid: int,
+) -> os.stat_result:
+    try:
+        opened = os.fstat(descriptor)
+        linked = path.lstat()
+    except OSError as exc:
+        raise SystemExit(f"cannot inspect deadline control {path.name}: {exc}") from exc
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or not stat.S_ISREG(linked.st_mode)
+        or opened.st_nlink != 1
+        or (opened.st_dev, opened.st_ino) != (linked.st_dev, linked.st_ino)
+        or opened.st_uid != owner_uid
+        or opened.st_gid != owner_gid
+        or stat.S_IMODE(opened.st_mode) != 0o600
+    ):
+        raise SystemExit(f"deadline control is unsafe: {path.name}")
+    return opened
+
+
+def _control_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _pin_deadline_controls(
+    workdir: Path, *, owner_uid: int, owner_gid: int
+) -> tuple[dict[str, int], dict[str, tuple[int, ...]]]:
+    present = {
+        entry.name for entry in workdir.iterdir() if entry.name.startswith("_deadline_")
+    }
+    if present != DEADLINE_CONTROL_NAMES:
+        raise SystemExit(
+            "deadline control set differs before isolation: "
+            f"expected {sorted(DEADLINE_CONTROL_NAMES)}, found {sorted(present)}"
+        )
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptors: dict[str, int] = {}
+    identities: dict[str, tuple[int, ...]] = {}
+    try:
+        for name in sorted(DEADLINE_CONTROL_NAMES):
+            path = workdir / name
+            descriptor = os.open(path, flags)
+            descriptors[name] = descriptor
+            identities[name] = _control_identity(
+                _deadline_control_metadata(
+                    path,
+                    descriptor,
+                    owner_uid=owner_uid,
+                    owner_gid=owner_gid,
+                )
+            )
+    except BaseException:
+        for descriptor in descriptors.values():
+            os.close(descriptor)
+        raise
+    return descriptors, identities
+
+
+def _prepare_isolated_workdir(
+    module: ModuleType,
+    workdir: Path,
+    uid: int,
+    gid: int,
+    *,
+    owner_uid: int = 0,
+    owner_gid: int = 0,
+) -> tuple[Path, Path]:
+    """Apply the pinned launcher's policy without exposing deadline controls."""
+    metadata = workdir.lstat()
+    if (
+        workdir.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != owner_uid
+        or metadata.st_gid != owner_gid
+    ):
+        raise SystemExit(
+            f"workdir must be an authority-owned non-symlink directory: {workdir}"
+        )
+    descriptors, identities = _pin_deadline_controls(
+        workdir, owner_uid=owner_uid, owner_gid=owner_gid
+    )
+    try:
+        task_memory = module.seal_task_memory(workdir)
+        for entry in list(workdir.iterdir()):
+            if entry.name in DEADLINE_CONTROL_NAMES:
+                continue
+            if task_memory is not None and entry == task_memory:
+                continue
+            entry_metadata = entry.lstat()
+            if not stat.S_ISREG(entry_metadata.st_mode):
+                raise SystemExit(
+                    f"unexpected non-regular workdir entry before isolation: {entry}"
+                )
+            if entry_metadata.st_uid != owner_uid:
+                raise SystemExit(
+                    f"driver artifact must remain authority-owned: {entry}"
+                )
+            os.chown(entry, owner_uid, gid)
+            mode = 0o600 if entry.name in ("driver.log", "agent.log") else 0o640
+            os.chmod(entry, mode)
+
+        private_paths = [workdir / name for name in module.PLANNER_WRITABLE_DIRECTORIES]
+        for path in private_paths:
+            module._create_private_directory(path, uid, gid)
+        for name in module.PLANNER_WRITABLE_MAILBOXES:
+            module._create_fixed_mailbox(workdir / name, gid)
+
+        os.chown(workdir, owner_uid, gid)
+        os.chmod(workdir, 0o2750)
+        module._publish_mailbox_marker(workdir, uid, gid)
+        return workdir / ".codex", workdir / "tmp"
+    finally:
+        try:
+            for name, descriptor in descriptors.items():
+                after = _deadline_control_metadata(
+                    workdir / name,
+                    descriptor,
+                    owner_uid=owner_uid,
+                    owner_gid=owner_gid,
+                )
+                if _control_identity(after) != identities[name]:
+                    raise SystemExit(
+                        f"deadline control changed during isolation: {name}"
+                    )
+        finally:
+            for descriptor in descriptors.values():
+                os.close(descriptor)
+
+
+def _anonymous_secret_fd() -> int:
+    """Create an anonymous, close-on-exec regular file for one credential."""
+    creator = getattr(os, "memfd_create", None)
+    if creator is not None:
+        return creator("rpent-planner-key", getattr(os, "MFD_CLOEXEC", 0x0001))
+
+    flags = getattr(os, "O_TMPFILE", 0)
+    if not flags:
+        raise SystemExit("anonymous planner credential storage is unavailable")
+    last_error: OSError | None = None
+    for directory in ("/dev/shm", "/tmp"):
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(
+                directory, flags | os.O_RDWR | getattr(os, "O_CLOEXEC", 0), 0o600
+            )
+            os.fchmod(descriptor, 0o600)
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 0
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                raise OSError("O_TMPFILE did not create the required anonymous inode")
+            os.set_inheritable(descriptor, False)
+            return descriptor
+        except OSError as exc:
+            last_error = exc
+            if descriptor is not None:
+                os.close(descriptor)
+    raise SystemExit(
+        "anonymous planner credential storage is unavailable"
+    ) from last_error
+
+
+def _secret_memfd(path: Path) -> tuple[int, str]:
+    """Copy an owned mode-0600 secret into an anonymous, exec-closing fd."""
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_size <= 1
+        or metadata.st_size > 16 * 1024
+    ):
+        raise SystemExit("API key file must be owned, regular, mode 0600, and bounded")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    source = os.open(path, flags)
+    try:
+        opened = os.fstat(source)
+        identity = (opened.st_dev, opened.st_ino, opened.st_size, opened.st_mtime_ns)
+        if identity != (
+            metadata.st_dev,
+            metadata.st_ino,
+            metadata.st_size,
+            metadata.st_mtime_ns,
+        ):
+            raise SystemExit("API key file changed while opening")
+        raw = os.read(source, metadata.st_size + 1)
+        after = os.fstat(source)
+        if (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+        ) != identity or len(raw) != metadata.st_size:
+            raise SystemExit("API key file changed while reading")
+    finally:
+        os.close(source)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeError as exc:
+        raise SystemExit("API key file must contain UTF-8 text") from exc
+    if len(text.splitlines()) != 1 or not text.strip():
+        raise SystemExit("API key file must contain exactly one non-empty line")
+    descriptor = _anonymous_secret_fd()
+    try:
+        remaining = memoryview(raw)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("anonymous credential write made no progress")
+            remaining = remaining[written:]
+        os.lseek(descriptor, 0, os.SEEK_SET)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor, f"/proc/self/fd/{descriptor}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--launcher", type=Path, required=True)
+    parser.add_argument("--launcher-sha256", required=True)
+    parser.add_argument("--rollout-root", type=Path, required=True)
+    parser.add_argument("launcher_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if not args.launcher_args or args.launcher_args[0] != "--":
+        parser.error("expected audited launcher arguments after --")
+
+    raw_rollout_root = args.rollout_root.expanduser()
+    if problem := _rollout_root_problem(raw_rollout_root):
+        raise SystemExit(problem)
+    rollout_root = raw_rollout_root.resolve()
+    if not rollout_root.is_dir():
+        raise SystemExit(f"rollout root must be a real directory: {rollout_root}")
+    launcher_args = list(args.launcher_args[1:])
+    if launcher_args.count("--key-file") != 1:
+        raise SystemExit("audited launcher requires exactly one --key-file")
+    key_index = launcher_args.index("--key-file")
+    if key_index + 1 >= len(launcher_args):
+        raise SystemExit("audited launcher --key-file has no value")
+    module = _load_launcher(args.launcher.expanduser(), args.launcher_sha256)
+    secret_fd, secret_path = _secret_memfd(Path(launcher_args[key_index + 1]))
+    launcher_args[key_index + 1] = secret_path
+
+    original_install_landlock = module.install_landlock_boundary
+
+    def prepare_isolated_workdir(workdir: Path, uid: int, gid: int):
+        _prepare_isolated_workdir(module, workdir, uid, gid)
+        return Path(".codex"), Path("tmp")
+
+    def install_landlock_boundary(_workdir: Path) -> None:
+        original_install_landlock(Path("."))
+
+    module.prepare_isolated_workdir = prepare_isolated_workdir
+    module.install_landlock_boundary = install_landlock_boundary
+
+    def require_inside(path: Path, _ignored: Path, label: str) -> Path:
+        return _inside(path, rollout_root, label)
+
+    module.require_inside = require_inside
+    previous = sys.argv
+    try:
+        sys.argv = [str(args.launcher), *launcher_args]
+        result = module.main()
+    finally:
+        sys.argv = previous
+        os.close(secret_fd)
+    return int(result or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rpent/reproduce/robocasa/secure_script.py
+++ b/rpent/reproduce/robocasa/secure_script.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execute one pinned external Python script from securely opened source bytes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+def _read_source(path: Path, expected_sha256: str) -> str:
+    if len(expected_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in expected_sha256
+    ):
+        raise SystemExit("expected SHA-256 must be lowercase hexadecimal")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise SystemExit(f"cannot securely open external script: {exc}") from exc
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != os.geteuid()
+            or before.st_mode & 0o022
+            or before.st_size <= 0
+            or before.st_size > 4 * 1024 * 1024
+        ):
+            raise SystemExit(
+                "external script must be owned, regular, immutable, and bounded"
+            )
+        chunks: list[bytes] = []
+        remaining = before.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 64 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        source = b"".join(chunks)
+        after = os.fstat(descriptor)
+        before_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_uid,
+            before.st_gid,
+            before.st_mode,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        )
+        after_identity = (
+            after.st_dev,
+            after.st_ino,
+            after.st_uid,
+            after.st_gid,
+            after.st_mode,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        )
+        if before_identity != after_identity or len(source) != before.st_size:
+            raise SystemExit("external script changed while it was being read")
+    finally:
+        os.close(descriptor)
+    if hashlib.sha256(source).hexdigest() != expected_sha256:
+        raise SystemExit("external script does not match its frozen SHA-256")
+    try:
+        return source.decode("utf-8")
+    except UnicodeError as exc:
+        raise SystemExit("external script must be UTF-8 source") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("script_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if not args.script_args or args.script_args[0] != "--":
+        parser.error("expected external script arguments after --")
+    source = _read_source(args.source, args.sha256)
+    previous = sys.argv
+    namespace = {
+        "__name__": "__main__",
+        "__file__": str(args.source),
+        "__package__": None,
+        "__builtins__": __builtins__,
+    }
+    try:
+        sys.argv = [str(args.source), *args.script_args[1:]]
+        exec(
+            compile(source, str(args.source), "exec", dont_inherit=True),
+            namespace,
+        )
+    finally:
+        sys.argv = previous
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rpent/reproduce/robocasa/validator.py
+++ b/rpent/reproduce/robocasa/validator.py
@@ -1,0 +1,1549 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One canonical validator shared by resume decisions and summaries."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .artifacts import CellResult, Completion, Integrity, Outcome, artifact_directory
+from .deadline_supervisor import (
+    DEADLINE_PROTOCOL,
+    FREEZE_NAME,
+    SEAL_NAME,
+    deadline_receipt_problem,
+    driver_stop_problem,
+    normalize_deadline_outcome,
+    timeout_driver_exit_problem,
+)
+from .protocol import (
+    CELLS,
+    EMPTY_MEMORY_TASKS,
+    PAPER_REFERENCES,
+    PROTOCOL_ID,
+    SPLITS,
+    Cell,
+    command_problem,
+)
+from .provenance import RUN_MANIFEST_NAME, load_run_manifest
+
+_ALLOWED_AGENT_EVENT_TYPES = frozenset(
+    {
+        "thread.started",
+        "turn.started",
+        "turn.completed",
+        "turn.failed",
+        "item.started",
+        "item.updated",
+        "item.completed",
+        "error",
+    }
+)
+_ALLOWED_AGENT_ITEM_TYPES = frozenset(
+    {"agent_message", "reasoning", "command_execution", "image_view", "todo_list"}
+)
+_HEX = frozenset("0123456789abcdef")
+_CONTRACT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "started_monotonic_ns",
+        "deadline_monotonic_ns",
+        "timeout_ns",
+        "driver",
+        "external_deadline_sha256",
+    }
+)
+_SUPERVISOR_FIELDS = frozenset(
+    {
+        "protocol",
+        "run_id",
+        "nonce",
+        "fired",
+        "contract_sha256",
+        "freeze_sha256",
+        "error",
+    }
+)
+_SEAL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "deadline_monotonic_ns",
+        "sealed_monotonic_ns",
+        "contract_sha256",
+    }
+)
+_FREEZE_PREFIX_FIELDS = frozenset(
+    {
+        "prefix_step",
+        "success",
+        "final_state_sha256",
+        "command_trace_sha256",
+        "raw_command_trace_sha256",
+        "files_sha256",
+    }
+)
+_FREEZE_FIELDS = frozenset(
+    {
+        "schema_version",
+        "protocol",
+        "run_id",
+        "nonce",
+        "deadline_monotonic_ns",
+        "frozen_monotonic_ns",
+        "contract_sha256",
+        "seal_sha256",
+        "driver",
+        "driver_stop",
+        "dropped_done_steps",
+        *_FREEZE_PREFIX_FIELDS,
+    }
+)
+_PLANNER_STATUS_FIELDS = frozenset(
+    {
+        "schema_version",
+        "state",
+        "started_at",
+        "finished_at",
+        "elapsed_seconds",
+        "timeout_seconds",
+        "kill_after_seconds",
+        "termination_cause",
+        "wrapper_rc",
+        "raw_termination_cause",
+        "raw_wrapper_rc",
+        "child_pid",
+        "child_pgid",
+        "child_rc",
+        "child_signal",
+        "deadline_fired",
+        "external_deadline_fired",
+        "interrupted_signal",
+        "forwarded_signal_sent",
+        "term_sent",
+        "kill_sent",
+        "orphan_cleanup_term_sent",
+        "parent_pid",
+        "parent_death_signal",
+        "parent_death_signal_enabled",
+        "parent_death_observed",
+        "subreaper_enabled",
+        "descendant_cleanup",
+        "spawn_error",
+        "supervision_error",
+        "protocol_violation_detected",
+        "policy_stop_triggered",
+        "policy_stop_source",
+        "provider_protocol_violation",
+        "live_codex_protocol_violation",
+        "stdout_total_lines",
+        "stdout_blank_lines",
+        "stdout_json_events",
+        "malformed_jsonl_lines",
+        "terminal_event_count",
+        "terminal_event_counts",
+        "terminal_event",
+        "forbidden_web_search_event_count",
+        "forbidden_web_search_event_counts",
+        "forbidden_web_search_event",
+        "deadline_supervisor",
+    }
+)
+_CLEANUP_FIELDS = frozenset(
+    {
+        "subreaper_enabled",
+        "complete",
+        "detected",
+        "term_sent",
+        "kill_sent",
+        "reaped",
+        "remaining",
+        "errors",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Validation:
+    cell: Cell
+    result: CellResult
+    artifact_problems: tuple[str, ...] = ()
+    protocol_problems: tuple[str, ...] = ()
+    provenance_problems: tuple[str, ...] = ()
+    audit: dict[str, Any] | None = None
+
+    @property
+    def problems(self) -> tuple[str, ...]:
+        return (
+            self.artifact_problems + self.protocol_problems + self.provenance_problems
+        )
+
+    @property
+    def resumable(self) -> bool:
+        return not self.result.canonical
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    if not isinstance(value, dict):
+        raise ValueError("root is not an object")
+    return value
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _validate_agent_log(path: Path, audit: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    timed_out = audit.get("termination_cause") == "planner_timeout"
+    try:
+        with path.open(encoding="utf-8", errors="replace") as stream:
+            lines = list(stream)
+    except Exception as exc:
+        return [f"evidence.agent_log is unreadable: {exc}"]
+    if not lines and not timed_out:
+        problems.append("evidence.agent_log has no events")
+    saw_turn_completed = False
+    reconnect_lines: list[int] = []
+    for number, raw in enumerate(lines, 1):
+        if not raw.strip():
+            if not timed_out:
+                problems.append(f"agent log line {number} is blank")
+            continue
+        try:
+            event = json.loads(raw)
+        except Exception as exc:
+            if not timed_out:
+                problems.append(f"agent log line {number} is invalid JSON: {exc}")
+            continue
+        if not isinstance(event, dict):
+            if not timed_out:
+                problems.append(f"agent log line {number} is not an event object")
+            continue
+        event_type = event.get("type")
+        if event_type not in _ALLOWED_AGENT_EVENT_TYPES:
+            problems.append(
+                f"agent log line {number} has prohibited or unknown "
+                f"event type {event_type!r}"
+            )
+            continue
+        if event_type == "turn.completed":
+            saw_turn_completed = True
+        if event_type == "turn.failed" and not timed_out:
+            problems.append(
+                f"agent log line {number} has prohibited event type {event_type!r}"
+            )
+            continue
+        if event_type == "error":
+            message = event.get("message")
+            if not isinstance(message, str) or not message.startswith(
+                "Reconnecting..."
+            ):
+                problems.append(
+                    f"agent log line {number} has a non-recoverable error event"
+                )
+            else:
+                reconnect_lines.append(number)
+            continue
+        if event_type.startswith("item."):
+            item = event.get("item")
+            if not isinstance(item, dict):
+                problems.append(
+                    f"agent log line {number} has item event without item object"
+                )
+                continue
+            item_type = item.get("type")
+            if item_type not in _ALLOWED_AGENT_ITEM_TYPES:
+                problems.append(
+                    f"agent log line {number} has prohibited or unknown "
+                    f"item type {item_type!r}"
+                )
+    if not timed_out and not saw_turn_completed:
+        problems.append("evidence.agent_log has no turn.completed event")
+    if reconnect_lines and not timed_out and not saw_turn_completed:
+        problems.append("agent transport reconnect was not followed by turn.completed")
+    return problems
+
+
+def _agent_log_summary(path: Path) -> dict[str, Any] | None:
+    """Rebuild the external wrapper's JSONL counters from archived bytes."""
+    try:
+        with path.open(encoding="utf-8", errors="replace") as stream:
+            lines = list(stream)
+    except OSError:
+        return None
+    blank_lines = 0
+    json_events = 0
+    malformed_lines = 0
+    terminal_events: list[dict[str, Any]] = []
+    web_events: list[dict[str, Any]] = []
+    for line_number, raw in enumerate(lines, 1):
+        if not raw.strip():
+            blank_lines += 1
+            continue
+        try:
+            event = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeError):
+            malformed_lines += 1
+            continue
+        if not isinstance(event, dict):
+            malformed_lines += 1
+            continue
+        json_events += 1
+        event_type = event.get("type")
+        if event_type in {"turn.completed", "turn.failed"}:
+            terminal_events.append({"type": event_type, "line_number": line_number})
+        item = event.get("item")
+        if event_type in {"item.started", "item.completed"} and isinstance(item, dict):
+            item_type = item.get("type")
+            if isinstance(item_type, str) and "web_search" in (
+                item_type.strip().lower().replace("-", "_")
+            ):
+                web_events.append(
+                    {
+                        "type": event_type,
+                        "item_type": item_type,
+                        "line_number": line_number,
+                    }
+                )
+    return {
+        "stdout_total_lines": len(lines),
+        "stdout_blank_lines": blank_lines,
+        "stdout_json_events": json_events,
+        "malformed_jsonl_lines": malformed_lines,
+        "terminal_event_count": len(terminal_events),
+        "terminal_event_counts": {
+            event_type: sum(event["type"] == event_type for event in terminal_events)
+            for event_type in ("turn.completed", "turn.failed")
+        },
+        "terminal_event": terminal_events[-1] if terminal_events else None,
+        "forbidden_web_search_event_count": len(web_events),
+        "forbidden_web_search_event_counts": {
+            event_type: sum(event["type"] == event_type for event in web_events)
+            for event_type in ("item.completed", "item.started")
+        },
+        "forbidden_web_search_event": web_events[0] if web_events else None,
+    }
+
+
+def _planner_raw_outcome(status: dict[str, Any]) -> tuple[str, int]:
+    """Replay the frozen external deadline wrapper's classify() function."""
+    if (
+        status.get("provider_protocol_violation") is not None
+        or status.get("forbidden_web_search_event_count") != 0
+    ):
+        return "planner_protocol_error", 23
+    interrupted = status.get("interrupted_signal")
+    if type(interrupted) is int:
+        return "operator_interrupted", 128 + interrupted
+    if status.get("external_deadline_fired") is True:
+        return "planner_timeout", 20
+    counts = status.get("terminal_event_counts")
+    failed = counts.get("turn.failed") if isinstance(counts, dict) else None
+    if type(failed) is int and failed:
+        return "planner_failed", 21
+    if status.get("child_rc") != 0:
+        return "planner_failed", 22
+    completed = counts.get("turn.completed") if isinstance(counts, dict) else None
+    if (
+        status.get("malformed_jsonl_lines") != 0
+        or status.get("terminal_event_count") != 1
+        or completed != 1
+    ):
+        return "planner_protocol_error", 23
+    return "planner_completed", 0
+
+
+def _planner_status_semantic_problems(
+    status: dict[str, Any],
+    agent_log: Path,
+    *,
+    timed_out: bool,
+) -> list[str]:
+    problems: list[str] = []
+    summary = _agent_log_summary(agent_log)
+    if summary is None:
+        problems.append("planner status cannot be replayed from evidence.agent_log")
+    elif any(status.get(key) != value for key, value in summary.items()):
+        problems.append(
+            "planner status JSONL summary disagrees with evidence.agent_log"
+        )
+
+    child_rc = status.get("child_rc")
+    child_signal = status.get("child_signal")
+    if type(child_rc) is not int or child_rc < 0:
+        problems.append("planner status child_rc must be a non-negative integer")
+    if child_signal is not None and (
+        type(child_signal) is not int
+        or child_signal <= 0
+        or child_rc != 128 + child_signal
+    ):
+        problems.append("planner status child signal and shell return code disagree")
+    for key in ("child_pid", "child_pgid", "parent_pid"):
+        if type(status.get(key)) is not int or status[key] <= 0:
+            problems.append(f"planner status {key} must be a positive integer")
+    if status.get("child_pid") != status.get("child_pgid"):
+        problems.append("planner status child pid and process group must agree")
+
+    raw_cause, raw_rc = _planner_raw_outcome(status)
+    if (
+        status.get("raw_termination_cause") != raw_cause
+        or status.get("raw_wrapper_rc") != raw_rc
+    ):
+        problems.append("planner raw outcome disagrees with replayed classification")
+    normalized_cause, normalized_rc = normalize_deadline_outcome(
+        raw_cause,
+        raw_rc,
+        supervisor_fired=timed_out,
+        provider_violation=status.get("provider_protocol_violation"),
+        forbidden_web_search_event_count=status.get("forbidden_web_search_event_count"),
+    )
+    if (
+        status.get("termination_cause") != normalized_cause
+        or status.get("wrapper_rc") != normalized_rc
+    ):
+        problems.append("planner final outcome disagrees with deadline normalization")
+    return problems
+
+
+def _parse_trace(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    commands: list[dict[str, Any]] = []
+    problems: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="strict").splitlines()
+    except Exception as exc:
+        return [], [f"trace is unreadable: {exc}"]
+    for number, raw in enumerate(lines, 1):
+        if not raw.strip():
+            problems.append(f"trace line {number} is blank")
+            continue
+        try:
+            command = json.loads(raw)
+        except Exception as exc:
+            problems.append(f"trace line {number} is invalid JSON: {exc}")
+            continue
+        if problem := command_problem(command):
+            problems.append(f"trace line {number} is invalid: {problem}")
+            continue
+        commands.append(command)
+    return commands, problems
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in _HEX for character in value)
+    )
+
+
+def _driver_problem(value: Any) -> str | None:
+    if not isinstance(value, dict) or set(value) != {
+        "pid",
+        "pgid",
+        "start_time_ticks",
+    }:
+        return "driver identity has an invalid schema"
+    if any(type(value[key]) is not int or value[key] <= 0 for key in value):
+        return "driver identity values must be positive integers"
+    return None
+
+
+def _trusted_digest(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"{path.name} is not a regular non-symlink file")
+    return _digest(path)
+
+
+def _canonical_trace(commands: list[dict[str, Any]]) -> bytes:
+    return b"".join(
+        (json.dumps(command, ensure_ascii=False, separators=(",", ":")) + "\n").encode(
+            "utf-8"
+        )
+        for command in commands
+    )
+
+
+def _receipt_problems(
+    receipt: dict[str, Any],
+    *,
+    step: int,
+    contract: dict[str, Any],
+    contract_sha256: str,
+    prefix: bool,
+) -> list[str]:
+    problems: list[str] = []
+    published = receipt.get("done_published_monotonic_ns")
+    problem = deadline_receipt_problem(
+        receipt,
+        step=step,
+        contract=contract,
+        contract_sha256=contract_sha256,
+        require_before_deadline=prefix,
+    )
+    if problem is not None:
+        problems.append(f"deadline receipt {step} {problem}")
+    elif not prefix and published < contract["deadline_monotonic_ns"]:
+        problems.append(f"on-time deadline receipt {step} has no committed marker")
+    return problems
+
+
+def _validate_frozen_prefix(
+    log_directory: Path,
+    directory: Path,
+    audit: dict[str, Any],
+    commands: list[dict[str, Any]],
+    contract: dict[str, Any],
+    contract_sha256: str,
+    freeze: dict[str, Any],
+) -> list[str]:
+    problems: list[str] = []
+    prefix_step = freeze.get("prefix_step")
+    if type(prefix_step) is not int or prefix_step < 0:
+        return ["deadline freeze prefix_step must be a non-negative integer"]
+
+    expected_names = {
+        *(f"done_{step:02d}.flag" for step in range(prefix_step + 1)),
+        *(f"state_{step:02d}.json" for step in range(prefix_step + 1)),
+        *(f"log_{step:02d}.json" for step in range(1, prefix_step + 1)),
+        *(f"_deadline_commit_{step:02d}.json" for step in range(1, prefix_step + 1)),
+    }
+    files = freeze.get("files_sha256")
+    if (
+        not isinstance(files, dict)
+        or set(files) != expected_names
+        or any(not _is_sha256(value) for value in files.values())
+    ):
+        return ["deadline freeze files_sha256 is not the exact canonical prefix"]
+
+    actual_done = {path.name for path in log_directory.glob("done_*.flag")}
+    expected_done = {f"done_{step:02d}.flag" for step in range(prefix_step + 1)}
+    if actual_done != expected_done:
+        problems.append("archived deadline prefix has missing or extra done markers")
+
+    for prefix, suffix, minimum_step in (
+        ("state_", ".json", 0),
+        ("log_", ".json", 1),
+        ("_deadline_commit_", ".json", 1),
+    ):
+        for path in log_directory.glob(f"{prefix}*{suffix}"):
+            raw_step = path.name[len(prefix) : -len(suffix)]
+            try:
+                step = int(raw_step)
+            except ValueError:
+                problems.append(
+                    f"archived deadline journal has invalid name {path.name}"
+                )
+                continue
+            if path.name != f"{prefix}{step:02d}{suffix}":
+                problems.append(
+                    f"archived deadline journal has invalid name {path.name}"
+                )
+            if step < minimum_step or (
+                step <= prefix_step and path.name not in expected_names
+            ):
+                problems.append(
+                    f"archived deadline journal is outside the canonical prefix/tail: "
+                    f"{path.name}"
+                )
+            try:
+                _trusted_digest(path)
+            except Exception as exc:
+                problems.append(
+                    f"archived deadline journal {path.name} is unsafe: {exc}"
+                )
+
+    for name, expected_digest in files.items():
+        path = log_directory / name
+        try:
+            actual_digest = _trusted_digest(path)
+        except Exception as exc:
+            problems.append(f"frozen journal {name} is missing or unsafe: {exc}")
+            continue
+        if actual_digest != expected_digest:
+            problems.append(f"frozen journal {name} hash disagrees with freeze")
+        if name.startswith("done_"):
+            try:
+                if path.stat().st_size != 0:
+                    problems.append(f"frozen marker {name} must be empty")
+            except OSError as exc:
+                problems.append(f"frozen marker {name} cannot be inspected: {exc}")
+
+    rebuilt: list[dict[str, Any]] = []
+    final_state: dict[str, Any] | None = None
+    task_language = audit.get("task_language")
+    for step in range(prefix_step + 1):
+        suffix = f"{step:02d}"
+        try:
+            state = _read_object(log_directory / f"state_{suffix}.json")
+        except Exception as exc:
+            problems.append(f"frozen state {step} is invalid JSON: {exc}")
+            continue
+        if state.get("step") != step or not isinstance(state.get("success"), bool):
+            problems.append(f"frozen state {step} has invalid step/success fields")
+        if (
+            not isinstance(state.get("task_language"), str)
+            or not state["task_language"]
+            or state["task_language"] != task_language
+        ):
+            problems.append(
+                f"frozen state {step} task_language disagrees with canonical audit"
+            )
+        final_state = state
+        if step == 0:
+            continue
+        try:
+            log = _read_object(log_directory / f"log_{suffix}.json")
+        except Exception as exc:
+            problems.append(f"frozen log {step} is invalid JSON: {exc}")
+            continue
+        command = log.get("command")
+        if not isinstance(command, dict) or (problem := command_problem(command)):
+            detail = (
+                problem if isinstance(command, dict) else "command is not an object"
+            )
+            problems.append(f"frozen log {step} has invalid command: {detail}")
+        else:
+            rebuilt.append(command)
+        try:
+            receipt = _read_object(log_directory / f"_deadline_commit_{suffix}.json")
+        except Exception as exc:
+            problems.append(f"deadline receipt {step} is invalid JSON: {exc}")
+        else:
+            problems.extend(
+                _receipt_problems(
+                    receipt,
+                    step=step,
+                    contract=contract,
+                    contract_sha256=contract_sha256,
+                    prefix=True,
+                )
+            )
+
+    for receipt_path in log_directory.glob("_deadline_commit_*.json"):
+        raw_step = receipt_path.name[len("_deadline_commit_") : -5]
+        if not raw_step.isdigit() or int(raw_step) <= prefix_step:
+            continue
+        try:
+            receipt = _read_object(receipt_path)
+        except Exception as exc:
+            problems.append(f"tail deadline receipt is invalid JSON: {exc}")
+            continue
+        problems.extend(
+            _receipt_problems(
+                receipt,
+                step=int(raw_step),
+                contract=contract,
+                contract_sha256=contract_sha256,
+                prefix=False,
+            )
+        )
+
+    trace_bytes = _canonical_trace(rebuilt)
+    trace_sha256 = hashlib.sha256(trace_bytes).hexdigest()
+    raw_trace = log_directory / "command_trace.jsonl"
+    try:
+        raw_trace_sha256 = _trusted_digest(raw_trace)
+    except Exception as exc:
+        problems.append(f"raw command trace is missing or unsafe: {exc}")
+    else:
+        if raw_trace_sha256 != freeze.get("raw_command_trace_sha256"):
+            problems.append("raw command trace hash disagrees with freeze")
+    try:
+        canonical_trace_sha256 = _trusted_digest(
+            directory / str(audit.get("command_trace"))
+        )
+    except Exception as exc:
+        problems.append(f"canonical command trace is missing or unsafe: {exc}")
+    else:
+        if canonical_trace_sha256 != trace_sha256:
+            problems.append("canonical command trace differs from frozen prefix logs")
+    if rebuilt != commands or trace_sha256 != freeze.get("command_trace_sha256"):
+        problems.append("deadline freeze command trace does not match rebuilt prefix")
+    if final_state is None:
+        problems.append("deadline freeze has no final state")
+    else:
+        final_state_path = log_directory / f"state_{prefix_step:02d}.json"
+        try:
+            final_state_sha256 = _trusted_digest(final_state_path)
+        except Exception as exc:
+            problems.append(f"deadline final state is missing or unsafe: {exc}")
+        else:
+            if final_state_sha256 != freeze.get("final_state_sha256"):
+                problems.append("deadline freeze final state hash disagrees")
+        if final_state.get("success") is not freeze.get("success"):
+            problems.append("deadline freeze success disagrees with final state")
+        if final_state.get("success") is not audit.get("success"):
+            problems.append("canonical audit success disagrees with frozen final state")
+    return problems
+
+
+def _validate_evidence(
+    directory: Path,
+    cell: Cell,
+    audit: dict[str, Any],
+    commands: list[dict[str, Any]],
+    configuration: dict[str, Any] | None,
+) -> list[str]:
+    problems: list[str] = []
+    evidence = audit.get("evidence")
+    if not isinstance(evidence, dict):
+        return ["evidence must be an object"]
+    timed_out = audit.get("termination_cause") == "planner_timeout"
+    expected_keys = {"agent_log", "planner_status", "deadline_contract"}
+    if timed_out:
+        expected_keys.update({"deadline_seal", "deadline_freeze"})
+    if set(evidence) != expected_keys:
+        problems.append("evidence must contain exactly the deadline protocol files")
+
+    paths: dict[str, Path] = {}
+    digests: dict[str, str] = {}
+    for key in expected_keys:
+        item = evidence.get(key)
+        if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+            problems.append(f"evidence.{key} must contain exactly path and sha256")
+            continue
+        relative, digest = item.get("path"), item.get("sha256")
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or Path(relative).is_absolute()
+            or ".." in Path(relative).parts
+        ):
+            problems.append(f"evidence.{key}.path must be a confined relative path")
+            continue
+        path = directory / relative
+        try:
+            unsafe_component = any(
+                candidate.is_symlink()
+                for candidate in (
+                    directory / Path(*Path(relative).parts[:index])
+                    for index in range(1, len(Path(relative).parts) + 1)
+                )
+            )
+            actual_digest = _trusted_digest(path)
+        except Exception as exc:
+            problems.append(f"evidence.{key} is missing or unsafe: {exc}")
+            continue
+        if unsafe_component or not _is_sha256(digest) or actual_digest != digest:
+            problems.append(f"evidence.{key} is unsafe or hash-mismatched")
+            continue
+        paths[key] = path
+        digests[key] = digest
+    if set(paths) != expected_keys:
+        return problems
+    if len({path.parent for path in paths.values()}) != 1:
+        problems.append("deadline evidence files must share one archived log directory")
+        return problems
+    log_directory = paths["deadline_contract"].parent
+    problems.extend(_validate_agent_log(paths["agent_log"], audit))
+
+    objects: dict[str, dict[str, Any]] = {}
+    for key in expected_keys - {"agent_log"}:
+        try:
+            objects[key] = _read_object(paths[key])
+        except Exception as exc:
+            problems.append(f"evidence.{key} is invalid JSON: {exc}")
+    if set(objects) != expected_keys - {"agent_log"}:
+        return problems
+
+    runtime = configuration.get("runtime") if isinstance(configuration, dict) else None
+    inputs = runtime.get("inputs_sha256") if isinstance(runtime, dict) else None
+    expected_external_sha256 = (
+        inputs.get("deadline") if isinstance(inputs, dict) else None
+    )
+    expected_kill_after = (
+        runtime.get("kill_after_seconds") if isinstance(runtime, dict) else None
+    )
+    expected_timeout = SPLITS[cell.split].timeout_seconds
+    expected_timeout_ns = expected_timeout * 1_000_000_000
+    if not _is_sha256(expected_external_sha256):
+        problems.append("root runtime deadline identity is missing or invalid")
+
+    deadline = audit.get("deadline")
+    contract = objects["deadline_contract"]
+    contract_sha256 = digests["deadline_contract"]
+    driver = contract.get("driver")
+    nonce = contract.get("nonce")
+    started_ns = contract.get("started_monotonic_ns")
+    deadline_ns = contract.get("deadline_monotonic_ns")
+    timeout_ns = contract.get("timeout_ns")
+    if set(contract) != _CONTRACT_FIELDS:
+        problems.append("deadline contract has an invalid schema")
+    if problem := _driver_problem(driver):
+        problems.append(problem)
+    if (
+        contract.get("schema_version") != 1
+        or contract.get("protocol") != DEADLINE_PROTOCOL
+        or contract.get("run_id") != audit.get("run_id")
+        or not isinstance(nonce, str)
+        or len(nonce) != 32
+        or any(character not in _HEX for character in nonce)
+        or type(started_ns) is not int
+        or started_ns <= 0
+        or type(deadline_ns) is not int
+        or type(timeout_ns) is not int
+        or timeout_ns != expected_timeout_ns
+        or deadline_ns != started_ns + timeout_ns
+        or contract.get("external_deadline_sha256") != expected_external_sha256
+        or not isinstance(deadline, dict)
+        or contract_sha256 != deadline.get("contract_sha256")
+        or deadline_ns != deadline.get("deadline_monotonic_ns")
+        or timeout_ns != deadline.get("timeout_ns")
+        or driver != deadline.get("driver")
+    ):
+        problems.append("deadline contract disagrees with audit/root protocol")
+
+    status = objects["planner_status"]
+    supervisor = status.get("deadline_supervisor")
+    cleanup = status.get("descendant_cleanup")
+    if set(status) != _PLANNER_STATUS_FIELDS:
+        problems.append("evidence.planner_status has an invalid schema")
+    if (
+        status.get("schema_version") != 1
+        or status.get("state") != "finished"
+        or status.get("termination_cause") != audit.get("termination_cause")
+        or status.get("wrapper_rc") != (20 if timed_out else 0)
+        or status.get("timeout_seconds") != expected_timeout
+        or status.get("kill_after_seconds") != expected_kill_after
+        or status.get("deadline_fired") is not timed_out
+        or type(status.get("external_deadline_fired")) is not bool
+        or status.get("interrupted_signal") is not None
+        or status.get("forwarded_signal_sent") is not False
+        or status.get("parent_death_signal") != 15
+        or status.get("parent_death_signal_enabled") is not True
+        or status.get("subreaper_enabled") is not True
+        or status.get("parent_death_observed") is not False
+        or status.get("spawn_error") is not None
+        or status.get("supervision_error") is not None
+        or status.get("protocol_violation_detected") is not False
+        or status.get("policy_stop_triggered") is not False
+        or status.get("policy_stop_source") is not None
+        or status.get("provider_protocol_violation") is not None
+        or status.get("live_codex_protocol_violation") is not None
+    ):
+        problems.append("evidence.planner_status is not a canonical planner outcome")
+    problems.extend(
+        _planner_status_semantic_problems(
+            status,
+            paths["agent_log"],
+            timed_out=timed_out,
+        )
+    )
+    if audit.get("agent_exit_code") != status.get("wrapper_rc"):
+        problems.append("audit agent_exit_code disagrees with planner wrapper status")
+    if (
+        not isinstance(cleanup, dict)
+        or set(cleanup) != _CLEANUP_FIELDS
+        or cleanup.get("subreaper_enabled") is not True
+        or cleanup.get("complete") is not True
+        or cleanup.get("remaining") != []
+        or cleanup.get("errors") != []
+        or status.get("term_sent") is not bool(cleanup.get("term_sent"))
+        or status.get("kill_sent") is not bool(cleanup.get("kill_sent"))
+        or status.get("orphan_cleanup_term_sent") is not bool(cleanup.get("term_sent"))
+    ):
+        problems.append("evidence.planner_status descendant cleanup is incomplete")
+    if (
+        not isinstance(supervisor, dict)
+        or set(supervisor) != _SUPERVISOR_FIELDS
+        or supervisor.get("protocol") != DEADLINE_PROTOCOL
+        or supervisor.get("run_id") != audit.get("run_id")
+        or supervisor.get("nonce") != nonce
+        or supervisor.get("fired") is not timed_out
+        or supervisor.get("contract_sha256") != contract_sha256
+        or supervisor.get("freeze_sha256")
+        != (digests.get("deadline_freeze") if timed_out else None)
+        or supervisor.get("error") is not None
+    ):
+        problems.append("planner deadline supervisor disagrees with contract/audit")
+
+    if not timed_out:
+        for name in (SEAL_NAME, FREEZE_NAME):
+            path = log_directory / name
+            if path.exists() or path.is_symlink():
+                problems.append(
+                    f"completed planner archive unexpectedly contains {name}"
+                )
+        return problems
+
+    seal = objects["deadline_seal"]
+    seal_sha256 = digests["deadline_seal"]
+    sealed_ns = seal.get("sealed_monotonic_ns")
+    if set(seal) != _SEAL_FIELDS:
+        problems.append("deadline seal has an invalid schema")
+    if (
+        seal.get("schema_version") != 1
+        or seal.get("protocol") != DEADLINE_PROTOCOL
+        or seal.get("run_id") != audit.get("run_id")
+        or seal.get("nonce") != nonce
+        or seal.get("deadline_monotonic_ns") != deadline_ns
+        or seal.get("contract_sha256") != contract_sha256
+        or type(sealed_ns) is not int
+        or sealed_ns < deadline_ns
+        or not isinstance(deadline, dict)
+        or seal_sha256 != deadline.get("seal_sha256")
+    ):
+        problems.append("deadline seal disagrees with contract/audit")
+
+    freeze = objects["deadline_freeze"]
+    freeze_sha256 = digests["deadline_freeze"]
+    frozen_ns = freeze.get("frozen_monotonic_ns")
+    driver_stop = freeze.get("driver_stop")
+    dropped = freeze.get("dropped_done_steps")
+    if set(freeze) != _FREEZE_FIELDS:
+        problems.append("deadline freeze has an invalid schema")
+    if problem := _driver_problem(freeze.get("driver")):
+        problems.append(f"deadline freeze {problem}")
+    prefix_step = freeze.get("prefix_step")
+    dropped_valid = (
+        isinstance(dropped, list)
+        and all(type(step) is int for step in dropped)
+        and dropped == sorted(set(dropped))
+        and type(prefix_step) is int
+        and all(step > prefix_step for step in dropped)
+    )
+    if (
+        freeze.get("schema_version") != 1
+        or freeze.get("protocol") != DEADLINE_PROTOCOL
+        or freeze.get("run_id") != audit.get("run_id")
+        or freeze.get("nonce") != nonce
+        or freeze.get("deadline_monotonic_ns") != deadline_ns
+        or freeze.get("contract_sha256") != contract_sha256
+        or freeze.get("seal_sha256") != seal_sha256
+        or freeze.get("driver") != driver
+        or type(frozen_ns) is not int
+        or type(sealed_ns) is not int
+        or frozen_ns < sealed_ns
+        or driver_stop_problem(driver_stop) is not None
+        or not dropped_valid
+        or freeze_sha256 != deadline.get("freeze_sha256")
+        or freeze.get("prefix_step") != audit.get("steps")
+        or freeze.get("success") is not audit.get("success")
+        or deadline.get("prefix_step") != freeze.get("prefix_step")
+        or deadline.get("success_at_deadline") is not freeze.get("success")
+        or deadline.get("driver_stop") != driver_stop
+    ):
+        problems.append("deadline freeze disagrees with sealed canonical audit")
+    problems.extend(
+        _validate_frozen_prefix(
+            log_directory,
+            directory,
+            audit,
+            commands,
+            contract,
+            contract_sha256,
+            freeze,
+        )
+    )
+    return problems
+
+
+def _validate_audit_provenance(
+    audit: dict[str, Any], configuration: dict[str, Any]
+) -> list[str]:
+    """Bind every cell's recorded identities to the root run configuration."""
+    problems: list[str] = []
+    planner = configuration.get("planner")
+    memory = configuration.get("memory")
+    checkpoint = configuration.get("checkpoint")
+    runtime = configuration.get("runtime")
+    if not all(
+        isinstance(item, dict) for item in (planner, memory, checkpoint, runtime)
+    ):
+        return ["root run configuration identities are malformed"]
+    assert isinstance(planner, dict)
+    assert isinstance(memory, dict)
+    assert isinstance(checkpoint, dict)
+    assert isinstance(runtime, dict)
+
+    planner_fields = {
+        "planner_profile": "profile",
+        "planner_backend": "backend",
+        "planner_model": "model",
+        "planner_reasoning_effort": "reasoning_effort",
+        "planner_auth_mode": "auth_mode",
+        "planner_provider": "provider",
+        "planner_endpoint_identity": "endpoint_identity",
+    }
+    for audit_name, config_name in planner_fields.items():
+        if audit.get(audit_name) != planner.get(config_name):
+            problems.append(f"audit {audit_name} differs from the root run manifest")
+
+    if audit.get("preliminary") is not configuration.get("preliminary"):
+        problems.append("audit preliminary flag differs from the root run manifest")
+    if audit.get("release_ready") is not False:
+        problems.append("preliminary runtime audit must set release_ready=false")
+    if audit.get("runtime_root") != runtime.get("root"):
+        problems.append("audit runtime_root differs from the root run manifest")
+
+    inputs = runtime.get("inputs_sha256")
+    navview = runtime.get("navview")
+    if not isinstance(inputs, dict) or not isinstance(navview, dict):
+        problems.append("root runtime input identity is malformed")
+    else:
+        expected_scripts = {
+            "external_driver": inputs.get("driver"),
+            "external_deadline": inputs.get("deadline"),
+            "driver_adapter": inputs.get("preliminary_driver_adapter"),
+            "deadline_supervisor": inputs.get("deadline_supervisor_adapter"),
+            "artifact_builder": inputs.get("artifact_builder"),
+        }
+        if audit.get("runtime_scripts") != expected_scripts:
+            problems.append("audit runtime_scripts differ from the root run manifest")
+        expected_navview = {"xml_sha256": inputs.get("navview_xml"), **navview}
+        if audit.get("navview") != expected_navview:
+            problems.append("audit navview identity differs from the root run manifest")
+
+    expected_memory = {
+        "kind": memory.get("source"),
+        "revision": memory.get("revision"),
+        "manifest_sha256": memory.get("manifest_sha256"),
+    }
+    if audit.get("memory_source") != expected_memory:
+        problems.append("audit memory_source differs from the root run manifest")
+
+    recorded_checkpoint = audit.get("checkpoint")
+    if not isinstance(recorded_checkpoint, dict):
+        problems.append("audit checkpoint identity is missing")
+    else:
+        for key in (
+            "checkpoint_id",
+            "authority_manifest_sha256",
+            "fingerprint",
+        ):
+            if recorded_checkpoint.get(key) != checkpoint.get(key):
+                problems.append(
+                    f"audit checkpoint.{key} differs from the root manifest"
+                )
+        files = recorded_checkpoint.get("files")
+        shard_names = (
+            "model-00001-of-00003.safetensors",
+            "model-00002-of-00003.safetensors",
+            "model-00003-of-00003.safetensors",
+        )
+        expected_shards = (
+            {name: files.get(f"model/{name}") for name in shard_names}
+            if isinstance(files, dict)
+            else None
+        )
+        if audit.get("checkpoint_sha256") != expected_shards:
+            problems.append(
+                "audit checkpoint shard hashes disagree with attested files"
+            )
+    return problems
+
+
+def _validate_protocol(
+    directory: Path,
+    cell: Cell,
+    audit: dict[str, Any],
+    commands: list[dict[str, Any]],
+    trace_name: str,
+    run_config_sha256: str | None,
+    run_configuration: dict[str, Any] | None,
+) -> list[str]:
+    problems: list[str] = []
+    required = {
+        "suite": "robocasa365",
+        "source": "harness",
+        "commit_protocol": "done_marker_v1",
+        "memory_role": "formal_evaluation",
+        "command_trace": trace_name,
+    }
+    for key, expected in required.items():
+        if audit.get(key) != expected:
+            problems.append(f"{key}={audit.get(key)!r}, expected {expected!r}")
+    if audit.get("protocol_id") != PROTOCOL_ID:
+        problems.append(f"protocol_id must be {PROTOCOL_ID}")
+    if run_config_sha256 is None or audit.get("run_config_sha256") != run_config_sha256:
+        problems.append("audit run_config_sha256 must match the root run manifest")
+    if audit.get("split") != cell.split.value:
+        problems.append(f"split must be {cell.split.value}")
+    if type(audit.get("schema_version")) is not int or audit.get("schema_version") != 1:
+        problems.append("schema_version must be integer 1")
+    if audit.get("valid") is not True:
+        problems.append("valid must be true")
+    for key, expected in (
+        ("global_memory", False),
+        ("task_notes_available", False),
+        ("perception_isolation", True),
+        ("reset_enabled", False),
+    ):
+        if audit.get(key) is not expected:
+            problems.append(f"{key} must be {expected}")
+    expected_reset_seed = (
+        4_200_000 + cell.seed if cell.split.value == "composite_seen" else None
+    )
+    if audit.get("reset_seed") != expected_reset_seed:
+        problems.append(
+            f"reset_seed must be protocol-derived value {expected_reset_seed!r}"
+        )
+    if audit.get("artifact_errors") != []:
+        problems.append("artifact_errors must be empty")
+    if type(audit.get("steps")) is not int or audit.get("steps") != len(commands):
+        problems.append(f"steps must equal trace command count {len(commands)}")
+    for key in ("trace_recovered_from_logs", "rollout_timeout"):
+        if not isinstance(audit.get(key), bool):
+            problems.append(f"{key} must be boolean")
+    dropped = audit.get("incomplete_commands_dropped")
+    if type(dropped) is not int or dropped < 0:
+        problems.append("incomplete_commands_dropped must be a non-negative integer")
+    if type(audit.get("agent_exit_code")) is not int:
+        problems.append("agent_exit_code must be an integer")
+    success = audit.get("success")
+    if not isinstance(success, bool):
+        problems.append("success must be boolean")
+    failure_type = audit.get("failure_type")
+    if success is True and failure_type is not None:
+        problems.append("successful rollout must have null failure_type")
+    if success is False and failure_type not in {"task_failure", "rollout_timeout"}:
+        problems.append("failed rollout has invalid failure_type")
+    timeout = audit.get("rollout_timeout") is True
+    if success is False and (failure_type == "rollout_timeout") != timeout:
+        problems.append("rollout_timeout flag and failure_type disagree")
+    deadline = audit.get("deadline")
+    if not isinstance(deadline, dict) or set(deadline) != {
+        "protocol",
+        "contract_sha256",
+        "seal_sha256",
+        "freeze_sha256",
+        "deadline_monotonic_ns",
+        "timeout_ns",
+        "driver",
+        "driver_stop",
+        "driver_return_code_before_stop",
+        "prefix_step",
+        "success_at_deadline",
+    }:
+        problems.append("deadline attestation has an invalid schema")
+    else:
+        contract_sha256 = deadline.get("contract_sha256")
+        seal_sha256 = deadline.get("seal_sha256")
+        freeze_sha256 = deadline.get("freeze_sha256")
+        expected_timeout_ns = SPLITS[cell.split].timeout_seconds * 1_000_000_000
+        if (
+            deadline.get("protocol") != DEADLINE_PROTOCOL
+            or not _is_sha256(contract_sha256)
+            or type(deadline.get("deadline_monotonic_ns")) is not int
+            or deadline["deadline_monotonic_ns"] <= 0
+            or deadline.get("timeout_ns") != expected_timeout_ns
+            or _driver_problem(deadline.get("driver")) is not None
+        ):
+            problems.append("deadline contract identity is invalid")
+        if timeout:
+            if (
+                not _is_sha256(seal_sha256)
+                or not _is_sha256(freeze_sha256)
+                or not isinstance(deadline.get("driver_stop"), dict)
+                or timeout_driver_exit_problem(
+                    deadline.get("driver_stop"),
+                    deadline.get("driver_return_code_before_stop"),
+                    success_latched=deadline.get("success_at_deadline"),
+                )
+                is not None
+                or deadline.get("prefix_step") != len(commands)
+                or deadline.get("success_at_deadline") is not success
+            ):
+                problems.append("timeout deadline freeze identity is invalid")
+        elif (
+            seal_sha256 is not None
+            or freeze_sha256 is not None
+            or deadline.get("driver_stop") is not None
+            or deadline.get("driver_return_code_before_stop") is not None
+            or deadline.get("prefix_step") is not None
+            or deadline.get("success_at_deadline") is not None
+        ):
+            problems.append("completed rollout must not contain a deadline freeze")
+    expected_termination = "planner_timeout" if timeout else "planner_completed"
+    if audit.get("termination_cause") != expected_termination:
+        problems.append(f"termination_cause must be {expected_termination}")
+    if audit.get("infra_status") != "ok":
+        problems.append("infra_status must be ok")
+    expected_planner_status = "timeout" if timeout else "completed"
+    if audit.get("planner_status") != expected_planner_status:
+        problems.append(f"planner_status must be {expected_planner_status}")
+    if audit.get("environment_success") is not success:
+        problems.append("environment_success must agree with success")
+    for key in (
+        "planner_profile",
+        "planner_backend",
+        "planner_model",
+        "planner_reasoning_effort",
+        "planner_auth_mode",
+        "planner_provider",
+        "planner_endpoint_identity",
+    ):
+        if not isinstance(audit.get(key), str) or not audit[key]:
+            problems.append(f"{key} must be a non-empty string")
+    preliminary = audit.get("preliminary")
+    release_ready = audit.get("release_ready")
+    if not isinstance(preliminary, bool) or not isinstance(release_ready, bool):
+        problems.append("preliminary and release_ready must be boolean")
+    elif preliminary and release_ready:
+        problems.append("preliminary results cannot claim release_ready")
+    expected_memory = {
+        "seed": 0,
+        "audit": f"{cell.task}_s0.json",
+        "command_trace": f"{cell.task}_s0.jsonl",
+    }
+    if cell.task in EMPTY_MEMORY_TASKS:
+        if (
+            audit.get("task_memory") is not None
+            or audit.get("task_memory_available") is not False
+        ):
+            problems.append("empty-whitelist task memory must be null and unavailable")
+    elif (
+        audit.get("task_memory") != expected_memory
+        or audit.get("task_memory_available") is not True
+    ):
+        problems.append(
+            "task memory must be the exact task-matched successful seed-0 pair"
+        )
+    language = audit.get("task_language")
+    if not isinstance(language, str) or not language.strip():
+        problems.append("task_language must be non-empty")
+    else:
+        for number, command in enumerate(commands, 1):
+            if command["action"] == "vla_act" and command.get("prompt") != language:
+                problems.append(
+                    f"trace command {number} does not use task_language verbatim"
+                )
+    problems.extend(
+        _validate_evidence(directory, cell, audit, commands, run_configuration)
+    )
+    return problems
+
+
+def validate_cell(
+    root: Path,
+    cell: Cell,
+    *,
+    expected_run_config_sha256: str | None = None,
+) -> Validation:
+    """Validate completion commit, hashes, audit identity, trace and protocol."""
+    run_manifest, run_manifest_problem = load_run_manifest(root)
+    provenance: list[str] = []
+    run_config_sha256 = None
+    run_configuration: dict[str, Any] | None = None
+    if run_manifest_problem is not None:
+        provenance.append(run_manifest_problem)
+    else:
+        assert run_manifest is not None
+        run_config_sha256 = run_manifest["run_config_sha256"]
+        run_configuration = run_manifest["config"]
+        if (
+            expected_run_config_sha256 is not None
+            and run_config_sha256 != expected_run_config_sha256
+        ):
+            provenance.append("root run manifest differs from the active run")
+    try:
+        directory = artifact_directory(root, cell)
+    except ValueError as exc:
+        result = CellResult(Completion.INCOMPLETE, Outcome.UNKNOWN, Integrity.UNKNOWN)
+        return Validation(
+            cell,
+            result,
+            artifact_problems=(f"unsafe artifact directory: {exc}",),
+            provenance_problems=tuple(provenance),
+        )
+    commit_path = directory / f"{cell.tag}.completed.json"
+    if not commit_path.is_file() or commit_path.is_symlink():
+        result = CellResult(Completion.INCOMPLETE, Outcome.UNKNOWN, Integrity.UNKNOWN)
+        return Validation(
+            cell,
+            result,
+            artifact_problems=("missing completion manifest",),
+            provenance_problems=tuple(provenance),
+        )
+    artifact: list[str] = []
+    protocol: list[str] = []
+    try:
+        commit = _read_object(commit_path)
+    except Exception as exc:
+        result = CellResult(
+            Completion.COMPLETED, Outcome.UNKNOWN, Integrity.INVALID, str(exc)
+        )
+        return Validation(
+            cell,
+            result,
+            artifact_problems=(f"invalid completion manifest: {exc}",),
+            provenance_problems=tuple(provenance),
+        )
+    if (
+        type(commit.get("schema_version")) is not int
+        or commit.get("schema_version") != 1
+    ):
+        artifact.append("completion manifest schema_version must be integer 1")
+    identity = commit.get("cell")
+    expected_identity = {
+        "split": cell.split.value,
+        "task": cell.task,
+        "seed": cell.seed,
+    }
+    if identity != expected_identity:
+        artifact.append("completion manifest identity mismatch")
+    if (
+        run_config_sha256 is None
+        or commit.get("run_config_sha256") != run_config_sha256
+    ):
+        provenance.append(
+            "completion run_config_sha256 must match the root run manifest"
+        )
+    files = commit.get("files")
+    audit_name, trace_name = f"{cell.tag}.json", f"{cell.tag}.jsonl"
+    if not isinstance(files, dict) or set(files) != {audit_name, trace_name}:
+        artifact.append("completion manifest file set mismatch")
+        files = {}
+    for name, digest in files.items():
+        path = directory / name
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or not path.is_file()
+            or path.is_symlink()
+            or _digest(path) != digest
+        ):
+            artifact.append(f"missing, unsafe, or hash-mismatched artifact: {name}")
+    try:
+        audit = _read_object(directory / audit_name)
+    except Exception as exc:
+        audit = None
+        artifact.append(f"invalid audit: {exc}")
+    commands, trace_problems = _parse_trace(directory / trace_name)
+    protocol.extend(trace_problems)
+    success: bool | None = None
+    if audit is not None:
+        if (
+            audit.get("task") != cell.task
+            or type(audit.get("seed")) is not int
+            or audit.get("seed") != cell.seed
+        ):
+            artifact.append("audit identity mismatch")
+        success = (
+            audit.get("success") if isinstance(audit.get("success"), bool) else None
+        )
+        try:
+            protocol.extend(
+                _validate_protocol(
+                    directory,
+                    cell,
+                    audit,
+                    commands,
+                    trace_name,
+                    run_config_sha256,
+                    run_configuration,
+                )
+            )
+        except Exception as exc:
+            protocol.append(
+                f"protocol validation failed closed: {type(exc).__name__}: {exc}"
+            )
+        if run_configuration is not None:
+            try:
+                provenance.extend(_validate_audit_provenance(audit, run_configuration))
+            except Exception as exc:
+                provenance.append(
+                    f"provenance validation failed closed: {type(exc).__name__}: {exc}"
+                )
+    recorded = commit.get("result")
+    expected_outcome = (
+        Outcome.SUCCESS
+        if success is True
+        else Outcome.FAILURE
+        if success is False
+        else None
+    )
+    if not isinstance(recorded, dict):
+        artifact.append("completion result is not an object")
+    else:
+        if recorded.get("completion") != Completion.COMPLETED.value:
+            artifact.append("completion result does not claim completed")
+        if recorded.get("integrity") != Integrity.VALID.value:
+            artifact.append("completion result does not claim valid")
+        if (
+            expected_outcome is None
+            or recorded.get("outcome") != expected_outcome.value
+        ):
+            artifact.append("completion outcome disagrees with audit")
+    if artifact or protocol or provenance:
+        reason = "; ".join(artifact + protocol + provenance)
+        result = CellResult(
+            Completion.COMPLETED, Outcome.UNKNOWN, Integrity.INVALID, reason
+        )
+    else:
+        assert expected_outcome is not None
+        result = CellResult(Completion.COMPLETED, expected_outcome, Integrity.VALID)
+    return Validation(
+        cell,
+        result,
+        artifact_problems=tuple(artifact),
+        protocol_problems=tuple(protocol),
+        provenance_problems=tuple(provenance),
+        audit=audit,
+    )
+
+
+def validate_run(root: Path) -> dict[str, Any]:
+    """Summarize all 340 cells exclusively from :func:`validate_cell`."""
+    run_manifest, run_manifest_problem = load_run_manifest(root)
+    run_config_sha256 = (
+        run_manifest["run_config_sha256"] if run_manifest is not None else None
+    )
+    validations = [
+        validate_cell(
+            root,
+            cell,
+            expected_run_config_sha256=run_config_sha256,
+        )
+        for cell in CELLS
+    ]
+    missing = [
+        item for item in validations if item.result.completion is Completion.INCOMPLETE
+    ]
+    invalid = [
+        item
+        for item in validations
+        if (item.artifact_problems or item.provenance_problems)
+        and item.result.completion is Completion.COMPLETED
+    ]
+    violations = [item for item in validations if item.protocol_problems]
+    provenance_violations = [
+        item
+        for item in validations
+        if item.provenance_problems and item.result.completion is Completion.COMPLETED
+    ]
+    split_rows: dict[str, Any] = {}
+    task_rates: list[float] = []
+    for split, spec in SPLITS.items():
+        split_items = [item for item in validations if item.cell.split is split]
+        details = []
+        for task in spec.tasks:
+            items = [
+                item
+                for item in split_items
+                if item.cell.task == task and item.result.canonical
+            ]
+            successes = sum(item.result.outcome is Outcome.SUCCESS for item in items)
+            rate = 100.0 * successes / len(spec.seeds)
+            details.append(
+                {
+                    "task": task,
+                    "successes": successes,
+                    "completed": len(items),
+                    "trials": len(spec.seeds),
+                    "rate": rate,
+                }
+            )
+            task_rates.append(rate)
+        canonical = [item for item in split_items if item.result.canonical]
+        successes = sum(item.result.outcome is Outcome.SUCCESS for item in canonical)
+        expected = len(spec.tasks) * len(spec.seeds)
+        rate = 100.0 * successes / expected
+        split_rows[split.value] = {
+            "expected": expected,
+            "completed": len(canonical),
+            "successes": successes,
+            "rate": rate,
+            "observed_rate": 100.0 * successes / len(canonical) if canonical else 0.0,
+            "tasks_detail": details,
+        }
+    counts = Counter(
+        "canonical_success"
+        if item.result.canonical and item.result.outcome is Outcome.SUCCESS
+        else "canonical_failure"
+        if item.result.canonical
+        else "invalid"
+        if item.result.integrity is Integrity.INVALID
+        else "incomplete"
+        for item in validations
+    )
+    canonical = [item for item in validations if item.result.canonical]
+    successes = sum(item.result.outcome is Outcome.SUCCESS for item in canonical)
+    complete = run_manifest_problem is None and len(canonical) == len(CELLS)
+    # The checked-in runtime is explicitly preliminary. A future formal runtime
+    # needs a new, independently reviewed manifest schema before publication.
+    root_release_ready = False
+    publication_ready = (
+        complete
+        and root_release_ready
+        and all(
+            item.audit is not None
+            and item.audit.get("release_ready") is True
+            and item.audit.get("preliminary") is False
+            for item in canonical
+        )
+    )
+    deltas = (
+        {
+            name: {
+                split: split_rows[split]["rate"] - reference[split]
+                for split in split_rows
+            }
+            for name, reference in PAPER_REFERENCES.items()
+        }
+        if publication_ready
+        else None
+    )
+    return {
+        "expected": len(CELLS),
+        "complete": complete,
+        "run_manifest": str(Path(root) / RUN_MANIFEST_NAME),
+        "run_config_sha256": run_config_sha256,
+        "run_manifest_problems": (
+            [] if run_manifest_problem is None else [run_manifest_problem]
+        ),
+        "publication_ready": publication_ready,
+        "root_release_ready": root_release_ready,
+        "comparison_ready": publication_ready,
+        "counts": dict(counts),
+        "splits": split_rows,
+        "overall": {
+            "successes": successes,
+            "completed": len(canonical),
+            "rollouts": len(CELLS),
+            "rollout_weighted_rate": 100.0 * successes / len(CELLS),
+            "task_weighted_rate": sum(task_rates) / len(task_rates),
+        },
+        "paper": PAPER_REFERENCES,
+        "delta_percentage_points": deltas,
+        "missing": [_issue(item) for item in missing],
+        "invalid": [_issue(item) for item in invalid],
+        "protocol_violations": [_issue(item) for item in violations],
+        "provenance_violations": [_issue(item) for item in provenance_violations],
+        "resume": [item.cell.tag for item in validations if item.resumable],
+    }
+
+
+def _identity(cell: Cell) -> dict[str, Any]:
+    return {"split": cell.split.value, "task": cell.task, "seed": cell.seed}
+
+
+def _issue(validation: Validation) -> dict[str, Any]:
+    return {**_identity(validation.cell), "problems": list(validation.problems)}
+
+
+summarize = validate_run

--- a/tests/test_checkpoint_identity.py
+++ b/tests/test_checkpoint_identity.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from robots.robocasa import checkpoint_identity
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fixture(tmp_path: Path, monkeypatch):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    model = tmp_path / "model"
+    vlm = tmp_path / "vlm"
+    model.mkdir()
+    vlm.mkdir()
+    shard = model / "model-00001-of-00001.safetensors"
+    shard.write_bytes(b"frozen-weights")
+    index = model / "model.safetensors.index.json"
+    index.write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": shard.stat().st_size},
+                "weight_map": {"layer": shard.name},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (model / "config.json").write_text("{}\n", encoding="utf-8")
+    (vlm / "config.json").write_text("{}\n", encoding="utf-8")
+    files = {}
+    for prefix, root in (("model", model), ("vlm", vlm)):
+        for path in sorted(root.iterdir()):
+            files[f"{prefix}/{path.name}"] = {
+                "size": path.stat().st_size,
+                "sha256": _digest(path),
+            }
+    authority = tmp_path / "checkpoint_manifest.json"
+    authority.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "checkpoint_id": "RLDX-1-FT-RC365",
+                "algorithm": "sha256",
+                "weight_total_size": shard.stat().st_size,
+                "files": files,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(checkpoint_identity, "AUTHORITY_PATH", authority)
+    return model, vlm
+
+
+def test_checkpoint_attestation_binds_content_and_file_identity(tmp_path, monkeypatch):
+    model, vlm = _fixture(tmp_path, monkeypatch)
+    attestation = checkpoint_identity.verify_checkpoint(model, vlm)
+    assert len(attestation["fingerprint"]) == 64
+    assert checkpoint_identity.validate_attestation(attestation, model, vlm)
+
+    path = tmp_path / "attestation.json"
+    path.write_text(json.dumps(attestation), encoding="utf-8")
+    path.chmod(0o600)
+    assert checkpoint_identity.load_attestation(path, model, vlm) == attestation
+
+    (model / "config.json").write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="changed since verification"):
+        checkpoint_identity.load_attestation(path, model, vlm)
+
+
+def test_checkpoint_verification_rejects_hash_and_shard_set_changes(
+    tmp_path, monkeypatch
+):
+    model, vlm = _fixture(tmp_path, monkeypatch)
+    (model / "config.json").write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="hash mismatch"):
+        checkpoint_identity.verify_checkpoint(model, vlm)
+
+    model, vlm = _fixture(tmp_path / "other", monkeypatch)
+    (model / "extra.safetensors").write_bytes(b"extra")
+    with pytest.raises(ValueError, match="shard set mismatch"):
+        checkpoint_identity.verify_checkpoint(model, vlm)
+
+
+def test_checkpoint_verification_rejects_symlinked_root(tmp_path, monkeypatch):
+    model, vlm = _fixture(tmp_path, monkeypatch)
+    alias = tmp_path / "model-alias"
+    alias.symlink_to(model, target_is_directory=True)
+    with pytest.raises(ValueError, match="real directory"):
+        checkpoint_identity.verify_checkpoint(alias, vlm)

--- a/tests/test_navview_patch.py
+++ b/tests/test_navview_patch.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+import subprocess
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+from setuptools.build_meta import build_wheel
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PATCH_PATH = REPO_ROOT / "robots/robocasa/patches/robosuite_navview.patch"
+TARGET = Path("robosuite/models/assets/bases/omron_mobile_base.xml")
+UPSTREAM_FIXTURE = """\
+<mujoco model="omron_mobile_base">
+    <worldbody>
+        <body name="base" pos="0 0 0">
+            <body name="fixed_support" pos="-0.05 0 0.50">
+                <geom type="cylinder"/>
+            </body>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
+
+def test_navview_patch_applies_cleanly_to_upstream_without_camera(tmp_path):
+    target = tmp_path / TARGET
+    target.parent.mkdir(parents=True)
+    target.write_text(UPSTREAM_FIXTURE, encoding="utf-8")
+
+    subprocess.run(
+        ["git", "apply", "--check", str(PATCH_PATH)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "apply", str(PATCH_PATH)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    cameras = ET.parse(target).getroot().findall(".//camera[@name='navview']")
+    assert len(cameras) == 1
+    assert cameras[0].attrib == {
+        "name": "navview",
+        "mode": "fixed",
+        "pos": "0.2 0 1.6",
+        "xyaxes": "0 -1 0 0.643 0 0.766",
+        "fovy": "75",
+    }
+
+
+def test_wheel_contains_navview_delivery_assets(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    shutil.copytree(
+        REPO_ROOT,
+        source,
+        ignore=shutil.ignore_patterns(".git", "logs", "__pycache__", "*.pyc"),
+    )
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    monkeypatch.chdir(source)
+
+    wheel_path = wheel_dir / build_wheel(str(wheel_dir))
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+    assert "robots/robocasa/patches/robosuite_navview.patch" in names
+    assert "robots/robocasa/patches/README.md" in names
+    assert "robots/robocasa/checkpoint_manifest.json" in names

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+import zipfile
+from pathlib import Path
+
+from setuptools import find_namespace_packages
+from setuptools.build_meta import build_wheel
+from setuptools.config.pyprojecttoml import load_file
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_wheel_package_discovery_includes_robot_backends():
+    config = load_file(REPO_ROOT / "pyproject.toml")
+    package_find = config["tool"]["setuptools"]["packages"]["find"]
+
+    assert "robots*" in package_find["include"]
+    discovered = set(
+        find_namespace_packages(
+            where=str(REPO_ROOT),
+            include=package_find["include"],
+            exclude=package_find["exclude"],
+        )
+    )
+    assert {
+        "robots",
+        "robots.libero",
+        "robots.robocasa",
+        "robots.robotwin",
+    } <= discovered
+
+
+def test_built_wheel_contains_robot_backend_modules(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    shutil.copytree(
+        REPO_ROOT,
+        source,
+        ignore=shutil.ignore_patterns(".git", "logs", "__pycache__", "*.pyc"),
+    )
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    monkeypatch.chdir(source)
+
+    wheel_path = wheel_dir / build_wheel(str(wheel_dir))
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+    assert "robots/libero/env_server.py" in names
+    assert "robots/robocasa/env_server.py" in names
+    assert "robots/robotwin/env_server.py" in names

--- a/tests/test_robocasa_artifacts.py
+++ b/tests/test_robocasa_artifacts.py
@@ -1,0 +1,170 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from rpent.reproduce.robocasa.artifacts import (
+    CellResult,
+    Completion,
+    Integrity,
+    Outcome,
+    publish_completed_cell,
+    secure_artifact_subdirectory,
+)
+from rpent.reproduce.robocasa.protocol import cell_for
+
+
+def test_cell_result_rejects_contradictory_axes():
+    with pytest.raises(ValueError):
+        CellResult(Completion.INCOMPLETE, Outcome.SUCCESS, Integrity.UNKNOWN)
+
+
+def _minimal_publication(cell):
+    return (
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        {
+            "task": cell.task,
+            "seed": cell.seed,
+            "success": True,
+            "run_config_sha256": "a" * 64,
+            "task_language": "open the drawer",
+        },
+        [{"action": "release"}],
+    )
+
+
+def test_publisher_securely_creates_split_and_task_directories(tmp_path: Path):
+    root = tmp_path / "results"
+    root.mkdir(mode=0o700)
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    result, audit, commands = _minimal_publication(cell)
+
+    publish_completed_cell(root, cell, result, audit, commands)
+
+    split = root / "atomic"
+    task = split / cell.task
+    for directory in (split, task):
+        metadata = directory.lstat()
+        assert directory.is_dir() and not directory.is_symlink()
+        assert metadata.st_uid == __import__("os").geteuid()
+        assert metadata.st_mode & 0o022 == 0
+    assert (task / f"{cell.tag}.completed.json").is_file()
+    assert not list(task.glob(f".{cell.tag}.*"))
+
+
+@pytest.mark.parametrize("component", ["root", "split", "task"])
+def test_publisher_rejects_symlink_directory_components(tmp_path: Path, component: str):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o700)
+    root = tmp_path / "results"
+    if component == "root":
+        root.symlink_to(outside, target_is_directory=True)
+    else:
+        root.mkdir(mode=0o700)
+        split = root / "atomic"
+        if component == "split":
+            split.symlink_to(outside, target_is_directory=True)
+        else:
+            split.mkdir(mode=0o700)
+            (split / cell.task).symlink_to(outside, target_is_directory=True)
+    result, audit, commands = _minimal_publication(cell)
+
+    with pytest.raises(ValueError, match="artifact"):
+        publish_completed_cell(root, cell, result, audit, commands)
+
+    assert not list(outside.rglob("*.completed.json"))
+
+
+@pytest.mark.parametrize("component", ["root", "split", "task"])
+def test_publisher_rejects_non_directory_components(tmp_path: Path, component: str):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    root = tmp_path / "results"
+    if component == "root":
+        root.write_text("not a directory\n", encoding="utf-8")
+    else:
+        root.mkdir(mode=0o700)
+        split = root / "atomic"
+        if component == "split":
+            split.write_text("not a directory\n", encoding="utf-8")
+        else:
+            split.mkdir(mode=0o700)
+            (split / cell.task).write_text("not a directory\n", encoding="utf-8")
+    result, audit, commands = _minimal_publication(cell)
+
+    with pytest.raises(ValueError, match="artifact"):
+        publish_completed_cell(root, cell, result, audit, commands)
+
+
+@pytest.mark.parametrize("component", ["root", "split", "task"])
+@pytest.mark.parametrize("unsafe_mode", [0o720, 0o702])
+def test_publisher_rejects_group_or_world_writable_components(
+    tmp_path: Path, component: str, unsafe_mode: int
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    root = tmp_path / "results"
+    split = root / "atomic"
+    task = split / cell.task
+    task.mkdir(parents=True, mode=0o700)
+    for directory in (root, split, task):
+        directory.chmod(0o700)
+    {"root": root, "split": split, "task": task}[component].chmod(unsafe_mode)
+    result, audit, commands = _minimal_publication(cell)
+
+    with pytest.raises(ValueError, match="writable by group or other"):
+        publish_completed_cell(root, cell, result, audit, commands)
+
+
+@pytest.mark.parametrize(
+    ("component", "mismatched_call"), [("root", 1), ("split", 2), ("task", 3)]
+)
+def test_publisher_rejects_directory_not_owned_by_current_uid(
+    tmp_path: Path, monkeypatch, component: str, mismatched_call: int
+):
+    from rpent.reproduce.robocasa import artifacts as artifact_module
+
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    root = tmp_path / "results"
+    (root / "atomic" / cell.task).mkdir(parents=True, mode=0o700)
+    actual_uid = artifact_module.os.geteuid()
+    calls = 0
+
+    def observed_uid():
+        nonlocal calls
+        calls += 1
+        return actual_uid + int(calls == mismatched_call)
+
+    monkeypatch.setattr(artifact_module.os, "geteuid", observed_uid)
+    result, audit, commands = _minimal_publication(cell)
+
+    with pytest.raises(ValueError, match=f"artifact {component} must be owned"):
+        publish_completed_cell(root, cell, result, audit, commands)
+
+
+def test_log_archive_rejects_symlink_descendant(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    root = tmp_path / "results"
+    task = root / "atomic" / cell.task
+    task.mkdir(parents=True, mode=0o700)
+    root.chmod(0o700)
+    (root / "atomic").chmod(0o700)
+    outside = tmp_path / "outside-logs"
+    outside.mkdir(mode=0o700)
+    (task / "run_logs").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="artifact subdirectory"):
+        with secure_artifact_subdirectory(root, cell, "run_logs", cell.tag, "run-1"):
+            pass

--- a/tests/test_robocasa_artifacts.py
+++ b/tests/test_robocasa_artifacts.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -24,12 +26,1377 @@ from rpent.reproduce.robocasa.artifacts import (
     publish_completed_cell,
     secure_artifact_subdirectory,
 )
-from rpent.reproduce.robocasa.protocol import cell_for
+from rpent.reproduce.robocasa.deadline_supervisor import DEADLINE_PROTOCOL
+from rpent.reproduce.robocasa.protocol import PROTOCOL_ID, SPLITS, cell_for
+from rpent.reproduce.robocasa.provenance import make_run_manifest
+from rpent.reproduce.robocasa.validator import (
+    _agent_log_summary,
+    validate_cell,
+    validate_run,
+)
+
+FIXTURE_SHA256 = "a" * 64
+PLANNER_TRANSPORT = {
+    "auth_mode": "api-key",
+    "provider": "rpent_responses_api",
+    "endpoint_identity": "responses_api:https://planner.example/v1",
+    "credential_broker": False,
+    "credential_broker_protocol": None,
+}
+
+
+def _isolation_attestation() -> dict:
+    return {
+        "schema_version": 2,
+        "planner_transport": dict(PLANNER_TRANSPORT),
+    }
+
+
+def _run_configuration(root: Path) -> dict:
+    return {
+        "protocol_id": PROTOCOL_ID,
+        "runtime_kind": "preliminary_external_snapshot",
+        "preliminary": True,
+        "planner": {
+            "profile": "codex-gpt55-xhigh",
+            "backend": "codex",
+            "model": "gpt-5.5",
+            "reasoning_effort": "xhigh",
+            **PLANNER_TRANSPORT,
+            "wire_api": "responses",
+            "provider_retry_policy": {
+                "request_max_retries": 12,
+                "stream_max_retries": 120,
+                "stream_idle_timeout_ms": 330_000,
+            },
+            "credential_boundary": "cell_codex_only_generated_shell_excluded",
+            "network_policy": {},
+            "isolation": {},
+            "codex": {},
+            "isolation_preflight": _isolation_attestation(),
+        },
+        "memory": {
+            "source": "fixture-memory",
+            "revision": None,
+            "manifest_sha256": FIXTURE_SHA256,
+            "global_memory": False,
+            "task_notes": False,
+        },
+        "checkpoint": {
+            "checkpoint_id": "RLDX-1-FT-RC365",
+            "authority_manifest_sha256": FIXTURE_SHA256,
+            "fingerprint": FIXTURE_SHA256,
+        },
+        "runtime": {
+            "root": str((root / "runtime").resolve()),
+            "inputs_sha256": {
+                "driver": FIXTURE_SHA256,
+                "deadline": FIXTURE_SHA256,
+                "preliminary_driver_adapter": FIXTURE_SHA256,
+                "deadline_supervisor_adapter": FIXTURE_SHA256,
+                "artifact_builder": FIXTURE_SHA256,
+                "navview_xml": FIXTURE_SHA256,
+            },
+            "navview": {
+                "camera": "mobilebase0_navview",
+                "mode": "fixed",
+                "pos": "0.2 0 1.6",
+                "xyaxes": "0 -1 0 0.643 0 0.766",
+                "fovy": "75",
+            },
+            "startup_timeout_seconds": 2400,
+            "kill_after_seconds": 15,
+            "driver_policy": {},
+            "source_trees": {},
+            "source_git": {},
+        },
+        "implementation_sha256": {"fixture.py": FIXTURE_SHA256},
+    }
+
+
+def _run_digest(root: Path) -> str:
+    path = root / "_run_manifest.json"
+    if not path.exists():
+        root.mkdir(parents=True, exist_ok=True)
+        manifest = make_run_manifest(_run_configuration(root))
+        path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+        path.chmod(0o600)
+    return json.loads(path.read_text(encoding="utf-8"))["run_config_sha256"]
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _planner_status(
+    *,
+    timeout: bool,
+    timeout_seconds: int,
+    contract_sha256: str,
+    freeze_sha256: str | None,
+    nonce: str,
+) -> dict:
+    termination = "planner_timeout" if timeout else "planner_completed"
+    wrapper_rc = 20 if timeout else 0
+    return {
+        "schema_version": 1,
+        "state": "finished",
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T00:30:00Z",
+        "elapsed_seconds": float(timeout_seconds),
+        "timeout_seconds": timeout_seconds,
+        "kill_after_seconds": 15,
+        "termination_cause": termination,
+        "wrapper_rc": wrapper_rc,
+        "raw_termination_cause": termination,
+        "raw_wrapper_rc": wrapper_rc,
+        "child_pid": 9001,
+        "child_pgid": 9001,
+        "child_rc": 0,
+        "child_signal": None,
+        "deadline_fired": timeout,
+        "external_deadline_fired": timeout,
+        "interrupted_signal": None,
+        "forwarded_signal_sent": False,
+        "term_sent": False,
+        "kill_sent": False,
+        "orphan_cleanup_term_sent": False,
+        "parent_pid": 8001,
+        "parent_death_signal": 15,
+        "parent_death_signal_enabled": True,
+        "parent_death_observed": False,
+        "subreaper_enabled": True,
+        "descendant_cleanup": {
+            "subreaper_enabled": True,
+            "complete": True,
+            "detected": [],
+            "term_sent": [],
+            "kill_sent": [],
+            "reaped": [],
+            "remaining": [],
+            "errors": [],
+        },
+        "spawn_error": None,
+        "supervision_error": None,
+        "protocol_violation_detected": False,
+        "policy_stop_triggered": False,
+        "policy_stop_source": None,
+        "provider_protocol_violation": None,
+        "live_codex_protocol_violation": None,
+        "stdout_total_lines": 1,
+        "stdout_blank_lines": 0,
+        "stdout_json_events": 1,
+        "malformed_jsonl_lines": 0,
+        "terminal_event_count": 1,
+        "terminal_event_counts": {"turn.completed": 1, "turn.failed": 0},
+        "terminal_event": {"type": "turn.completed", "line_number": 1},
+        "forbidden_web_search_event_count": 0,
+        "forbidden_web_search_event_counts": {
+            "item.completed": 0,
+            "item.started": 0,
+        },
+        "forbidden_web_search_event": None,
+        "deadline_supervisor": {
+            "protocol": DEADLINE_PROTOCOL,
+            "run_id": "run-1",
+            "nonce": nonce,
+            "fired": timeout,
+            "contract_sha256": contract_sha256,
+            "freeze_sha256": freeze_sha256,
+            "error": None,
+        },
+    }
+
+
+def _audit(root: Path, cell, success: bool = True, *, timeout: bool = False):
+    directory = root / cell.split.value / cell.task
+    logs = directory / "run_logs" / cell.tag / "run-1"
+    logs.mkdir(parents=True, exist_ok=True)
+    agent = logs / "agent.log"
+    status = logs / "planner_status.json"
+    contract = logs / "_deadline_contract.json"
+    seal = logs / "_deadline_seal.json"
+    freeze = logs / "_deadline_freeze.json"
+    raw_trace = logs / "command_trace.jsonl"
+    agent.write_text('{"type":"turn.completed"}\n', encoding="utf-8")
+    nonce = "0123456789abcdef0123456789abcdef"
+    driver = {"pid": 7001, "pgid": 7001, "start_time_ticks": 123456}
+    timeout_seconds = SPLITS[cell.split].timeout_seconds
+    timeout_ns = timeout_seconds * 1_000_000_000
+    started_ns = 1_000_000_000
+    deadline_ns = started_ns + timeout_ns
+    contract_value = {
+        "schema_version": 1,
+        "protocol": DEADLINE_PROTOCOL,
+        "run_id": "run-1",
+        "nonce": nonce,
+        "started_monotonic_ns": started_ns,
+        "deadline_monotonic_ns": deadline_ns,
+        "timeout_ns": timeout_ns,
+        "driver": driver,
+        "external_deadline_sha256": FIXTURE_SHA256,
+    }
+    _write_json(contract, contract_value)
+    contract_sha256 = _digest(contract)
+    seal_sha256 = None
+    freeze_sha256 = None
+    driver_stop = None
+    if timeout:
+        trace = b'{"action":"release"}\n'
+        raw_trace.write_bytes(trace)
+        (logs / "done_00.flag").write_bytes(b"")
+        (logs / "done_01.flag").write_bytes(b"")
+        _write_json(
+            logs / "state_00.json",
+            {"step": 0, "success": False, "task_language": "open the drawer"},
+        )
+        _write_json(
+            logs / "state_01.json",
+            {"step": 1, "success": success, "task_language": "open the drawer"},
+        )
+        _write_json(logs / "log_01.json", {"command": {"action": "release"}})
+        _write_json(
+            logs / "_deadline_commit_01.json",
+            {
+                "schema_version": 1,
+                "protocol": DEADLINE_PROTOCOL,
+                "run_id": "run-1",
+                "nonce": nonce,
+                "step": 1,
+                "deadline_monotonic_ns": deadline_ns,
+                "done_published_monotonic_ns": deadline_ns - 1,
+                "contract_sha256": contract_sha256,
+            },
+        )
+        seal_value = {
+            "schema_version": 1,
+            "protocol": DEADLINE_PROTOCOL,
+            "run_id": "run-1",
+            "nonce": nonce,
+            "deadline_monotonic_ns": deadline_ns,
+            "sealed_monotonic_ns": deadline_ns + 1,
+            "contract_sha256": contract_sha256,
+        }
+        _write_json(seal, seal_value)
+        seal_sha256 = _digest(seal)
+        files = {
+            name: _digest(logs / name)
+            for name in (
+                "done_00.flag",
+                "done_01.flag",
+                "state_00.json",
+                "state_01.json",
+                "log_01.json",
+                "_deadline_commit_01.json",
+            )
+        }
+        driver_stop = {
+            "observed_state": "T",
+            "supervisor_stopped": True,
+            "kill_sent": True,
+            "kill_observed": True,
+        }
+        freeze_value = {
+            "schema_version": 1,
+            "protocol": DEADLINE_PROTOCOL,
+            "run_id": "run-1",
+            "nonce": nonce,
+            "deadline_monotonic_ns": deadline_ns,
+            "frozen_monotonic_ns": deadline_ns + 2,
+            "contract_sha256": contract_sha256,
+            "seal_sha256": seal_sha256,
+            "driver": driver,
+            "driver_stop": driver_stop,
+            "dropped_done_steps": [],
+            "prefix_step": 1,
+            "success": success,
+            "final_state_sha256": files["state_01.json"],
+            "command_trace_sha256": hashlib.sha256(trace).hexdigest(),
+            "raw_command_trace_sha256": _digest(raw_trace),
+            "files_sha256": files,
+        }
+        _write_json(freeze, freeze_value)
+        freeze_sha256 = _digest(freeze)
+    _write_json(
+        status,
+        _planner_status(
+            timeout=timeout,
+            timeout_seconds=timeout_seconds,
+            contract_sha256=contract_sha256,
+            freeze_sha256=freeze_sha256,
+            nonce=nonce,
+        ),
+    )
+
+    configuration = _run_configuration(root)
+    checkpoint_files = {
+        f"model/model-{index:05d}-of-00003.safetensors": FIXTURE_SHA256
+        for index in range(1, 4)
+    }
+    return {
+        "schema_version": 1,
+        "protocol_id": PROTOCOL_ID,
+        "suite": "robocasa365",
+        "source": "harness",
+        "split": cell.split.value,
+        "task": cell.task,
+        "seed": cell.seed,
+        "success": success,
+        "valid": True,
+        "failure_type": None
+        if success
+        else "rollout_timeout"
+        if timeout
+        else "task_failure",
+        "steps": 1,
+        "commit_protocol": "done_marker_v1",
+        "trace_recovered_from_logs": False,
+        "incomplete_commands_dropped": 0,
+        "agent_exit_code": 20 if timeout else 0,
+        "termination_cause": "planner_timeout" if timeout else "planner_completed",
+        "rollout_timeout": timeout,
+        "infra_status": "ok",
+        "planner_status": "timeout" if timeout else "completed",
+        "environment_success": success,
+        "planner_profile": "codex-gpt55-xhigh",
+        "planner_backend": "codex",
+        "planner_model": "gpt-5.5",
+        "planner_reasoning_effort": "xhigh",
+        "planner_auth_mode": PLANNER_TRANSPORT["auth_mode"],
+        "planner_provider": PLANNER_TRANSPORT["provider"],
+        "planner_endpoint_identity": PLANNER_TRANSPORT["endpoint_identity"],
+        "preliminary": True,
+        "release_ready": False,
+        "run_id": "run-1",
+        "run_config_sha256": _run_digest(root),
+        "runtime_root": configuration["runtime"]["root"],
+        "runtime_scripts": {
+            "external_driver": FIXTURE_SHA256,
+            "external_deadline": FIXTURE_SHA256,
+            "driver_adapter": FIXTURE_SHA256,
+            "deadline_supervisor": FIXTURE_SHA256,
+            "artifact_builder": FIXTURE_SHA256,
+        },
+        "deadline": {
+            "protocol": DEADLINE_PROTOCOL,
+            "contract_sha256": contract_sha256,
+            "seal_sha256": seal_sha256,
+            "freeze_sha256": freeze_sha256,
+            "deadline_monotonic_ns": deadline_ns,
+            "timeout_ns": timeout_ns,
+            "driver": driver,
+            "driver_stop": driver_stop,
+            "driver_return_code_before_stop": -9 if timeout else None,
+            "prefix_step": 1 if timeout else None,
+            "success_at_deadline": success if timeout else None,
+        },
+        "memory_source": {
+            "kind": "fixture-memory",
+            "revision": None,
+            "manifest_sha256": FIXTURE_SHA256,
+        },
+        "navview": {
+            "xml_sha256": FIXTURE_SHA256,
+            **configuration["runtime"]["navview"],
+        },
+        "checkpoint": {
+            **configuration["checkpoint"],
+            "files": checkpoint_files,
+        },
+        "checkpoint_sha256": {
+            f"model-{index:05d}-of-00003.safetensors": FIXTURE_SHA256
+            for index in range(1, 4)
+        },
+        "task_language": "open the drawer",
+        "task_memory": {
+            "seed": 0,
+            "audit": f"{cell.task}_s0.json",
+            "command_trace": f"{cell.task}_s0.jsonl",
+        },
+        "task_memory_available": True,
+        "task_notes_available": False,
+        "memory_role": "formal_evaluation",
+        "global_memory": False,
+        "perception_isolation": True,
+        "reset_enabled": False,
+        "reset_seed": 4_200_000 + cell.seed
+        if cell.split.value == "composite_seen"
+        else None,
+        "command_trace": f"{cell.tag}.jsonl",
+        "artifact_errors": [],
+        "evidence": {
+            "agent_log": {
+                "path": str(agent.relative_to(directory)),
+                "sha256": _digest(agent),
+            },
+            "planner_status": {
+                "path": str(status.relative_to(directory)),
+                "sha256": _digest(status),
+            },
+            "deadline_contract": {
+                "path": str(contract.relative_to(directory)),
+                "sha256": contract_sha256,
+            },
+            **(
+                {
+                    "deadline_seal": {
+                        "path": str(seal.relative_to(directory)),
+                        "sha256": seal_sha256,
+                    },
+                    "deadline_freeze": {
+                        "path": str(freeze.relative_to(directory)),
+                        "sha256": freeze_sha256,
+                    },
+                }
+                if timeout
+                else {}
+            ),
+        },
+    }
+
+
+def _set_agent_events(root: Path, cell, audit, events) -> None:
+    path = root / cell.split.value / cell.task / audit["evidence"]["agent_log"]["path"]
+    path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+    audit["evidence"]["agent_log"]["sha256"] = hashlib.sha256(
+        path.read_bytes()
+    ).hexdigest()
+    summary = _agent_log_summary(path)
+    assert summary is not None
+    status_path = _evidence_path(root, cell, audit, "planner_status")
+    status = _read_json(status_path)
+    status.update(summary)
+    _sync_status_evidence(root, cell, audit, status)
+
+
+def _evidence_path(root: Path, cell, audit: dict, key: str) -> Path:
+    directory = root / cell.split.value / cell.task
+    return directory / audit["evidence"][key]["path"]
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sync_status_evidence(root: Path, cell, audit: dict, status: dict) -> None:
+    status_path = _evidence_path(root, cell, audit, "planner_status")
+    _write_json(status_path, status)
+    audit["evidence"]["planner_status"]["sha256"] = _digest(status_path)
+
+
+def _refresh_freeze(root: Path, cell, audit: dict) -> None:
+    freeze_path = _evidence_path(root, cell, audit, "deadline_freeze")
+    freeze = _read_json(freeze_path)
+    log_directory = freeze_path.parent
+    files = freeze.get("files_sha256")
+    if isinstance(files, dict):
+        for name in files:
+            path = log_directory / name
+            if path.is_file():
+                files[name] = _digest(path)
+    prefix_step = freeze.get("prefix_step")
+    if type(prefix_step) is int and prefix_step >= 0:
+        final_state = log_directory / f"state_{prefix_step:02d}.json"
+        if final_state.is_file():
+            freeze["final_state_sha256"] = _digest(final_state)
+        commands = []
+        for step in range(1, prefix_step + 1):
+            log_path = log_directory / f"log_{step:02d}.json"
+            if log_path.is_file():
+                commands.append(_read_json(log_path).get("command"))
+        trace = b"".join(
+            (json.dumps(command, separators=(",", ":")) + "\n").encode("utf-8")
+            for command in commands
+        )
+        freeze["command_trace_sha256"] = hashlib.sha256(trace).hexdigest()
+    raw_trace = log_directory / "command_trace.jsonl"
+    if raw_trace.is_file():
+        freeze["raw_command_trace_sha256"] = _digest(raw_trace)
+    _write_json(freeze_path, freeze)
+    freeze_sha256 = _digest(freeze_path)
+    audit["evidence"]["deadline_freeze"]["sha256"] = freeze_sha256
+    audit["deadline"]["freeze_sha256"] = freeze_sha256
+    status_path = _evidence_path(root, cell, audit, "planner_status")
+    status = _read_json(status_path)
+    status["deadline_supervisor"]["freeze_sha256"] = freeze_sha256
+    _sync_status_evidence(root, cell, audit, status)
+
+
+def _publish_for_validation(root: Path, cell, audit: dict):
+    result = CellResult(
+        Completion.COMPLETED,
+        Outcome.SUCCESS if audit.get("success") is True else Outcome.FAILURE,
+        Integrity.VALID,
+    )
+    publish_completed_cell(root, cell, result, audit, [{"action": "release"}])
+    return validate_cell(root, cell)
+
+
+def test_only_completed_valid_results_are_published_and_validated(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    result = CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID)
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        result,
+        _audit(tmp_path, cell),
+        [{"action": "release"}],
+    )
+    validation = validate_cell(tmp_path, cell)
+    assert validation.result == result
+    assert not validation.resumable
+    summary = validate_run(tmp_path)
+    assert summary["counts"]["canonical_success"] == 1
+    assert summary["expected"] == 340
+    assert summary["splits"]["atomic"]["expected"] == 180
+    assert summary["splits"]["composite_seen"]["expected"] == 80
+    assert summary["splits"]["composite_unseen"]["expected"] == 80
+    assert len(summary["paper"]) == 3
+    assert summary["delta_percentage_points"] is None
+    assert summary["publication_ready"] is False
+    assert len(summary["missing"]) == 339
+    assert len(summary["resume"]) == 339
+    drawer = next(
+        row
+        for row in summary["splits"]["atomic"]["tasks_detail"]
+        if row["task"] == "OpenDrawer"
+    )
+    assert drawer == {
+        "task": "OpenDrawer",
+        "successes": 1,
+        "completed": 1,
+        "trials": 10,
+        "rate": 10.0,
+    }
+
+
+def test_incomplete_or_invalid_results_are_never_canonical(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    incomplete = CellResult(Completion.INCOMPLETE, Outcome.UNKNOWN, Integrity.UNKNOWN)
+    with pytest.raises(ValueError, match="only completed"):
+        publish_completed_cell(tmp_path, cell, incomplete, {}, [])
+    assert validate_cell(tmp_path, cell).resumable
+
+
+def test_manifest_hash_tampering_is_resume_eligible(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.FAILURE, Integrity.VALID),
+        _audit(tmp_path, cell, False),
+        [{"action": "release"}],
+    )
+    artifact = tmp_path / "atomic" / cell.task / f"{cell.tag}.jsonl"
+    artifact.write_text('{"action":"navigate_to"}\n')
+    validation = validate_cell(tmp_path, cell)
+    assert validation.result.integrity is Integrity.INVALID
+    assert validation.resumable
 
 
 def test_cell_result_rejects_contradictory_axes():
     with pytest.raises(ValueError):
         CellResult(Completion.INCOMPLETE, Outcome.SUCCESS, Integrity.UNKNOWN)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "problem"),
+    [
+        ("global_memory", True, "global_memory"),
+        ("task_notes_available", True, "task_notes_available"),
+        ("termination_cause", "planner_timeout", "termination_cause"),
+        ("steps", 2, "steps"),
+    ],
+)
+def test_protocol_fields_fail_closed(tmp_path: Path, field, value, problem):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    audit[field] = value
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "vla_act", "prompt": "open the drawer"}],
+    )
+    validation = validate_cell(tmp_path, cell)
+    assert any(problem in item for item in validation.protocol_problems)
+
+
+def test_vla_prompt_memory_and_web_search_are_strict(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    agent_path = (
+        tmp_path / "atomic" / cell.task / audit["evidence"]["agent_log"]["path"]
+    )
+    agent_path.write_text(
+        json.dumps({"type": "item.completed", "item": {"type": "web_search"}}) + "\n"
+    )
+    audit["evidence"]["agent_log"]["sha256"] = hashlib.sha256(
+        agent_path.read_bytes()
+    ).hexdigest()
+    audit["task_memory"]["audit"] = "Other_s0.json"
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "vla_act", "prompt": "open the drawer"}],
+    )
+    problems = validate_cell(tmp_path, cell).protocol_problems
+    assert any("task memory" in item for item in problems)
+    assert any("web_search" in item for item in problems)
+
+    with pytest.raises(ValueError, match="task_language"):
+        publish_completed_cell(
+            tmp_path,
+            cell,
+            CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+            _audit(tmp_path, cell),
+            [{"action": "vla_act", "prompt": "different"}],
+        )
+
+
+def test_agent_log_accepts_only_frozen_event_and_item_allowlists(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    events = [
+        {"type": "thread.started", "thread_id": "thread-1"},
+        {"type": "turn.started"},
+    ]
+    events.extend(
+        {
+            "type": event_type,
+            "item": {"type": item_type, "id": f"{event_type}-{item_type}"},
+        }
+        for event_type, item_type in zip(
+            (
+                "item.started",
+                "item.updated",
+                "item.completed",
+                "item.completed",
+                "item.completed",
+            ),
+            (
+                "agent_message",
+                "reasoning",
+                "command_execution",
+                "image_view",
+                "todo_list",
+            ),
+            strict=True,
+        )
+    )
+    events.append({"type": "turn.completed"})
+    _set_agent_events(tmp_path, cell, audit, events)
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    assert validate_cell(tmp_path, cell).result.canonical
+
+
+def test_agent_log_accepts_recovered_transport_reconnect(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    _set_agent_events(
+        tmp_path,
+        cell,
+        audit,
+        [
+            {
+                "type": "error",
+                "message": "Reconnecting... 1/5 (stream disconnected before completion)",
+            },
+            {"type": "turn.completed"},
+        ],
+    )
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    assert validate_cell(tmp_path, cell).result.canonical
+
+
+@pytest.mark.parametrize("event_type", ["turn.failed", "error", "future.event"])
+def test_agent_log_rejects_failed_and_unknown_top_level_events(
+    tmp_path: Path, event_type
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    _set_agent_events(
+        tmp_path,
+        cell,
+        audit,
+        [{"type": event_type}, {"type": "turn.completed"}],
+    )
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    problems = validate_cell(tmp_path, cell).protocol_problems
+    assert any(event_type in problem for problem in problems)
+
+
+@pytest.mark.parametrize(
+    "item_type",
+    [
+        "file_change",
+        "mcp_tool_call",
+        "collab_tool_call",
+        "web_search",
+        "future_item",
+    ],
+)
+def test_agent_log_rejects_side_effecting_and_unknown_items(tmp_path: Path, item_type):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    _set_agent_events(
+        tmp_path,
+        cell,
+        audit,
+        [
+            {"type": "item.completed", "item": {"type": item_type}},
+            {"type": "turn.completed"},
+        ],
+    )
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    problems = validate_cell(tmp_path, cell).protocol_problems
+    assert any(item_type in problem for problem in problems)
+
+
+@pytest.mark.parametrize(
+    "event_type", ["item.started", "item.updated", "item.completed"]
+)
+@pytest.mark.parametrize("item", [None, "not-an-object"])
+def test_every_item_event_requires_an_item_object(tmp_path: Path, event_type, item):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    _set_agent_events(
+        tmp_path,
+        cell,
+        audit,
+        [
+            {"type": event_type, "item": item},
+            {"type": "turn.completed"},
+        ],
+    )
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    problems = validate_cell(tmp_path, cell).protocol_problems
+    assert any("without item object" in problem for problem in problems)
+
+
+def test_completed_planner_requires_turn_completed_event(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    _set_agent_events(tmp_path, cell, audit, [{"type": "turn.started"}])
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    problems = validate_cell(tmp_path, cell).protocol_problems
+    assert any("no turn.completed" in problem for problem in problems)
+
+
+def test_planner_timeout_may_omit_turn_completed_event(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    _set_agent_events(tmp_path, cell, audit, [{"type": "turn.started"}])
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.FAILURE, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    assert validate_cell(tmp_path, cell).result.canonical
+
+
+def test_planner_timeout_takes_priority_over_simultaneous_turn_failed(
+    tmp_path: Path,
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    _set_agent_events(tmp_path, cell, audit, [{"type": "turn.failed"}])
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.FAILURE, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    assert validate_cell(tmp_path, cell).result.canonical
+
+
+def test_planner_timeout_does_not_reclassify_reconnect_as_infrastructure(
+    tmp_path: Path,
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    _set_agent_events(
+        tmp_path,
+        cell,
+        audit,
+        [
+            {"type": "turn.started"},
+            {
+                "type": "error",
+                "message": "Reconnecting... 1/5 (stream disconnected before completion)",
+            },
+        ],
+    )
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.FAILURE, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    assert validate_cell(tmp_path, cell).result.canonical
+
+
+def test_success_committed_before_planner_timeout_remains_canonical(
+    tmp_path: Path,
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=True, timeout=True)
+    audit["agent_exit_code"] = 20
+    _set_agent_events(
+        tmp_path,
+        cell,
+        audit,
+        [
+            {"type": "turn.started"},
+            {
+                "type": "error",
+                "message": "Reconnecting... 1/5 (stream disconnected before completion)",
+            },
+        ],
+    )
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    assert validate_cell(tmp_path, cell).result.canonical
+    summary = validate_run(tmp_path)
+    assert summary["counts"]["canonical_success"] == 1
+    assert summary["overall"]["completed"] == 1
+    assert cell.tag not in summary["resume"]
+
+
+@pytest.mark.parametrize("mutation", ["missing", "extra"])
+def test_deadline_evidence_requires_the_exact_file_set(tmp_path: Path, mutation: str):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    if mutation == "missing":
+        del audit["evidence"]["deadline_contract"]
+    else:
+        audit["evidence"]["unexpected"] = dict(audit["evidence"]["agent_log"])
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(
+        "exactly the deadline protocol files" in item for item in validation.problems
+    )
+
+
+@pytest.mark.parametrize("key", ["deadline_seal", "deadline_freeze"])
+def test_timeout_requires_both_seal_and_freeze_evidence(tmp_path: Path, key: str):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    del audit["evidence"][key]
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(
+        "exactly the deadline protocol files" in item for item in validation.problems
+    )
+
+
+@pytest.mark.parametrize("name", ["_deadline_seal.json", "_deadline_freeze.json"])
+def test_completed_archive_rejects_any_deadline_seal_or_freeze(
+    tmp_path: Path, name: str
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    log_directory = _evidence_path(tmp_path, cell, audit, "deadline_contract").parent
+    _write_json(log_directory / name, {"unexpected": True})
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("unexpectedly contains" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize(
+    ("key", "timeout", "problem"),
+    [
+        ("deadline_contract", False, "deadline contract has an invalid schema"),
+        ("planner_status", False, "planner_status has an invalid schema"),
+        ("deadline_seal", True, "deadline seal has an invalid schema"),
+        ("deadline_freeze", True, "deadline freeze has an invalid schema"),
+    ],
+)
+def test_deadline_evidence_objects_have_exact_schemas(
+    tmp_path: Path, key: str, timeout: bool, problem: str
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=not timeout, timeout=timeout)
+    path = _evidence_path(tmp_path, cell, audit, key)
+    value = _read_json(path)
+    value["unexpected"] = True
+    _write_json(path, value)
+    digest = _digest(path)
+    audit["evidence"][key]["sha256"] = digest
+    if key == "deadline_contract":
+        audit["deadline"]["contract_sha256"] = digest
+        status = _read_json(_evidence_path(tmp_path, cell, audit, "planner_status"))
+        status["deadline_supervisor"]["contract_sha256"] = digest
+        _sync_status_evidence(tmp_path, cell, audit, status)
+    elif key == "deadline_seal":
+        audit["deadline"]["seal_sha256"] = digest
+    elif key == "deadline_freeze":
+        audit["deadline"]["freeze_sha256"] = digest
+        status = _read_json(_evidence_path(tmp_path, cell, audit, "planner_status"))
+        status["deadline_supervisor"]["freeze_sha256"] = digest
+        _sync_status_evidence(tmp_path, cell, audit, status)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(problem in item for item in validation.problems)
+
+
+@pytest.mark.parametrize("field", ["timeout_ns", "external_deadline_sha256"])
+def test_deadline_contract_binds_protocol_timeout_and_runtime_source(
+    tmp_path: Path, field: str
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    path = _evidence_path(tmp_path, cell, audit, "deadline_contract")
+    contract = _read_json(path)
+    if field == "timeout_ns":
+        contract[field] += 1
+        contract["deadline_monotonic_ns"] += 1
+        audit["deadline"]["timeout_ns"] += 1
+        audit["deadline"]["deadline_monotonic_ns"] += 1
+    else:
+        contract[field] = "b" * 64
+    _write_json(path, contract)
+    digest = _digest(path)
+    audit["evidence"]["deadline_contract"]["sha256"] = digest
+    audit["deadline"]["contract_sha256"] = digest
+    status = _read_json(_evidence_path(tmp_path, cell, audit, "planner_status"))
+    status["deadline_supervisor"]["contract_sha256"] = digest
+    _sync_status_evidence(tmp_path, cell, audit, status)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("root protocol" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "done_01.flag",
+        "state_01.json",
+        "log_01.json",
+        "_deadline_commit_01.json",
+        "command_trace.jsonl",
+    ],
+)
+def test_timeout_rejects_missing_frozen_journal_file(tmp_path: Path, name: str):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    log_directory = _evidence_path(tmp_path, cell, audit, "deadline_freeze").parent
+    (log_directory / name).unlink()
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(
+        phrase in " ".join(validation.problems)
+        for phrase in ("journal", "done markers", "command trace")
+    )
+
+
+def test_timeout_rejects_late_receipt_even_when_all_hashes_match(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    receipt_path = (
+        _evidence_path(tmp_path, cell, audit, "deadline_freeze").parent
+        / "_deadline_commit_01.json"
+    )
+    receipt = _read_json(receipt_path)
+    receipt["done_published_monotonic_ns"] = receipt["deadline_monotonic_ns"]
+    _write_json(receipt_path, receipt)
+    _refresh_freeze(tmp_path, cell, audit)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("published after the deadline" in item for item in validation.problems)
+
+
+def test_timeout_rejects_receipt_before_contract_start_when_hashes_match(
+    tmp_path: Path,
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    receipt_path = (
+        _evidence_path(tmp_path, cell, audit, "deadline_freeze").parent
+        / "_deadline_commit_01.json"
+    )
+    receipt = _read_json(receipt_path)
+    receipt["done_published_monotonic_ns"] = 0
+    _write_json(receipt_path, receipt)
+    _refresh_freeze(tmp_path, cell, audit)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(
+        "before the deadline contract started" in item for item in validation.problems
+    )
+
+
+@pytest.mark.parametrize("target", ["success", "command"])
+def test_timeout_rebuilds_success_and_trace_from_frozen_journal(
+    tmp_path: Path, target: str
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=True, timeout=True)
+    log_directory = _evidence_path(tmp_path, cell, audit, "deadline_freeze").parent
+    if target == "success":
+        state_path = log_directory / "state_01.json"
+        state = _read_json(state_path)
+        state["success"] = False
+        _write_json(state_path, state)
+    else:
+        _write_json(
+            log_directory / "log_01.json",
+            {"command": {"action": "release", "steps": 2}},
+        )
+    _refresh_freeze(tmp_path, cell, audit)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(
+        phrase in " ".join(validation.problems)
+        for phrase in ("success disagrees", "command trace")
+    )
+
+
+def test_timeout_rejects_extra_done_marker_outside_frozen_prefix(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    log_directory = _evidence_path(tmp_path, cell, audit, "deadline_freeze").parent
+    (log_directory / "done_02.flag").write_bytes(b"")
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("extra done markers" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize("dropped", [[2, 2], [3, 2], [1]])
+def test_timeout_rejects_noncanonical_dropped_done_steps(
+    tmp_path: Path, dropped: list[int]
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    freeze_path = _evidence_path(tmp_path, cell, audit, "deadline_freeze")
+    freeze = _read_json(freeze_path)
+    freeze["dropped_done_steps"] = dropped
+    _write_json(freeze_path, freeze)
+    _refresh_freeze(tmp_path, cell, audit)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("sealed canonical audit" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("kill_sent", False),
+        ("kill_observed", False),
+        ("supervisor_stopped", False),
+    ],
+)
+def test_timeout_rejects_invalid_driver_termination_proof(
+    tmp_path: Path, field: str, value: bool
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    freeze_path = _evidence_path(tmp_path, cell, audit, "deadline_freeze")
+    freeze = _read_json(freeze_path)
+    freeze["driver_stop"][field] = value
+    audit["deadline"]["driver_stop"] = dict(freeze["driver_stop"])
+    _write_json(freeze_path, freeze)
+    _refresh_freeze(tmp_path, cell, audit)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("sealed canonical audit" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize(("return_code", "canonical"), [(75, True), (9, False)])
+def test_timeout_binds_passive_driver_exit_to_adapter_return_code(
+    tmp_path: Path, return_code: int, canonical: bool
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    freeze_path = _evidence_path(tmp_path, cell, audit, "deadline_freeze")
+    freeze = _read_json(freeze_path)
+    passive_stop = {
+        "observed_state": "Z",
+        "supervisor_stopped": False,
+        "kill_sent": False,
+        "kill_observed": True,
+    }
+    freeze["driver_stop"] = passive_stop
+    audit["deadline"]["driver_stop"] = dict(passive_stop)
+    audit["deadline"]["driver_return_code_before_stop"] = return_code
+    _write_json(freeze_path, freeze)
+    _refresh_freeze(tmp_path, cell, audit)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert validation.result.canonical is canonical
+    if not canonical:
+        assert any(
+            "timeout deadline freeze identity" in item for item in validation.problems
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("log_00.json", {"command": {"action": "release"}}),
+        ("_deadline_commit_00.json", {"unexpected": True}),
+        ("state_-1.json", {"step": -1, "success": False}),
+    ],
+)
+def test_timeout_rejects_journals_outside_the_canonical_prefix_or_tail(
+    tmp_path: Path, name: str, value: dict
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    log_directory = _evidence_path(tmp_path, cell, audit, "deadline_freeze").parent
+    _write_json(log_directory / name, value)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any(
+        "outside the canonical prefix/tail" in item for item in validation.problems
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("raw_termination_cause", "planner_failed"),
+        ("raw_wrapper_rc", 22),
+        ("stdout_total_lines", 999),
+        ("terminal_event_count", 0),
+    ],
+)
+def test_planner_status_is_replayed_from_raw_outcome_and_agent_log(
+    tmp_path: Path, field: str, value
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    status_path = _evidence_path(tmp_path, cell, audit, "planner_status")
+    status = _read_json(status_path)
+    status[field] = value
+    _sync_status_evidence(tmp_path, cell, audit, status)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("planner" in item for item in validation.problems)
+
+
+def test_timeout_accepts_external_completion_observed_at_supervisor_deadline(
+    tmp_path: Path,
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    status_path = _evidence_path(tmp_path, cell, audit, "planner_status")
+    status = _read_json(status_path)
+    status["external_deadline_fired"] = False
+    status["raw_termination_cause"] = "planner_completed"
+    status["raw_wrapper_rc"] = 0
+    _sync_status_evidence(tmp_path, cell, audit, status)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert validation.result.canonical
+
+
+@pytest.mark.parametrize("raw_agent_log", ["", "{truncated-json\n"])
+def test_timeout_accepts_missing_or_truncated_terminal_at_supervisor_deadline(
+    tmp_path: Path, raw_agent_log: str
+):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    agent_path = _evidence_path(tmp_path, cell, audit, "agent_log")
+    agent_path.write_text(raw_agent_log, encoding="utf-8")
+    audit["evidence"]["agent_log"]["sha256"] = _digest(agent_path)
+    summary = _agent_log_summary(agent_path)
+    assert summary is not None
+    status_path = _evidence_path(tmp_path, cell, audit, "planner_status")
+    status = _read_json(status_path)
+    status.update(summary)
+    status["external_deadline_fired"] = False
+    status["raw_termination_cause"] = "planner_protocol_error"
+    status["raw_wrapper_rc"] = 23
+    _sync_status_evidence(tmp_path, cell, audit, status)
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert validation.result.canonical
+
+
+def test_audit_agent_exit_code_must_match_planner_wrapper(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    audit["agent_exit_code"] = 0
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("agent_exit_code" in item for item in validation.problems)
+
+
+def test_timeout_binds_audit_task_language_to_every_frozen_state(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell, success=False, timeout=True)
+    audit["task_language"] = "close the fridge"
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert any("task_language" in item for item in validation.problems)
+
+
+def test_old_pre_deadline_preliminary_artifact_fails_closed(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    del audit["deadline"]
+    del audit["evidence"]["deadline_contract"]
+
+    validation = _publish_for_validation(tmp_path, cell, audit)
+
+    assert not validation.result.canonical
+    assert validation.resumable
+    assert any("deadline" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        {"action": "move_to", "target": [0, 0, 0]},
+        {"action": "move_to", "xyz": [0, 0]},
+        {"action": "release", "steps": True},
+        {"action": "move_base", "steps": 0},
+        {"action": "set_gripper", "gripper": "hold"},
+        {"action": "rotate_pitch", "gripper": "hold"},
+        {"action": "move_to", "xyz": [0, 0, 0], "tol": 2.0},
+        {"action": "vla_act", "prompt": "open the drawer", "max_chunks": 1},
+    ],
+)
+def test_command_schemas_fail_closed(tmp_path: Path, command):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    with pytest.raises(ValueError, match="command trace line 1 is invalid"):
+        publish_completed_cell(
+            tmp_path,
+            cell,
+            CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+            _audit(tmp_path, cell),
+            [command],
+        )
+
+
+def test_empty_unseen_memory_must_be_null(tmp_path: Path):
+    cell = cell_for("composite_unseen", "HeatKebabSandwich", 1)
+    audit = _audit(tmp_path, cell)
+    audit["task_language"] = "heat kebab"
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+    assert any(
+        "empty-whitelist" in item
+        for item in validate_cell(tmp_path, cell).protocol_problems
+    )
+    audit = _audit(tmp_path, cell)
+    audit["task_language"] = "heat kebab"
+    audit["task_memory"] = None
+    audit["task_memory_available"] = False
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+    assert validate_cell(tmp_path, cell).result.canonical
 
 
 def _minimal_publication(cell):
@@ -168,3 +1535,58 @@ def test_log_archive_rejects_symlink_descendant(tmp_path: Path):
     with pytest.raises(ValueError, match="artifact subdirectory"):
         with secure_artifact_subdirectory(root, cell, "run_logs", cell.tag, "run-1"):
             pass
+
+
+def test_validator_rejects_symlink_task_without_following_it(tmp_path: Path):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    root = tmp_path / "results"
+    _run_digest(root)
+    split = root / "atomic"
+    split.mkdir(mode=0o700)
+    outside = tmp_path / "outside-result"
+    outside.mkdir(mode=0o700)
+    (outside / f"{cell.tag}.completed.json").write_text("{}\n", encoding="utf-8")
+    (split / cell.task).symlink_to(outside, target_is_directory=True)
+
+    validation = validate_cell(root, cell)
+
+    assert not validation.result.canonical
+    assert any("unsafe artifact directory" in item for item in validation.problems)
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        "runtime_scripts",
+        "memory_source",
+        "navview",
+        "checkpoint",
+        "preliminary",
+        "planner_auth_mode",
+        "planner_provider",
+        "planner_endpoint_identity",
+    ],
+)
+def test_cell_audit_identity_must_match_root_manifest(tmp_path: Path, tamper: str):
+    cell = cell_for("atomic", "OpenDrawer", 1)
+    audit = _audit(tmp_path, cell)
+    if tamper == "preliminary":
+        audit["preliminary"] = False
+    elif tamper == "checkpoint":
+        audit["checkpoint"]["fingerprint"] = "b" * 64
+    elif tamper.startswith("planner_"):
+        audit[tamper] = f"tampered-{audit[tamper]}"
+    else:
+        audit[tamper] = {**audit[tamper], "tampered": True}
+    publish_completed_cell(
+        tmp_path,
+        cell,
+        CellResult(Completion.COMPLETED, Outcome.SUCCESS, Integrity.VALID),
+        audit,
+        [{"action": "release"}],
+    )
+
+    validation = validate_cell(tmp_path, cell)
+
+    assert validation.provenance_problems
+    assert not validation.result.canonical

--- a/tests/test_robocasa_deadline.py
+++ b/tests/test_robocasa_deadline.py
@@ -1,0 +1,553 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import signal
+import stat
+import subprocess
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from rpent.reproduce.robocasa import preliminary_driver
+from rpent.reproduce.robocasa.deadline_supervisor import (
+    CONTRACT_NAME,
+    DEADLINE_PROTOCOL,
+    FREEZE_NAME,
+    GATE_NAME,
+    RECEIPT_PREFIX,
+    DeadlineController,
+    DeadlineError,
+    _atomic_json,
+    _ObservedProcess,
+    _open_gate,
+    _read_trusted_json,
+    _seal_committed_prefix,
+    normalize_deadline_outcome,
+    process_identity,
+    scan_committed_prefix,
+)
+from rpent.reproduce.robocasa.executor import _timeout_driver_exit_expected
+
+
+def _contract(
+    workdir: Path,
+    *,
+    deadline_ns: int,
+    started_ns: int | None = None,
+    run_id: str = "run-1",
+) -> tuple[dict, str]:
+    descriptor = _open_gate(workdir / GATE_NAME, create=True)
+    os.close(descriptor)
+    identity = process_identity(os.getpid())
+    assert identity is not None
+    if started_ns is None:
+        started_ns = min(time.monotonic_ns(), deadline_ns - 1)
+    timeout_ns = deadline_ns - started_ns
+    contract = {
+        "schema_version": 1,
+        "protocol": DEADLINE_PROTOCOL,
+        "run_id": run_id,
+        "nonce": "0" * 32,
+        "started_monotonic_ns": started_ns,
+        "deadline_monotonic_ns": deadline_ns,
+        "timeout_ns": timeout_ns,
+        "driver": {key: identity[key] for key in ("pid", "pgid", "start_time_ticks")},
+        "external_deadline_sha256": "a" * 64,
+    }
+    digest = _atomic_json(
+        workdir / CONTRACT_NAME,
+        contract,
+    )
+    return contract, digest
+
+
+def _publish(path: str | Path) -> None:
+    Path(path).write_text("", encoding="utf-8")
+
+
+def test_commit_gate_accepts_only_pre_deadline_publication(tmp_path: Path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    _contract(workdir, deadline_ns=time.monotonic_ns() + 1_000_000_000)
+
+    marker = workdir / "done_01.flag"
+    preliminary_driver._publish_done_before_deadline(_publish, marker, run_id="run-1")
+
+    assert marker.is_file()
+    receipt, _digest = _read_trusted_json(workdir / f"{RECEIPT_PREFIX}01.json")
+    assert receipt["done_published_monotonic_ns"] < receipt["deadline_monotonic_ns"]
+
+
+def test_commit_gate_rejects_command_that_finishes_after_deadline(tmp_path: Path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    _contract(workdir, deadline_ns=time.monotonic_ns() - 1)
+
+    marker = workdir / "done_01.flag"
+    with pytest.raises(SystemExit) as error:
+        preliminary_driver._publish_done_before_deadline(
+            _publish, marker, run_id="run-1"
+        )
+
+    assert error.value.code == 75
+    assert not marker.exists()
+    assert not (workdir / f"{RECEIPT_PREFIX}01.json").exists()
+
+
+@pytest.mark.parametrize("tamper", ["extra_field", "driver_start_time"])
+def test_commit_gate_rejects_non_exact_or_stale_driver_contract(
+    tmp_path: Path, tamper: str
+):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    contract, _digest = _contract(
+        workdir, deadline_ns=time.monotonic_ns() + 1_000_000_000
+    )
+    if tamper == "extra_field":
+        contract["unexpected"] = True
+    else:
+        contract["driver"]["start_time_ticks"] += 1
+    _atomic_json(workdir / CONTRACT_NAME, contract)
+
+    marker = workdir / "done_01.flag"
+    with pytest.raises(DeadlineError, match="does not match"):
+        preliminary_driver._publish_done_before_deadline(
+            _publish, marker, run_id="run-1"
+        )
+
+    assert not marker.exists()
+    assert not (workdir / f"{RECEIPT_PREFIX}01.json").exists()
+
+
+def test_commit_gate_removes_and_fsyncs_a_marker_published_across_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    (workdir / "done_00.flag").write_text("", encoding="utf-8")
+    (workdir / "state_00.json").write_text(
+        json.dumps({"step": 0, "success": False}) + "\n", encoding="utf-8"
+    )
+    (workdir / "state_01.json").write_text(
+        json.dumps({"step": 1, "success": True}) + "\n", encoding="utf-8"
+    )
+    (workdir / "log_01.json").write_text(
+        json.dumps({"command": {"action": "release"}}) + "\n",
+        encoding="utf-8",
+    )
+    (workdir / "command_trace.jsonl").write_text(
+        '{"action":"release"}\n', encoding="utf-8"
+    )
+    contract, contract_sha256 = _contract(workdir, deadline_ns=200, started_ns=100)
+    clock = iter((199, 201))
+    monkeypatch.setattr(preliminary_driver.time, "monotonic_ns", lambda: next(clock))
+
+    marker = workdir / "done_01.flag"
+    original_fsync = os.fsync
+    directory_fsyncs: list[bool] = []
+
+    def observe_fsync(descriptor: int) -> None:
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            directory_fsyncs.append(marker.exists())
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(
+        "rpent.reproduce.robocasa.deadline_supervisor.os.fsync", observe_fsync
+    )
+    with pytest.raises(SystemExit) as error:
+        preliminary_driver._publish_done_before_deadline(
+            _publish, marker, run_id="run-1"
+        )
+
+    assert error.value.code == 75
+    assert not marker.exists()
+    assert directory_fsyncs[-1] is False
+    receipt, _digest = _read_trusted_json(workdir / f"{RECEIPT_PREFIX}01.json")
+    assert receipt["done_published_monotonic_ns"] == 201
+    assert _seal_committed_prefix(workdir, contract, contract_sha256) == []
+    prefix = scan_committed_prefix(workdir)
+    assert prefix["prefix_step"] == 0
+    assert prefix["success"] is False
+    assert prefix["command_trace_sha256"] == hashlib.sha256(b"").hexdigest()
+    assert "state_01.json" not in prefix["files_sha256"]
+    assert "log_01.json" not in prefix["files_sha256"]
+    gate_descriptor = _open_gate(workdir / GATE_NAME, create=False)
+    try:
+        fcntl.flock(gate_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(gate_descriptor)
+
+
+@pytest.mark.parametrize(("terminal_ns", "fires"), [(199, False), (200, True)])
+def test_observed_planner_terminal_order_wins_over_delayed_watcher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_ns: int,
+    fires: bool,
+):
+    controller = DeadlineController(
+        workdir=tmp_path,
+        run_id="run-1",
+        driver_identity={"pid": 1, "pgid": 1, "start_time_ticks": 1},
+        timeout_seconds=1,
+        kill_after_seconds=1,
+        external_sha256="a" * 64,
+    )
+    controller.contract = {"deadline_monotonic_ns": 200}
+    clock = iter((terminal_ns, 300, 300))
+    monkeypatch.setattr(
+        "rpent.reproduce.robocasa.deadline_supervisor._time.monotonic_ns",
+        lambda: next(clock),
+    )
+    freeze = Mock()
+    monkeypatch.setattr(controller, "_freeze", freeze)
+
+    observed = _ObservedProcess(Mock(poll=Mock(return_value=0)), controller)
+    assert observed.poll() == 0
+    controller._watch()
+
+    assert controller.cancelled_monotonic_ns == terminal_ns
+    assert controller.fired is fires
+    assert freeze.call_count == int(fires)
+
+
+def test_terminal_timestamp_and_cancellation_are_linearized_against_watcher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    controller = DeadlineController(
+        workdir=workdir,
+        run_id="run-1",
+        driver_identity={"pid": 1, "pgid": 1, "start_time_ticks": 1},
+        timeout_seconds=1,
+        kill_after_seconds=1,
+        external_sha256="a" * 64,
+    )
+    controller.contract = {"deadline_monotonic_ns": 200}
+    timestamp_started = threading.Event()
+    release_timestamp = threading.Event()
+
+    def clock() -> int:
+        if threading.current_thread().name == "terminal-observer":
+            timestamp_started.set()
+            assert release_timestamp.wait(timeout=2)
+            return 199
+        return 300
+
+    monkeypatch.setattr(
+        "rpent.reproduce.robocasa.deadline_supervisor._time.monotonic_ns", clock
+    )
+    freeze = Mock()
+    monkeypatch.setattr(controller, "_freeze", freeze)
+    observer = threading.Thread(
+        target=controller.note_planner_terminal,
+        name="terminal-observer",
+    )
+    watcher = threading.Thread(target=controller._watch, name="deadline-watcher")
+
+    observer.start()
+    assert timestamp_started.wait(timeout=2)
+    watcher.start()
+    release_timestamp.set()
+    observer.join(timeout=2)
+    watcher.join(timeout=2)
+
+    assert not observer.is_alive()
+    assert not watcher.is_alive()
+    assert controller.cancelled_monotonic_ns == 199
+    assert controller.fired is False
+    freeze.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("return_code", "driver_stop", "success_latched", "expected"),
+    [
+        (
+            9,
+            {
+                "observed_state": "Z",
+                "supervisor_stopped": False,
+                "kill_sent": False,
+                "kill_observed": True,
+            },
+            False,
+            False,
+        ),
+        (
+            75,
+            {
+                "observed_state": "Z",
+                "supervisor_stopped": False,
+                "kill_sent": False,
+                "kill_observed": True,
+            },
+            False,
+            True,
+        ),
+        (
+            75,
+            {
+                "observed_state": "T",
+                "supervisor_stopped": True,
+                "kill_sent": True,
+                "kill_observed": True,
+            },
+            False,
+            False,
+        ),
+        (
+            -signal.SIGKILL,
+            {
+                "observed_state": "T",
+                "supervisor_stopped": True,
+                "kill_sent": True,
+                "kill_observed": True,
+            },
+            False,
+            True,
+        ),
+        (
+            -signal.SIGKILL,
+            {
+                "observed_state": "T",
+                "supervisor_stopped": True,
+                "kill_sent": False,
+                "kill_observed": False,
+            },
+            False,
+            False,
+        ),
+        (
+            0,
+            {
+                "observed_state": "Z",
+                "supervisor_stopped": False,
+                "kill_sent": False,
+                "kill_observed": True,
+            },
+            True,
+            True,
+        ),
+        (
+            0,
+            {
+                "observed_state": "Z",
+                "supervisor_stopped": False,
+                "kill_sent": False,
+                "kill_observed": True,
+            },
+            False,
+            False,
+        ),
+    ],
+)
+def test_timeout_driver_exit_requires_adapter_75_or_confirmed_supervisor_kill(
+    return_code: int, driver_stop: dict, success_latched: bool, expected: bool
+):
+    assert (
+        _timeout_driver_exit_expected(
+            {
+                "driver_stop": driver_stop,
+                "driver_return_code_before_stop": return_code,
+                "success_at_deadline": success_latched,
+            }
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "web_count", "raw_cause", "raw_rc", "expected"),
+    [
+        (None, 0, "planner_protocol_error", 23, ("planner_timeout", 20)),
+        (
+            {"violation": "forbidden_web_search"},
+            0,
+            "planner_protocol_error",
+            23,
+            ("planner_protocol_error", 23),
+        ),
+        (None, 1, "planner_protocol_error", 23, ("planner_protocol_error", 23)),
+        (None, 0, "operator_interrupted", 130, ("operator_interrupted", 130)),
+        (None, 0, "planner_completed", 0, ("planner_timeout", 20)),
+    ],
+)
+def test_outer_deadline_preserves_only_higher_priority_failures(
+    provider, web_count: int, raw_cause: str, raw_rc: int, expected
+):
+    assert (
+        normalize_deadline_outcome(
+            raw_cause,
+            raw_rc,
+            supervisor_fired=True,
+            provider_violation=provider,
+            forbidden_web_search_event_count=web_count,
+        )
+        == expected
+    )
+
+
+def test_driver_that_crashed_before_timeout_is_not_a_supervisor_termination(
+    tmp_path: Path,
+):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    (workdir / "done_00.flag").write_text("", encoding="utf-8")
+    (workdir / "state_00.json").write_text(
+        json.dumps({"step": 0, "success": False}) + "\n", encoding="utf-8"
+    )
+    (workdir / "command_trace.jsonl").write_text("", encoding="utf-8")
+    process = subprocess.Popen(
+        ["/bin/sh", "-c", "read _value; exit 9"],
+        stdin=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    identity = process_identity(process.pid)
+    assert identity is not None
+    driver_identity = {
+        key: identity[key] for key in ("pid", "pgid", "start_time_ticks")
+    }
+    assert process.stdin is not None
+    process.stdin.write("exit\n")
+    process.stdin.close()
+    exit_deadline = time.monotonic() + 2
+    while time.monotonic() < exit_deadline:
+        observed = process_identity(process.pid)
+        if observed is not None and observed["state"] == "Z":
+            break
+        time.sleep(0.005)
+    else:
+        pytest.fail("driver fixture did not become a zombie")
+    controller = DeadlineController(
+        workdir=workdir,
+        run_id="run-1",
+        driver_identity=driver_identity,
+        timeout_seconds=0.03,
+        kill_after_seconds=1,
+        external_sha256="a" * 64,
+    )
+    try:
+        controller.start(time.monotonic())
+        limit = time.monotonic() + 2
+        while not controller.fired and time.monotonic() < limit:
+            time.sleep(0.005)
+        controller.finish()
+        return_code = process.wait(timeout=2)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2)
+
+    assert controller.error is None
+    freeze, _digest = _read_trusted_json(workdir / FREEZE_NAME)
+    assert freeze["driver_stop"] == {
+        "observed_state": "Z",
+        "supervisor_stopped": False,
+        "kill_sent": False,
+        "kill_observed": True,
+    }
+    assert return_code == 9
+    assert not _timeout_driver_exit_expected(
+        {
+            "driver_stop": freeze["driver_stop"],
+            "driver_return_code_before_stop": return_code,
+            "success_at_deadline": freeze["success"],
+        }
+    )
+
+
+def test_deadline_controller_freezes_and_kills_the_committed_prefix(tmp_path: Path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    (workdir / "done_00.flag").write_text("", encoding="utf-8")
+    (workdir / "state_00.json").write_text(
+        json.dumps({"step": 0, "success": False}) + "\n", encoding="utf-8"
+    )
+    (workdir / "command_trace.jsonl").write_text("", encoding="utf-8")
+    process = subprocess.Popen(["sleep", "60"], start_new_session=True)
+    try:
+        identity = process_identity(process.pid)
+        assert identity is not None
+        driver_identity = {
+            key: identity[key] for key in ("pid", "pgid", "start_time_ticks")
+        }
+        controller = DeadlineController(
+            workdir=workdir,
+            run_id="run-1",
+            driver_identity=driver_identity,
+            timeout_seconds=0.2,
+            kill_after_seconds=1,
+            external_sha256="a" * 64,
+        )
+        controller.start(time.monotonic())
+        assert controller.contract is not None
+        assert controller.contract_sha256 is not None
+        (workdir / "state_01.json").write_text(
+            json.dumps({"step": 1, "success": True}) + "\n", encoding="utf-8"
+        )
+        (workdir / "log_01.json").write_text(
+            json.dumps({"command": {"action": "release"}}) + "\n",
+            encoding="utf-8",
+        )
+        (workdir / "command_trace.jsonl").write_text(
+            '{"action":"release"}\n', encoding="utf-8"
+        )
+        _atomic_json(
+            workdir / f"{RECEIPT_PREFIX}01.json",
+            {
+                "schema_version": 1,
+                "protocol": DEADLINE_PROTOCOL,
+                "run_id": "run-1",
+                "nonce": controller.contract["nonce"],
+                "step": 1,
+                "deadline_monotonic_ns": controller.contract["deadline_monotonic_ns"],
+                "done_published_monotonic_ns": controller.contract[
+                    "deadline_monotonic_ns"
+                ]
+                - 1,
+                "contract_sha256": controller.contract_sha256,
+            },
+        )
+        (workdir / "done_01.flag").write_text("", encoding="utf-8")
+        limit = time.monotonic() + 2
+        while not controller.fired and time.monotonic() < limit:
+            time.sleep(0.01)
+        controller.finish()
+        process.wait(timeout=2)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2)
+
+    assert controller.error is None
+    freeze, digest = _read_trusted_json(workdir / FREEZE_NAME)
+    assert digest == controller.freeze_sha256
+    assert freeze["prefix_step"] == 1
+    assert freeze["success"] is True
+    assert freeze["driver_stop"]["observed_state"] in {"T", "t"}
+    assert freeze["driver_stop"]["supervisor_stopped"] is True
+    assert freeze["driver_stop"]["kill_sent"] is True
+    assert freeze["driver_stop"]["kill_observed"] is True
+    assert process.returncode == -signal.SIGKILL

--- a/tests/test_robocasa_executor.py
+++ b/tests/test_robocasa_executor.py
@@ -1,0 +1,880 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import threading
+from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rpent.reproduce.robocasa import (
+    executor,
+    preflight,
+    preliminary_driver,
+    secure_script,
+)
+from rpent.reproduce.robocasa import sandbox as planner_sandbox
+from rpent.reproduce.robocasa.deadline_supervisor import (
+    CONTRACT_NAME,
+    GATE_NAME,
+    _open_gate,
+)
+from rpent.reproduce.robocasa.executor import ExecutorConfig, RuntimePaths, doctor
+from rpent.reproduce.robocasa.planner_transport import (
+    CHATGPT_BROKER_PROFILE,
+    CHATGPT_BROKER_PROTOCOL,
+    CODEX_REQUEST_MAX_RETRIES,
+    CODEX_STREAM_IDLE_TIMEOUT_MS,
+    CODEX_STREAM_MAX_RETRIES,
+    PlannerTransport,
+)
+from rpent.reproduce.robocasa.profiles import get_profile
+from rpent.reproduce.robocasa.protocol import cell_for
+
+
+def _write(path: Path, text: str = "fixture\n", *, mode: int = 0o600) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    path.chmod(mode)
+    return path
+
+
+def _runtime(tmp_path: Path) -> RuntimePaths:
+    root = tmp_path / "runtime"
+    model = root / "model"
+    vlm = root / "vlm"
+    model.mkdir(parents=True)
+    vlm.mkdir()
+    scripts = root / "scripts"
+    _write(root / "migration/robocasa_interactive_env.py")
+    _write(root / "migration/rldx_skill.py")
+    _write(root / "rldx/__init__.py")
+    _write(root / "external_dependencies/robocasa365/robocasa/__init__.py")
+    _write(root / "external_dependencies/robocasa365/robosuite/robosuite/__init__.py")
+    navview = root / "robosuite/robosuite/models/assets/bases/omron_mobile_base.xml"
+    _write(
+        navview,
+        """<mujoco><worldbody><body name="base">
+<camera name="navview" mode="fixed" pos="0.2 0 1.6"
+xyaxes="0 -1 0 0.643 0 0.766" fovy="75"/>
+</body></worldbody></mujoco>\n""",
+    )
+    for name in executor.CHECKPOINT_SHA256:
+        _write(model / name)
+    return RuntimePaths(
+        root=root,
+        sim_python=_write(scripts / "python", mode=0o700),
+        driver=_write(scripts / "driver.py"),
+        readiness=_write(scripts / "ready.py"),
+        deadline=_write(scripts / "deadline.py"),
+        isolation_launcher=_write(scripts / "isolate.py"),
+        artifact_builder=_write(scripts / "artifacts.py"),
+        model=model,
+        vlm_metadata=vlm,
+        navview_xml=navview,
+    )
+
+
+def _config(tmp_path: Path, *, preliminary: bool = True) -> ExecutorConfig:
+    results = tmp_path / "results"
+    rollouts = tmp_path / "rollouts"
+    memory = tmp_path / "memory"
+    for path in (results, memory):
+        path.mkdir(mode=0o700)
+    rollouts.mkdir(mode=0o711)
+    _write(memory / "manifest.json", "{}\n")
+    credential = _write(tmp_path / "secret", "secret-value\n")
+    return ExecutorConfig(
+        runtime=_runtime(tmp_path),
+        results_root=results,
+        rollout_root=rollouts,
+        memory_root=memory,
+        planner_profile=get_profile("codex-gpt55-xhigh"),
+        planner_transport=PlannerTransport.api_key(
+            credential_file=credential,
+            base_url="https://planner.example/v1",
+        ),
+        codex_bin=_write(tmp_path / "codex", mode=0o700),
+        preliminary_local_runtime=preliminary,
+    )
+
+
+def _patch_frozen_identities(monkeypatch) -> None:
+    monkeypatch.setattr(executor, "_frozen_runtime_problem", lambda *_args: None)
+    monkeypatch.setattr(
+        executor,
+        "_pinned_codex_identity",
+        lambda path: (
+            {
+                "path": str(path),
+                "sha256": executor.PINNED_CODEX_SHA256,
+                "version": executor.PINNED_CODEX_VERSION,
+            },
+            None,
+        ),
+    )
+    monkeypatch.setattr(executor, "_managed_codex_config_problem", lambda: None)
+
+
+def test_doctor_accepts_audited_preliminary_fixture(tmp_path, monkeypatch):
+    _patch_frozen_identities(monkeypatch)
+    monkeypatch.setattr(executor, "validate_memory_pack", lambda _root: [])
+    monkeypatch.setattr(
+        executor,
+        "_runtime_import_identity",
+        lambda _runtime: ({"robocasa": "fixture", "robosuite": "fixture"}, None),
+    )
+    monkeypatch.setattr(
+        executor,
+        "_git_snapshot",
+        lambda root: {"root": str(root), "commit": "f" * 40, "dirty": False},
+    )
+    monkeypatch.setattr(executor, "_rollout_directory_problem", lambda _root: None)
+    config = _config(tmp_path)
+    report = doctor(config)
+    assert report["ok"] is True
+    assert report["release_ready"] is False
+    assert report["runtime_kind"] == "preliminary_external_snapshot"
+    assert report["memory"]["manifest_sha256"]
+    assert "navview_patch" in report["scripts"]
+    serialized = json.dumps(report, sort_keys=True)
+    assert str(config.planner_transport.credential_file) not in serialized
+    assert "secret-value" not in serialized
+
+
+def test_doctor_requires_explicit_preliminary_acknowledgement(tmp_path, monkeypatch):
+    _patch_frozen_identities(monkeypatch)
+    monkeypatch.setattr(executor, "validate_memory_pack", lambda _root: [])
+    monkeypatch.setattr(
+        executor,
+        "_runtime_import_identity",
+        lambda _runtime: ({"robocasa": "fixture", "robosuite": "fixture"}, None),
+    )
+    report = doctor(_config(tmp_path, preliminary=False))
+    assert report["ok"] is False
+    assert any("preliminary" in problem for problem in report["problems"])
+
+
+def test_navview_must_be_a_direct_child_of_the_omron_base(tmp_path):
+    path = _write(
+        tmp_path / "nested-navview.xml",
+        """<mujoco><worldbody><body name="base"><body name="nested">
+<camera name="navview" mode="fixed" pos="0.2 0 1.6"
+xyaxes="0 -1 0 0.643 0 0.766" fovy="75"/>
+</body></body></worldbody></mujoco>\n""",
+    )
+
+    assert "direct child" in executor._navview_problem(path)
+
+
+def test_doctor_runs_active_isolation_preflight_when_requested(tmp_path, monkeypatch):
+    _patch_frozen_identities(monkeypatch)
+    monkeypatch.setattr(executor, "validate_memory_pack", lambda _root: [])
+    monkeypatch.setattr(
+        executor,
+        "_runtime_import_identity",
+        lambda _runtime: ({"robocasa": "fixture", "robosuite": "fixture"}, None),
+    )
+    monkeypatch.setattr(executor, "_rollout_directory_problem", lambda _root: None)
+    calls = []
+
+    def active(config):
+        calls.append(config)
+        return {"attestation_sha256": "a" * 64}
+
+    monkeypatch.setattr(preflight, "run_isolation_preflight", active)
+    config = _config(tmp_path)
+    report = doctor(config, verify_isolation=True)
+    assert report["ok"] is True
+    assert calls == [config]
+    assert report["isolation_preflight"] == {
+        "verified": True,
+        "attestation_sha256": "a" * 64,
+    }
+
+
+def test_doctor_reuses_valid_checkpoint_attestation(tmp_path, monkeypatch):
+    _patch_frozen_identities(monkeypatch)
+    monkeypatch.setattr(executor, "validate_memory_pack", lambda _root: [])
+    monkeypatch.setattr(
+        executor,
+        "_runtime_import_identity",
+        lambda _runtime: ({"robocasa": "fixture", "robosuite": "fixture"}, None),
+    )
+    monkeypatch.setattr(executor, "_rollout_directory_problem", lambda _root: None)
+    attestation = {
+        "fingerprint": "f" * 64,
+        "files": {
+            f"model/{name}": {"sha256": digest}
+            for name, digest in executor.CHECKPOINT_SHA256.items()
+        },
+    }
+    monkeypatch.setattr(
+        executor, "_load_checkpoint_attestation", lambda _config: attestation
+    )
+    monkeypatch.setattr(
+        executor,
+        "verify_checkpoint_identity",
+        lambda *_args, **_kwargs: pytest.fail("full hash must not run"),
+    )
+    report = doctor(_config(tmp_path), verify_checkpoint=True)
+    assert report["ok"] is True
+    assert report["checkpoint"]["verified"] is True
+    assert report["checkpoint"]["verification_source"] == "reused_attestation"
+
+
+def test_checkpoint_attestation_is_kept_out_of_planner_rollouts(tmp_path):
+    config = _config(tmp_path)
+    path = executor.checkpoint_attestation_path(config)
+    assert path == config.results_root / "_preflight/checkpoint-attestation.json"
+    assert config.rollout_root not in path.parents
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("https://planner.example", "https://planner.example/v1"),
+        ("https://planner.example/v1/", "https://planner.example/v1"),
+        ("http://127.0.0.1:4319", "http://127.0.0.1:4319/v1"),
+    ],
+)
+def test_normalize_responses_base_url(raw, expected):
+    assert executor.normalize_responses_base_url(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "http://example.com/v1",
+        "https://user:secret@example.com/v1",
+        "https://example.com/v1/responses",
+        "https://example.com/v1?token=secret",
+    ],
+)
+def test_normalize_responses_base_url_rejects_unsafe_values(raw):
+    with pytest.raises(ValueError):
+        executor.normalize_responses_base_url(raw)
+
+
+def test_subscription_transport_requires_one_loopback_listener(tmp_path):
+    credential = _write(tmp_path / "broker-capability", "capability\n")
+    with pytest.raises(ValueError, match="loopback"):
+        PlannerTransport.chatgpt_subscription(
+            credential_file=credential,
+            broker_base_url="https://broker.example/v1",
+            broker_health_url="http://127.0.0.1:4319/health",
+        )
+    with pytest.raises(ValueError, match="same listener"):
+        PlannerTransport.chatgpt_subscription(
+            credential_file=credential,
+            broker_base_url="http://127.0.0.1:4319/v1",
+            broker_health_url="http://127.0.0.1:4320/health",
+        )
+
+
+@pytest.mark.parametrize(
+    ("health_override", "expected_problem"),
+    [({}, None), ({"reasoning_effort": "high"}, "identity differs")],
+)
+def test_subscription_broker_health_is_bound_to_frozen_profile(
+    tmp_path, health_override, expected_problem
+):
+    payload = {
+        "provider_profile": CHATGPT_BROKER_PROFILE,
+        "auth_mode": "chatgpt_broker",
+        "credential_broker": True,
+        "credential_broker_ready": True,
+        "credential_broker_protocol": CHATGPT_BROKER_PROTOCOL,
+        "model": "gpt-5.5",
+        "reasoning_effort": "xhigh",
+        **health_override,
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = int(server.server_address[1])
+        config = _config(tmp_path)
+        transport = PlannerTransport.chatgpt_subscription(
+            credential_file=config.planner_transport.credential_file,
+            broker_base_url=f"http://127.0.0.1:{port}/v1",
+            broker_health_url=f"http://127.0.0.1:{port}/health",
+        )
+        problem = executor._broker_health_problem(
+            replace(config, planner_transport=transport)
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+    if expected_problem is None:
+        assert problem is None
+    else:
+        assert expected_problem in problem
+
+
+def test_secret_policy_rejects_group_access_and_symlinks(tmp_path):
+    secret = _write(tmp_path / "secret", "secret-value\n", mode=0o640)
+    assert "0600" in executor._trusted_credential(secret)
+    secret.chmod(0o600)
+    alias = tmp_path / "alias"
+    alias.symlink_to(secret)
+    assert "non-symlink" in executor._trusted_credential(alias)
+    assert executor._trusted_credential(secret) is None
+
+
+def test_secret_is_reopened_once_into_exec_closing_memfd(tmp_path):
+    secret = _write(tmp_path / "secret", "fixture-secret\n", mode=0o600)
+    descriptor, anonymous_path = planner_sandbox._secret_memfd(secret)
+    try:
+        assert Path(anonymous_path).read_text(encoding="utf-8") == "fixture-secret\n"
+        assert os.get_inheritable(descriptor) is False
+    finally:
+        os.close(descriptor)
+    alias = tmp_path / "alias"
+    alias.symlink_to(secret)
+    with pytest.raises(SystemExit, match="owned, regular"):
+        planner_sandbox._secret_memfd(alias)
+
+
+def test_secret_memfd_retries_partial_writes(tmp_path, monkeypatch):
+    secret = _write(tmp_path / "secret", "fixture-secret\n", mode=0o600)
+    real_write = os.write
+    write_calls = 0
+
+    def short_write(descriptor, data):
+        nonlocal write_calls
+        write_calls += 1
+        return real_write(descriptor, data[:3])
+
+    monkeypatch.setattr(planner_sandbox.os, "write", short_write)
+    descriptor, anonymous_path = planner_sandbox._secret_memfd(secret)
+    try:
+        assert Path(anonymous_path).read_text(encoding="utf-8") == "fixture-secret\n"
+        assert write_calls > 1
+    finally:
+        os.close(descriptor)
+
+
+def test_launcher_is_compiled_from_pinned_open_bytes(tmp_path):
+    source = b"VALUE = 7\n"
+    launcher = tmp_path / "launcher.py"
+    launcher.write_bytes(source)
+    launcher.chmod(0o600)
+    digest = hashlib.sha256(source).hexdigest()
+    assert planner_sandbox._load_launcher(launcher, digest).VALUE == 7
+    with pytest.raises(SystemExit, match="frozen SHA-256"):
+        planner_sandbox._load_launcher(launcher, "0" * 64)
+    launcher.chmod(0o620)
+    with pytest.raises(SystemExit, match="immutable"):
+        planner_sandbox._load_launcher(launcher, digest)
+
+
+def _stage_deadline_controls(workdir: Path) -> dict[str, Path]:
+    controls = {
+        GATE_NAME: _write(workdir / GATE_NAME, "", mode=0o600),
+        CONTRACT_NAME: _write(workdir / CONTRACT_NAME, "{}\n", mode=0o600),
+    }
+    assert set(controls) == planner_sandbox.DEADLINE_CONTROL_NAMES
+    return controls
+
+
+def _launcher_module(seal_task_memory=lambda _workdir: None):
+    return SimpleNamespace(
+        seal_task_memory=seal_task_memory,
+        PLANNER_WRITABLE_DIRECTORIES=(),
+        PLANNER_WRITABLE_MAILBOXES=(),
+        _create_private_directory=lambda *_args: None,
+        _create_fixed_mailbox=lambda *_args: None,
+        _publish_mailbox_marker=lambda *_args: None,
+    )
+
+
+def test_isolation_prepare_never_shares_deadline_controls(tmp_path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    controls = _stage_deadline_controls(workdir)
+    observation = _write(workdir / "state_00.json", "{}\n", mode=0o600)
+    identities = {name: path.stat().st_ino for name, path in controls.items()}
+
+    result = planner_sandbox._prepare_isolated_workdir(
+        _launcher_module(),
+        workdir,
+        os.geteuid(),
+        os.getegid(),
+        owner_uid=os.geteuid(),
+        owner_gid=os.getegid(),
+    )
+
+    assert result == (workdir / ".codex", workdir / "tmp")
+    for name, path in controls.items():
+        metadata = path.stat()
+        assert metadata.st_ino == identities[name]
+        assert metadata.st_uid == os.geteuid()
+        assert metadata.st_gid == os.getegid()
+        assert stat.S_IMODE(metadata.st_mode) == 0o600
+    assert stat.S_IMODE(observation.stat().st_mode) == 0o640
+    descriptor = _open_gate(controls[GATE_NAME], create=False)
+    os.close(descriptor)
+
+
+@pytest.mark.parametrize("tamper", ["replace", "hardlink", "permissions"])
+def test_isolation_prepare_rejects_deadline_gate_tampering(tmp_path, tamper):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    controls = _stage_deadline_controls(workdir)
+    gate = controls[GATE_NAME]
+
+    def tamper_with_control(_workdir):
+        if tamper == "replace":
+            gate.unlink()
+            _write(gate, "", mode=0o600)
+        elif tamper == "hardlink":
+            os.link(gate, workdir / "gate-alias")
+        else:
+            gate.chmod(0o660)
+        return None
+
+    with pytest.raises(SystemExit, match="deadline control is unsafe"):
+        planner_sandbox._prepare_isolated_workdir(
+            _launcher_module(tamper_with_control),
+            workdir,
+            os.geteuid(),
+            os.getegid(),
+            owner_uid=os.geteuid(),
+            owner_gid=os.getegid(),
+        )
+
+
+@pytest.mark.parametrize("tamper", ["missing", "extra"])
+def test_isolation_prepare_requires_exact_deadline_control_set(tmp_path, tamper):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    controls = _stage_deadline_controls(workdir)
+    if tamper == "missing":
+        controls[CONTRACT_NAME].unlink()
+    else:
+        _write(workdir / "_deadline_commit_01.json", "{}\n", mode=0o600)
+
+    with pytest.raises(SystemExit, match="deadline control set differs"):
+        planner_sandbox._prepare_isolated_workdir(
+            _launcher_module(),
+            workdir,
+            os.geteuid(),
+            os.getegid(),
+            owner_uid=os.geteuid(),
+            owner_gid=os.getegid(),
+        )
+
+
+def test_deadline_gate_stays_root_only_while_isolation_prepare_is_paused(tmp_path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(mode=0o700)
+    controls = _stage_deadline_controls(workdir)
+    entered = threading.Event()
+    release = threading.Event()
+    errors = []
+
+    def pause_prepare(_workdir):
+        entered.set()
+        assert release.wait(timeout=2)
+        return None
+
+    def prepare():
+        try:
+            planner_sandbox._prepare_isolated_workdir(
+                _launcher_module(pause_prepare),
+                workdir,
+                os.geteuid(),
+                os.getegid(),
+                owner_uid=os.geteuid(),
+                owner_gid=os.getegid(),
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=prepare)
+    thread.start()
+    assert entered.wait(timeout=2)
+    try:
+        for path in controls.values():
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        descriptor = _open_gate(controls[GATE_NAME], create=False)
+        os.close(descriptor)
+    finally:
+        release.set()
+        thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert errors == []
+
+
+def test_secure_script_rejects_tampering_and_group_write(tmp_path):
+    script = _write(tmp_path / "script.py", "VALUE = 1\n")
+    digest = hashlib.sha256(script.read_bytes()).hexdigest()
+    assert secure_script._read_source(script, digest) == "VALUE = 1\n"
+    with pytest.raises(SystemExit, match="frozen SHA-256"):
+        secure_script._read_source(script, "f" * 64)
+    script.chmod(0o620)
+    with pytest.raises(SystemExit, match="immutable"):
+        secure_script._read_source(script, digest)
+
+
+def test_doctor_runtime_hash_policy_is_fail_closed(tmp_path, monkeypatch):
+    source = _write(tmp_path / "driver.py", "frozen\n")
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    monkeypatch.setitem(executor.FROZEN_RUNTIME_SHA256, "driver", digest)
+    assert executor._frozen_runtime_problem("driver", source) is None
+    source.write_text("changed\n", encoding="utf-8")
+    assert "approved SHA-256" in executor._frozen_runtime_problem("driver", source)
+
+
+def test_codex_pin_rejects_unapproved_binary(tmp_path):
+    binary = _write(tmp_path / "codex", "not-codex\n", mode=0o700)
+    _identity, problem = executor._pinned_codex_identity(binary)
+    assert "pinned 0.147.0 SHA-256" in problem
+
+
+def test_managed_codex_config_must_be_empty_or_absent(tmp_path):
+    managed = tmp_path / "codex"
+    assert executor._managed_codex_config_problem(managed) is None
+    managed.mkdir()
+    assert executor._managed_codex_config_problem(managed) is None
+    _write(managed / "managed_config.toml", "model = 'other'\n")
+    assert "must be empty" in executor._managed_codex_config_problem(managed)
+
+
+def test_archive_records_only_bounded_audit_evidence(tmp_path):
+    workdir = tmp_path / "workdir"
+    destination = tmp_path / "archive"
+    workdir.mkdir()
+    _write(workdir / "agent.log", "{}\n")
+    _write(workdir / "planner_status.json", "{}\n")
+    _write(workdir / "image_cam_00.png", "large fixture")
+    destination.mkdir()
+    descriptor = os.open(destination, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        hashes = executor._archive_workdir(workdir, descriptor)
+    finally:
+        os.close(descriptor)
+    assert set(hashes) == {"agent.log", "planner_status.json"}
+    assert all(len(value) == 64 for value in hashes.values())
+    assert not (destination / "image_cam_00.png").exists()
+
+
+def test_only_committed_zero_exit_success_is_an_expected_driver_shutdown(tmp_path):
+    _write(tmp_path / "done_01.flag")
+    _write(tmp_path / "state_01.json", '{"success": true}\n')
+    _write(tmp_path / "log_01.json", "{}\n")
+    _write(tmp_path / "command_trace.jsonl", '{"action":"release"}\n')
+
+    assert executor._latched_success_exit(tmp_path, 0) is True
+    assert executor._latched_success_exit(tmp_path, 1) is False
+    (tmp_path / "log_01.json").unlink()
+    assert executor._latched_success_exit(tmp_path, 0) is False
+
+
+def test_timeout_driver_is_reaped_before_fallback_stop():
+    waits = []
+    process = SimpleNamespace(
+        poll=lambda: None,
+        wait=lambda timeout: waits.append(timeout) or -9,
+    )
+
+    assert (
+        executor._observe_driver_exit(
+            process,
+            termination="planner_timeout",
+            timeout_seconds=15,
+        )
+        == -9
+    )
+    assert waits == [15]
+
+
+def test_non_timeout_driver_is_not_waited_for():
+    process = SimpleNamespace(
+        poll=lambda: None,
+        wait=lambda timeout: pytest.fail(f"unexpected wait({timeout})"),
+    )
+
+    assert (
+        executor._observe_driver_exit(
+            process,
+            termination="planner_completed",
+            timeout_seconds=15,
+        )
+        is None
+    )
+
+
+def test_private_directory_policy(tmp_path):
+    directory = tmp_path / "private"
+    directory.mkdir(mode=0o700)
+    assert executor._private_directory_problem(directory, "fixture") is None
+    directory.chmod(0o750)
+    assert "group or other" in executor._private_directory_problem(directory, "fixture")
+    directory.chmod(0o700)
+    alias = tmp_path / "alias"
+    alias.symlink_to(directory, target_is_directory=True)
+    assert "real directory" in executor._private_directory_problem(alias, "fixture")
+
+
+def test_rollout_root_requires_traverse_only_mode(tmp_path):
+    root = tmp_path / "rollouts"
+    root.mkdir(mode=0o700)
+    assert "0711" in executor._rollout_directory_problem(root)
+    root.chmod(0o711)
+    assert "ancestor" in executor._rollout_directory_problem(root)
+
+
+def test_rollout_parents_are_explicitly_traverse_only(tmp_path):
+    root = tmp_path / "rollouts"
+    root.mkdir(mode=0o711)
+    target = root / "atomic" / "OpenDrawer_s01"
+    executor._prepare_rollout_parent(target, root)
+    assert stat.S_IMODE((root / "atomic").stat().st_mode) == 0o711
+    assert stat.S_IMODE(target.stat().st_mode) == 0o711
+
+
+def test_remove_workdir_is_contained(tmp_path):
+    root = tmp_path / "rollouts"
+    workdir = root / "task" / "attempt"
+    workdir.mkdir(parents=True)
+    executor._remove_workdir(workdir, root)
+    assert not workdir.exists()
+    with pytest.raises(RuntimeError, match="rollout root"):
+        executor._remove_workdir(root, root)
+
+
+def test_planner_command_keeps_generated_shell_off_network(tmp_path):
+    config = _config(tmp_path)
+    command = executor._planner_command(
+        config,
+        workdir=config.rollout_root,
+        run_id="run-1",
+        cell=cell_for("atomic", "OpenDrawer", 1),
+    )
+    assert "--sandbox" not in command
+    assert (
+        command[command.index("--launcher-sha256") + 1]
+        == (executor.FROZEN_RUNTIME_SHA256["isolation_launcher"])
+    )
+    assert 'default_permissions="rpent_outer_landlock"' in command
+    assert 'permissions.rpent_outer_landlock.filesystem={":root"="write"}' in command
+    assert "permissions.rpent_outer_landlock.network.enabled=false" in command
+    assert 'web_search="disabled"' in command
+    assert "allow_login_shell=false" in command
+    assert "analytics.enabled=false" in command
+    assert "feedback.enabled=false" in command
+    assert "check_for_update_on_startup=false" in command
+    assert 'otel.trace_exporter="none"' in command
+    assert "tools.experimental_request_user_input.enabled=false" in command
+    for feature in (
+        "browser_use_full_cdp_access",
+        "in_app_browser",
+        "image_generation",
+        "multi_agent",
+        "multi_agent_v2",
+    ):
+        assert feature in command
+    assert "use_legacy_landlock" not in command
+    assert "--add-dir" not in command
+    assert "danger-full-access" not in command
+    rendered = "\n".join(command)
+    assert "model_provider=rpent_responses_api" in command
+    assert "model_providers.rpent_responses_api.base_url=" in rendered
+    assert "model_providers.rpent_responses_api.request_max_retries=12" in command
+    assert "model_providers.rpent_responses_api.stream_max_retries=120" in command
+    assert (
+        "model_providers.rpent_responses_api.stream_idle_timeout_ms=330000" in command
+    )
+    assert "sorux" not in rendered.lower()
+
+
+def test_formal_planner_adapter_rejects_unaudited_claude_profile(tmp_path):
+    config = replace(_config(tmp_path), planner_profile=get_profile("claude-opus48"))
+    assert config.planner_profile.model == "claude-opus-4-8"
+    with pytest.raises(RuntimeError, match="declared but not audited"):
+        executor._planner_command(
+            config,
+            workdir=config.rollout_root,
+            run_id="run-1",
+            cell=cell_for("atomic", "OpenDrawer", 1),
+        )
+
+
+def test_subscription_planner_command_uses_broker_without_oauth_in_cell(tmp_path):
+    config = _config(tmp_path)
+    capability = _write(tmp_path / "broker-capability", "opaque-capability\n")
+    transport = PlannerTransport.chatgpt_subscription(
+        credential_file=capability,
+        broker_base_url="http://127.0.0.1:4319/v1",
+        broker_health_url="http://127.0.0.1:4319/health",
+    )
+    config = replace(config, planner_transport=transport)
+    command = executor._planner_command(
+        config,
+        workdir=config.rollout_root,
+        run_id="run-1",
+        cell=cell_for("atomic", "OpenDrawer", 1),
+    )
+    rendered = "\n".join(command)
+    assert "model_provider=rpent_chatgpt_broker" in command
+    assert "model_providers.rpent_chatgpt_broker.base_url=" in rendered
+    assert "model_providers.rpent_chatgpt_broker.request_max_retries=12" in command
+    assert "model_providers.rpent_chatgpt_broker.stream_max_retries=120" in command
+    assert (
+        "model_providers.rpent_chatgpt_broker.stream_idle_timeout_ms=330000" in command
+    )
+    assert "http://127.0.0.1:4319/v1" in rendered
+    assert "gpt-5.5" in rendered
+    assert "xhigh" in rendered
+    assert "auth.json" not in rendered
+    assert "CODEX_HOME" not in rendered
+    assert "openai_chatgpt_subscription" not in rendered
+    assert "opaque-capability" not in rendered
+    assert 'shell_environment_policy.exclude=["RLDX_PLANNER_API_KEY"]' in command
+    assert "permissions.rpent_outer_landlock.network.enabled=false" in command
+
+
+def test_codex_provider_retry_constants_are_frozen():
+    assert CODEX_REQUEST_MAX_RETRIES == 12
+    assert CODEX_STREAM_MAX_RETRIES == 120
+    assert CODEX_STREAM_IDLE_TIMEOUT_MS == 330_000
+
+
+def test_external_scripts_run_through_pinned_open_bytes_adapter(tmp_path):
+    config = _config(tmp_path)
+    command = executor._external_script_command(config, "readiness", ["--probe"])
+    assert command[1].endswith("/secure_script.py")
+    assert command[command.index("--source") + 1] == str(config.runtime.readiness)
+    assert (
+        command[command.index("--sha256") + 1]
+        == (executor.FROZEN_RUNTIME_SHA256["readiness"])
+    )
+    assert command[-2:] == ["--", "--probe"]
+
+
+def test_driver_environment_is_allowlisted_and_has_no_reset_override(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("RLDX_RESET_SEED", "123")
+    monkeypatch.setenv("PYTHONPATH", "/untrusted")
+    monkeypatch.setenv("LD_PRELOAD", "/untrusted/library.so")
+    environment = executor._driver_environment(
+        _config(tmp_path), 1, cell_for("atomic", "OpenDrawer", 1)
+    )
+    assert environment["CUDA_VISIBLE_DEVICES"] == "1"
+    assert environment["RLDX_ALLOW_RESET"] == "0"
+    assert environment["RLDX_PERCEPTION_ISOLATION"] == "1"
+    assert "RLDX_RESET_SEED" not in environment
+    assert "PYTHONPATH" not in environment
+    assert "LD_PRELOAD" not in environment
+
+
+def test_driver_environment_derives_seen_reset_seed(tmp_path, monkeypatch):
+    monkeypatch.setenv("RLDX_RESET_SEED", "999")
+    config = _config(tmp_path)
+    seen = executor._driver_environment(
+        config, 0, cell_for("composite_seen", "PrepareCoffee", 5)
+    )
+    unseen = executor._driver_environment(
+        config, 0, cell_for("composite_unseen", "ArrangeTea", 5)
+    )
+    assert seen["RLDX_RESET_SEED"] == "4200005"
+    assert "RLDX_RESET_SEED" not in unseen
+
+
+def test_preliminary_driver_rejects_schema_before_motion_and_after_success():
+    class Driver:
+        calls = 0
+
+        def dump_state(self, _step, publish_done=True):
+            return {"success": False}
+
+        def execute(self, _command):
+            self.calls += 1
+            return {"ok": True}
+
+    module = SimpleNamespace(RoboCasaDriver=Driver)
+    preliminary_driver._patch_driver(module)
+    driver = Driver()
+    driver.env = SimpleNamespace(
+        terminated=False,
+        current_raw_obs={"language": "open the drawer"},
+        env=SimpleNamespace(get_ep_meta=lambda: {"lang": "open the drawer"}),
+    )
+    invalid = {"action": "move_to", "xyz": [0, 0, 0], "extra": True}
+    assert "invalid command schema" in driver.execute(invalid)["error"]
+    assert driver.calls == 0
+    driver.env.terminated = True
+    assert "invalid command schema" in driver.execute(invalid)["error"]
+    with pytest.raises(SystemExit):
+        driver.execute({"action": "release"})
+    assert driver.calls == 0
+
+
+def test_preliminary_driver_translates_refused_post_success_step():
+    class Environment:
+        def reset(self):
+            return {}
+
+        def step(self, _action):
+            raise AssertionError("post-success physics must not run")
+
+    class Driver:
+        def dump_state(self, _step, publish_done=True):
+            return {"success": False}
+
+        def execute(self, _command):
+            return self.env.step(None)
+
+    module = SimpleNamespace(
+        RoboCasaDriver=Driver,
+        RoboCasaInteractiveEnv=Environment,
+    )
+    preliminary_driver._patch_driver(module)
+    environment = Environment()
+    environment._terminated = True
+    environment.terminated = False
+    environment.current_raw_obs = {"language": "open the drawer"}
+    environment.env = SimpleNamespace(get_ep_meta=lambda: {"lang": "open the drawer"})
+    driver = Driver()
+    driver.env = environment
+
+    assert driver.execute({"action": "release"}) == {
+        "status": "task_success",
+        "success": True,
+    }

--- a/tests/test_robocasa_memory.py
+++ b/tests/test_robocasa_memory.py
@@ -1,0 +1,227 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from rpent.reproduce.robocasa.memory import build_memory_pack, validate_memory_pack
+from rpent.reproduce.robocasa.protocol import (
+    ALLOWED_ACTIONS,
+    EMPTY_MEMORY_TASKS,
+    MEMORY_PAIR_TASKS,
+)
+
+
+def _source_tree(root: Path) -> None:
+    from rpent.reproduce.robocasa.memory import SOURCE_DIRS, _tasks_for_directory
+
+    for label, dirname in SOURCE_DIRS.items():
+        directory = root / dirname
+        directory.mkdir()
+        for task in _tasks_for_directory(label) - EMPTY_MEMORY_TASKS:
+            (directory / f"{task}_s0.json").write_text(
+                json.dumps(
+                    {
+                        "task": task,
+                        "seed": 0,
+                        "success": True,
+                        "task_language": f"do {task}",
+                    }
+                )
+            )
+            (directory / f"recipe_{task}_s0.jsonl").write_text(
+                json.dumps({"action": "rldx_skill"}) + "\n"
+            )
+
+
+def test_pack_has_only_canonical_pairs_empty_whitelist_and_hashes(tmp_path: Path):
+    source, destination = tmp_path / "migration", tmp_path / "pack"
+    source.mkdir()
+    _source_tree(source)
+    manifest = build_memory_pack(source, destination)
+    assert len(manifest["entries"]) == 50
+    assert manifest["protocol"] == "robocasa-harness-vla-v1"
+    assert manifest["source_directories"]["atomic"] == "explore_atomic_recipe"
+    assert not validate_memory_pack(destination)
+    assert sum(
+        entry["memory"] == "seed0_success" for entry in manifest["entries"]
+    ) == len(MEMORY_PAIR_TASKS)
+    assert all(not list((destination / task).iterdir()) for task in EMPTY_MEMORY_TASKS)
+    trace = destination / "OpenDrawer" / "OpenDrawer_s0.jsonl"
+    assert json.loads(trace.read_text())["action"] == "vla_act"
+    assert not any(path.name.endswith(".md") for path in destination.rglob("*"))
+
+
+def test_pack_expands_legacy_commands_to_the_frozen_action_surface(tmp_path: Path):
+    source, destination = tmp_path / "migration", tmp_path / "pack"
+    source.mkdir()
+    _source_tree(source)
+    trace = (
+        source / "exploration_unseen_recipe" / "recipe_RecycleBottlesByType_s0.jsonl"
+    )
+    trace.write_text(
+        "\n".join(
+            [
+                '{"action":"set_gripper","width":1.0}',
+                '{"action":"scripted_grasp","xyz":[1.0,2.0,3.0],"approach_z":0.1}',
+            ]
+        )
+        + "\n"
+    )
+    build_memory_pack(source, destination)
+    packed = destination / "RecycleBottlesByType" / "RecycleBottlesByType_s0.jsonl"
+    commands = [json.loads(line) for line in packed.read_text().splitlines()]
+    assert len(commands) == 6
+    assert {command["action"] for command in commands} <= ALLOWED_ACTIONS
+    assert commands[0] == {"action": "set_gripper", "gripper": 1.0}
+    assert [command["action"] for command in commands[1:]] == [
+        "set_gripper",
+        "move_to",
+        "move_to",
+        "set_gripper",
+        "move_to",
+    ]
+    assert not validate_memory_pack(destination)
+
+
+def test_pack_removes_embedded_audit_commands_and_normalizes_stats(tmp_path: Path):
+    source, destination = tmp_path / "migration", tmp_path / "pack"
+    source.mkdir()
+    _source_tree(source)
+    audit_path = source / "exploration_seen_recipe" / "SearingMeat_s0.json"
+    audit = json.loads(audit_path.read_text())
+    audit.update(
+        {
+            "command_sequence": [{"action": "set_gripper", "width": 1.0}],
+            "n_commands": 99,
+            "manual_cmds": 99,
+            "vla_calls": 99,
+        }
+    )
+    audit_path.write_text(json.dumps(audit))
+
+    build_memory_pack(source, destination)
+
+    packed = json.loads(
+        (destination / "SearingMeat" / "SearingMeat_s0.json").read_text()
+    )
+    assert "command_sequence" not in packed
+    assert packed["n_commands"] == 1
+    assert packed["manual_cmds"] == 0
+    assert packed["vla_calls"] == 1
+    assert not validate_memory_pack(destination)
+
+
+def test_pack_rejects_unsuccessful_memory_and_detects_tampering(tmp_path: Path):
+    source = tmp_path / "migration"
+    source.mkdir()
+    _source_tree(source)
+    audit = source / "explore_atomic_recipe" / "OpenDrawer_s0.json"
+    payload = json.loads(audit.read_text())
+    payload["success"] = False
+    audit.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="not a successful"):
+        build_memory_pack(source, tmp_path / "bad")
+    payload["success"] = True
+    audit.write_text(json.dumps(payload))
+    pack = tmp_path / "good"
+    build_memory_pack(source, pack)
+    (pack / "OpenDrawer" / "OpenDrawer_s0.jsonl").write_text("tampered\n")
+    assert any("hash mismatch" in problem for problem in validate_memory_pack(pack))
+
+
+def test_memory_validation_reparses_semantics_even_with_updated_hash(tmp_path: Path):
+    source, pack = tmp_path / "migration", tmp_path / "pack"
+    source.mkdir()
+    _source_tree(source)
+    build_memory_pack(source, pack)
+    trace = pack / "OpenDrawer" / "OpenDrawer_s0.jsonl"
+    trace.write_text('{"action":"vla_act","prompt":"wrong"}\n')
+    manifest_path = pack / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    entry = next(item for item in manifest["entries"] if item["task"] == "OpenDrawer")
+    entry["files"][trace.name] = hashlib.sha256(trace.read_bytes()).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+    assert any(
+        "invalid memory semantics" in problem for problem in validate_memory_pack(pack)
+    )
+
+
+def test_memory_validation_rejects_embedded_commands_with_updated_hash(tmp_path: Path):
+    source, pack = tmp_path / "migration", tmp_path / "pack"
+    source.mkdir()
+    _source_tree(source)
+    build_memory_pack(source, pack)
+    audit_path = pack / "OpenDrawer" / "OpenDrawer_s0.json"
+    audit = json.loads(audit_path.read_text())
+    audit["command_sequence"] = [{"action": "release"}]
+    audit_path.write_text(json.dumps(audit))
+    manifest_path = pack / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    entry = next(item for item in manifest["entries"] if item["task"] == "OpenDrawer")
+    entry["files"][audit_path.name] = hashlib.sha256(
+        audit_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    assert any("embeds commands" in problem for problem in validate_memory_pack(pack))
+
+
+def test_memory_pack_rejects_invalid_commands_and_extra_files(tmp_path: Path):
+    source = tmp_path / "migration"
+    source.mkdir()
+    _source_tree(source)
+    trace = source / "explore_atomic_recipe" / "recipe_OpenDrawer_s0.jsonl"
+    trace.write_text('{"arguments":{}}\n')
+    with pytest.raises(ValueError, match="invalid command"):
+        build_memory_pack(source, tmp_path / "bad")
+    trace.write_text('{"action":"release"}\n')
+    pack = tmp_path / "good"
+    build_memory_pack(source, pack)
+    (pack / "TASK_MEMORY.md").write_text("forbidden")
+    assert any(
+        "unexpected pack entries" in problem for problem in validate_memory_pack(pack)
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        {"action": "scripted_grasp", "xyz": [0, 0, 0]},
+        {"action": "move_to", "target": [0, 0, 0]},
+        {"action": "move_to", "xyz": [0, 0, float("nan")]},
+        {"action": "release", "steps": 0},
+        {"action": "vla_act", "prompt": "wrong"},
+    ],
+)
+def test_memory_validation_rejects_noncanonical_command_schemas(
+    tmp_path: Path, command
+):
+    source, pack = tmp_path / "migration", tmp_path / "pack"
+    source.mkdir()
+    _source_tree(source)
+    build_memory_pack(source, pack)
+    trace = pack / "OpenDrawer" / "OpenDrawer_s0.jsonl"
+    trace.write_text(json.dumps(command) + "\n")
+    manifest_path = pack / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    entry = next(item for item in manifest["entries"] if item["task"] == "OpenDrawer")
+    entry["files"][trace.name] = hashlib.sha256(trace.read_bytes()).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+    assert any(
+        "invalid memory semantics" in problem for problem in validate_memory_pack(pack)
+    )

--- a/tests/test_robocasa_protocol.py
+++ b/tests/test_robocasa_protocol.py
@@ -1,0 +1,53 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rpent.reproduce.robocasa.protocol import (
+    ALLOWED_ACTIONS,
+    CELLS,
+    EMPTY_MEMORY_TASKS,
+    EXPECTED_ROLLOUTS,
+    MEMORY_PAIR_TASKS,
+    PAPER_REFERENCES,
+    PROTOCOL_ID,
+    SPLITS,
+    Split,
+    cell_for,
+)
+
+
+def test_frozen_matrix_and_timeouts():
+    assert len(CELLS) == EXPECTED_ROLLOUTS == 340
+    assert len(ALLOWED_ACTIONS) == 8
+    assert len(MEMORY_PAIR_TASKS) == 43
+    assert len(EMPTY_MEMORY_TASKS) == 7
+    assert SPLITS[Split.ATOMIC].timeout_seconds == 1800
+    assert SPLITS[Split.COMPOSITE_SEEN].timeout_seconds == 3600
+    assert SPLITS[Split.COMPOSITE_UNSEEN].timeout_seconds == 3600
+    assert PROTOCOL_ID == "robocasa-harness-vla-v1"
+    assert set(PAPER_REFERENCES) == {
+        "RLDX-1",
+        "Harness VLA (Codex)",
+        "Harness VLA (CC)",
+    }
+
+
+def test_cell_for_rejects_non_protocol_cells():
+    assert cell_for("atomic", "OpenDrawer", 1).tag == "OpenDrawer_s1"
+    for args in (("atomic", "OpenDrawer", 0), ("atomic", "ArrangeTea", 1)):
+        try:
+            cell_for(*args)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("invalid cell accepted")

--- a/tests/test_robocasa_provenance.py
+++ b/tests/test_robocasa_provenance.py
@@ -1,0 +1,598 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rpent.reproduce.robocasa import executor, provenance
+from rpent.reproduce.robocasa.executor import ExecutorConfig, RuntimePaths
+from rpent.reproduce.robocasa.planner_transport import (
+    CODEX_REQUEST_MAX_RETRIES,
+    CODEX_STREAM_IDLE_TIMEOUT_MS,
+    CODEX_STREAM_MAX_RETRIES,
+    PlannerTransport,
+)
+from rpent.reproduce.robocasa.profiles import PlannerProfile, get_profile
+
+BASE_URL = "https://planner.example/v1"
+PROVENANCE_PATH = "rpent/reproduce/robocasa/provenance.py"
+
+
+def _write(path: Path, text: str = "fixture\n", *, mode: int = 0o600) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    path.chmod(mode)
+    return path
+
+
+def _runtime(tmp_path: Path) -> RuntimePaths:
+    root = tmp_path / "runtime"
+    migration = root / "migration"
+    robocasa = root / "external_dependencies/robocasa365/robocasa/robocasa"
+    robosuite = root / "external_dependencies/robocasa365/robosuite/robosuite"
+    navview = robosuite / "models/assets/bases/omron_mobile_base.xml"
+    _write(root / "rldx/runtime.py", "RLDX = 1\n")
+    _write(robocasa / "__init__.py", "ROBOCASA = 1\n")
+    _write(robosuite / "__init__.py", "ROBOSUITE = 1\n")
+    _write(migration / "robocasa_interactive_env.py")
+    _write(migration / "rldx_skill.py")
+    _write(
+        navview,
+        """<mujoco><worldbody><body name="base">
+<camera name="navview" mode="fixed" pos="0.2 0 1.6"
+xyaxes="0 -1 0 0.643 0 0.766" fovy="75"/>
+</body></worldbody></mujoco>
+""",
+    )
+    tools = root / "tools"
+    model = root / "checkpoint"
+    vlm = root / "vlm"
+    model.mkdir(parents=True)
+    vlm.mkdir()
+    return RuntimePaths(
+        root=root,
+        sim_python=_write(tools / "python", mode=0o700),
+        driver=_write(migration / "driver.py"),
+        readiness=_write(migration / "ready.py"),
+        deadline=_write(migration / "deadline.py"),
+        isolation_launcher=_write(migration / "isolate.py"),
+        artifact_builder=_write(migration / "artifacts.py"),
+        model=model,
+        vlm_metadata=vlm,
+        navview_xml=navview,
+    )
+
+
+def _config(tmp_path: Path) -> ExecutorConfig:
+    results = tmp_path / "results"
+    rollouts = tmp_path / "rollouts"
+    memory = tmp_path / "memory"
+    results.mkdir(mode=0o700)
+    rollouts.mkdir(mode=0o700)
+    memory.mkdir(mode=0o700)
+    _write(memory / "manifest.json", '{"memory": 1}\n')
+    credential = _write(tmp_path / "secret-a", "provenance-test-secret-a\n")
+    return ExecutorConfig(
+        runtime=_runtime(tmp_path),
+        results_root=results,
+        rollout_root=rollouts,
+        memory_root=memory,
+        planner_profile=get_profile("codex-gpt55-xhigh"),
+        planner_transport=PlannerTransport.api_key(
+            credential_file=credential,
+            base_url=BASE_URL,
+        ),
+        codex_bin=_write(tmp_path / "codex", mode=0o700),
+        preliminary_local_runtime=True,
+        memory_source="local-migration",
+        memory_revision="revision-a",
+    )
+
+
+def _attestation() -> dict[str, str]:
+    return {
+        "checkpoint_id": "RLDX-1-FT-RC365",
+        "authority_manifest_sha256": "a" * 64,
+        "fingerprint": "b" * 64,
+    }
+
+
+def _isolation_attestation(
+    transport: PlannerTransport | None = None,
+) -> dict[str, Any]:
+    if transport is None:
+        transport = PlannerTransport.api_key(
+            credential_file=Path("unused-api-key"),
+            base_url=BASE_URL,
+        )
+    value: dict[str, Any] = {
+        "schema_version": 2,
+        "passed": True,
+        "codex": {
+            "version": "codex-cli 0.147.0",
+            "sha256": (
+                "cb0a15567e9a60a5820d54b0f6ae86d504dc3805c1eab21a47f70e3eb7b73a40"
+            ),
+        },
+        "launcher_sha256": (
+            "6f0173f39753a8268b0b73aac2b729066f9798a0679c07e705a7c22f45cf81cb"
+        ),
+        "sandbox_adapter_sha256": provenance.sha256_file(
+            Path(provenance.__file__).with_name("sandbox.py")
+        ),
+        "profile": {
+            "permission_profile": "rpent_outer_landlock",
+            "filesystem_authority": (
+                "outer_rldx_landlock_abi1_uid_gid_fixed_mailboxes"
+            ),
+            "codex_filesystem_view": "full_write_fast_path_no_inner_fs_sandbox",
+            "command_network_authority": ("codex_0.147_restricted_network_seccomp"),
+            "arguments_sha256": "4" * 64,
+        },
+        "planner_transport": transport.manifest_identity(),
+        "kernel_release": "fixture-kernel",
+        "landlock_abi": 1,
+        "tool_names": [
+            "apply_patch",
+            "exec_command",
+            "update_plan",
+            "view_image",
+            "write_stdin",
+        ],
+        "tool_schema_sha256": "5" * 64,
+        "observed_item_types": [
+            "agent_message",
+            "command_execution",
+            "file_change",
+        ],
+        "checks": {
+            "scratch_write": True,
+            "root_create_blocked": True,
+            "rpent_read_blocked": True,
+            "runtime_read_blocked": True,
+            "proc_environ_read_blocked": True,
+            "shell_network_blocked": True,
+            "planner_secret_absent": True,
+            "usr_write_blocked": True,
+            "apply_patch_outside_blocked": True,
+            "view_image_outside_blocked": True,
+            "exec_escalation_rejected": True,
+            "deadline_controls_root_only": True,
+        },
+    }
+    value["attestation_sha256"] = provenance.canonical_sha256(value)
+    return value
+
+
+def _ensure_isolation_attestation(config: ExecutorConfig) -> None:
+    directory = config.results_root / "_preflight"
+    directory.mkdir(mode=0o700, exist_ok=True)
+    path = directory / provenance.ISOLATION_ATTESTATION_NAME
+    if path.exists():
+        return
+    _write(
+        path,
+        json.dumps(_isolation_attestation(config.planner_transport)) + "\n",
+        mode=0o600,
+    )
+
+
+@pytest.fixture
+def frozen_implementation(monkeypatch):
+    monkeypatch.setattr(
+        provenance,
+        "_implementation_hashes",
+        lambda: {PROVENANCE_PATH: "c" * 64},
+    )
+
+
+def _ensure(
+    config: ExecutorConfig,
+    attestation: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    _ensure_isolation_attestation(config)
+    return provenance.ensure_run_manifest(
+        config,
+        attestation or _attestation(),
+    )
+
+
+def test_manifest_creation_is_idempotent(tmp_path, frozen_implementation):
+    config = _config(tmp_path)
+
+    first = _ensure(config)
+    path = config.results_root / provenance.RUN_MANIFEST_NAME
+    first_bytes = path.read_bytes()
+    first_stat = path.stat()
+    second = _ensure(config)
+
+    assert first["schema_version"] == 3
+    assert second == first
+    assert path.read_bytes() == first_bytes
+    assert path.stat().st_ino == first_stat.st_ino
+    assert path.stat().st_mtime_ns == first_stat.st_mtime_ns
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_nonempty_legacy_results_root_cannot_be_claimed(
+    tmp_path, frozen_implementation
+):
+    config = _config(tmp_path)
+    _write(config.results_root / "legacy-result.json", "{}\n")
+
+    with pytest.raises(ValueError, match="non-empty results root"):
+        _ensure(config)
+
+
+def test_checkpoint_preflight_can_precede_run_manifest(tmp_path, frozen_implementation):
+    config = _config(tmp_path)
+    preflight = config.results_root / "_preflight"
+    preflight.mkdir(mode=0o700)
+    _write(preflight / "checkpoint-attestation.json", "{}\n", mode=0o600)
+
+    manifest = _ensure(config)
+
+    assert manifest["run_config_sha256"]
+
+
+def test_runner_lock_and_preflight_can_precede_run_manifest(
+    tmp_path, frozen_implementation
+):
+    config = _config(tmp_path)
+    _write(config.results_root / ".rpent-run.lock", "", mode=0o600)
+    preflight = config.results_root / "_preflight"
+    preflight.mkdir(mode=0o700)
+    _write(preflight / "checkpoint-attestation.json", "{}\n", mode=0o600)
+
+    manifest = _ensure(config)
+
+    assert manifest["run_config_sha256"]
+
+
+@pytest.mark.parametrize("extra_name", ["other.json", "nested"])
+def test_checkpoint_preflight_rejects_extra_entries(
+    tmp_path, frozen_implementation, extra_name
+):
+    config = _config(tmp_path)
+    preflight = config.results_root / "_preflight"
+    preflight.mkdir(mode=0o700)
+    _write(preflight / "checkpoint-attestation.json", "{}\n", mode=0o600)
+    extra = preflight / extra_name
+    if extra_name == "nested":
+        extra.mkdir()
+    else:
+        _write(extra, "{}\n")
+
+    with pytest.raises(ValueError, match="non-empty results root"):
+        _ensure(config)
+
+
+@pytest.mark.parametrize("tamper", ["digest", "config", "extra_field"])
+def test_tampered_or_extended_manifest_fails_closed(
+    tmp_path, frozen_implementation, tamper
+):
+    config = _config(tmp_path)
+    _ensure(config)
+    path = config.results_root / provenance.RUN_MANIFEST_NAME
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if tamper == "digest":
+        value["run_config_sha256"] = "0" * 64
+    elif tamper == "config":
+        value["config"]["memory"]["source"] = "tampered"
+    else:
+        value["unfrozen_extension"] = True
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        _ensure(config)
+
+
+def test_symlink_manifest_fails_closed(tmp_path, frozen_implementation):
+    config = _config(tmp_path)
+    _ensure(config)
+    second_root = tmp_path / "results-via-symlink"
+    second_root.mkdir(mode=0o700)
+    (second_root / provenance.RUN_MANIFEST_NAME).symlink_to(
+        config.results_root / provenance.RUN_MANIFEST_NAME
+    )
+
+    with pytest.raises(ValueError, match="non-symlink"):
+        _ensure(replace(config, results_root=second_root))
+
+
+def test_manifest_rejects_self_signed_formal_or_incomplete_configuration():
+    formal = provenance.make_run_manifest(
+        {
+            "protocol_id": provenance.PROTOCOL_ID,
+            "runtime_kind": "formal_rpent_release",
+            "preliminary": False,
+        }
+    )
+
+    _, problem = provenance.validate_run_manifest_value(formal)
+
+    assert problem is not None
+
+
+def test_run_manifest_freezes_codex_provider_retry_policy(tmp_path):
+    configuration = provenance.build_run_configuration(
+        _config(tmp_path),
+        _attestation(),
+        isolation_attestation=_isolation_attestation(),
+    )
+
+    assert configuration["planner"]["provider_retry_policy"] == {
+        "request_max_retries": 12,
+        "stream_max_retries": 120,
+        "stream_idle_timeout_ms": 330_000,
+    }
+    assert CODEX_REQUEST_MAX_RETRIES == 12
+    assert CODEX_STREAM_MAX_RETRIES == 120
+    assert CODEX_STREAM_IDLE_TIMEOUT_MS == 330_000
+
+    validated, problem = provenance.validate_run_manifest_value(
+        provenance.make_run_manifest(configuration)
+    )
+    assert problem is None
+    assert validated is not None
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {},
+        {
+            "request_max_retries": 11,
+            "stream_max_retries": 120,
+            "stream_idle_timeout_ms": 330_000,
+        },
+        {
+            "request_max_retries": 12,
+            "stream_max_retries": 119,
+            "stream_idle_timeout_ms": 330_000,
+        },
+        {
+            "request_max_retries": 12,
+            "stream_max_retries": 120,
+            "stream_idle_timeout_ms": 329_999,
+        },
+        {
+            "request_max_retries": 12,
+            "stream_max_retries": 120,
+            "stream_idle_timeout_ms": 330_000,
+            "unfrozen_extension": True,
+        },
+    ],
+)
+def test_self_signed_manifest_cannot_change_provider_retry_policy(tmp_path, policy):
+    configuration = provenance.build_run_configuration(
+        _config(tmp_path),
+        _attestation(),
+        isolation_attestation=_isolation_attestation(),
+    )
+    configuration["planner"]["provider_retry_policy"] = policy
+
+    validated, problem = provenance.validate_run_manifest_value(
+        provenance.make_run_manifest(configuration)
+    )
+
+    assert validated is None
+    assert problem is not None
+
+
+def test_execution_rechecks_runtime_identity_for_every_cell(
+    tmp_path, frozen_implementation
+):
+    config = _config(tmp_path)
+    _ensure_isolation_attestation(config)
+    executor.ensure_execution_run_manifest(config, _attestation())
+    _write(config.runtime.driver, "changed between cells\n")
+
+    with pytest.raises(ValueError, match="different RoboCasa run configuration"):
+        executor.ensure_execution_run_manifest(config, _attestation())
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "memory_manifest",
+        "memory_source",
+        "memory_revision",
+        "planner_effort",
+        "planner_endpoint",
+        "planner_auth_mode",
+        "runtime_script",
+        "navview",
+        "startup_timeout",
+        "kill_timeout",
+        "checkpoint_fingerprint",
+        "isolation_attestation",
+    ],
+)
+def test_scientific_configuration_change_cannot_reuse_results_root(
+    tmp_path, frozen_implementation, change
+):
+    config = _config(tmp_path)
+    attestation = _attestation()
+    _ensure(config, attestation)
+
+    if change == "memory_manifest":
+        _write(config.memory_root / "manifest.json", '{"memory": 2}\n')
+    elif change == "memory_source":
+        config = replace(config, memory_source="huggingface")
+    elif change == "memory_revision":
+        config = replace(config, memory_revision="revision-b")
+    elif change == "planner_effort":
+        profile = replace(config.planner_profile, reasoning_effort="high")
+        config = replace(config, planner_profile=profile)
+    elif change == "planner_endpoint":
+        config = replace(
+            config,
+            planner_transport=PlannerTransport.api_key(
+                credential_file=config.planner_transport.credential_file,
+                base_url="https://other-planner.example/v1",
+            ),
+        )
+    elif change == "planner_auth_mode":
+        config = replace(
+            config,
+            planner_transport=PlannerTransport.chatgpt_subscription(
+                credential_file=config.planner_transport.credential_file,
+                broker_base_url="http://127.0.0.1:8765/v1",
+                broker_health_url="http://127.0.0.1:8765/health",
+            ),
+        )
+    elif change == "runtime_script":
+        _write(config.runtime.driver, "changed driver\n")
+    elif change == "navview":
+        _write(config.runtime.navview_xml, "<mujoco changed='true'/>\n")
+    elif change == "startup_timeout":
+        config = replace(
+            config,
+            startup_timeout_seconds=config.startup_timeout_seconds + 1,
+        )
+    elif change == "kill_timeout":
+        config = replace(config, kill_after_seconds=config.kill_after_seconds + 1)
+    elif change == "isolation_attestation":
+        path = (
+            config.results_root / "_preflight" / provenance.ISOLATION_ATTESTATION_NAME
+        )
+        value = json.loads(path.read_text(encoding="utf-8"))
+        value["kernel_release"] = "different-kernel"
+        payload = {
+            key: item for key, item in value.items() if key != "attestation_sha256"
+        }
+        value["attestation_sha256"] = provenance.canonical_sha256(payload)
+        _write(path, json.dumps(value) + "\n")
+    else:
+        attestation = {**attestation, "fingerprint": "d" * 64}
+
+    with pytest.raises(ValueError, match="different RoboCasa run configuration"):
+        if change in {"planner_endpoint", "planner_auth_mode"}:
+            path = (
+                config.results_root
+                / "_preflight"
+                / provenance.ISOLATION_ATTESTATION_NAME
+            )
+            _write(
+                path,
+                json.dumps(_isolation_attestation(config.planner_transport)) + "\n",
+            )
+        _ensure(config, attestation)
+
+
+def test_isolation_attestation_tampering_fails_before_manifest(tmp_path):
+    config = _config(tmp_path)
+    _ensure_isolation_attestation(config)
+    path = config.results_root / "_preflight" / provenance.ISOLATION_ATTESTATION_NAME
+    value = json.loads(path.read_text(encoding="utf-8"))
+    value["passed"] = False
+    _write(path, json.dumps(value) + "\n")
+
+    with pytest.raises(ValueError, match="digest or pass state"):
+        provenance.ensure_run_manifest(
+            config,
+            _attestation(),
+        )
+
+
+def test_implementation_identity_is_nonempty_and_covers_provenance(tmp_path):
+    configuration = provenance.build_run_configuration(
+        _config(tmp_path),
+        _attestation(),
+        isolation_attestation=_isolation_attestation(),
+    )
+
+    implementation = configuration["implementation_sha256"]
+    assert implementation
+    assert PROVENANCE_PATH in implementation
+    assert len(implementation[PROVENANCE_PATH]) == 64
+    assert int(implementation[PROVENANCE_PATH], 16) >= 0
+
+
+def _keys(value: Any) -> set[str]:
+    if isinstance(value, dict):
+        return set(value).union(*(_keys(item) for item in value.values()), set())
+    if isinstance(value, list):
+        return set().union(*(_keys(item) for item in value), set())
+    return set()
+
+
+def test_operational_inputs_do_not_change_configuration_identity(
+    tmp_path, frozen_implementation
+):
+    config = _config(tmp_path)
+    first = provenance.build_run_configuration(
+        config,
+        _attestation(),
+        isolation_attestation=_isolation_attestation(config.planner_transport),
+    )
+    other_secret = _write(tmp_path / "secret-b", "provenance-test-secret-b\n")
+    operationally_changed = replace(
+        config,
+        planner_transport=replace(
+            config.planner_transport,
+            credential_file=other_secret,
+        ),
+        results_root=tmp_path / "other-results",
+        rollout_root=tmp_path / "other-rollouts",
+        keep_workdirs=not config.keep_workdirs,
+    )
+    second = provenance.build_run_configuration(
+        operationally_changed,
+        _attestation(),
+        isolation_attestation=_isolation_attestation(
+            operationally_changed.planner_transport
+        ),
+    )
+
+    assert second == first
+    serialized = json.dumps(first, sort_keys=True)
+    assert str(config.planner_transport.credential_file) not in serialized
+    assert str(other_secret) not in serialized
+    assert "provenance-test-secret-a" not in serialized
+    assert _keys(first).isdisjoint(
+        {
+            "api_key_file",
+            "credential_file",
+            "gpu",
+            "gpus",
+            "selection",
+            "max_attempts",
+            "retry_backoff_seconds",
+            "keep_workdirs",
+            "results_root",
+            "rollout_root",
+        }
+    )
+
+
+def test_scheduler_controls_are_not_executor_configuration_fields():
+    fields = set(ExecutorConfig.__dataclass_fields__)
+
+    assert fields.isdisjoint(
+        {"gpu", "gpus", "selection", "max_attempts", "retry_backoff_seconds"}
+    )
+    assert set(PlannerProfile.__dataclass_fields__) == {
+        "name",
+        "backend",
+        "model",
+        "reasoning_effort",
+    }

--- a/tests/test_robocasa_runtime.py
+++ b/tests/test_robocasa_runtime.py
@@ -14,9 +14,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
+from robots.robocasa import robot_spec
 from robots.robocasa.env_client import RoboCasaEnvClient
 from robots.robocasa.env_server import RoboCasaEnvFacade
 from robots.robocasa.primitives import RoboCasaPrimitives
@@ -29,8 +33,9 @@ from robots.robocasa.tools import (
     view_env_state,
 )
 from robots.robocasa.vla_client import RoboCasaVLAClient
-from robots.robocasa.vla_server import RoboCasaVLAFacade
+from robots.robocasa.vla_server import RoboCasaVLAFacade, _model_identity
 from rpent.session import EnvState
+from rpent.utils.resources import ensure_resources
 
 ACTION_SCHEMA = {
     "name": "rldx.robocasa.action.v1",
@@ -412,6 +417,15 @@ def test_vla_server_warmup_and_client_handshake():
         )
 
 
+def test_formal_vla_server_requires_checkpoint_attestation(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("RLDX_PERCEPTION_ISOLATION", "1")
+    with pytest.raises(ValueError, match="requires a checkpoint attestation"):
+        _model_identity(checkpoint)
+
+
 def test_base_and_vla_motion_invalidate_pose_dependent_calibration(tmp_path):
     env = _SkillEnv(succeed_after=999)
     primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
@@ -667,3 +681,127 @@ def test_camera_metadata_and_back_projection_tools(tmp_path):
     assert "integers" in invalid["results"][0]["error"]
     assert "error" in back_project_batch([[0, 0]] * 51, step=0, state=state)
     assert "error" in view_camera_meta("unknown", step=0, state=state)
+
+
+def test_robocasa_resources_auto_download_from_default_hf(tmp_path, monkeypatch):
+    calls = []
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return str(kwargs["local_dir"])
+
+    monkeypatch.setenv("RPENT_REPO_ROOT", str(tmp_path))
+    monkeypatch.delenv("RPENT_RESOURCES_HF_REPO", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.setattr("huggingface_hub.snapshot_download", snapshot_download)
+
+    resources = ensure_resources(robot_spec.get_robot_spec())
+
+    assert resources == tmp_path / "resources" / "robocasa"
+    assert calls == [
+        {
+            "repo_id": "RLinf/RPent-memory",
+            "repo_type": "dataset",
+            "local_dir": str(tmp_path / "resources"),
+            "allow_patterns": ["robocasa/**"],
+        }
+    ]
+
+
+def test_robot_config_propagates_hf_and_local_memory(tmp_path, monkeypatch):
+    default_memory = tmp_path / "resources" / "robocasa" / "memory"
+    monkeypatch.setattr(robot_spec, "get_memory_dir", lambda _name: default_memory)
+
+    base = {
+        "task_name": "OpenDrawer",
+        "split": "target",
+        "seed": 1,
+        "output_dir": tmp_path / "output",
+        "checkpoint_attestation": None,
+        "vla_metadata_path": None,
+    }
+    hf = robot_spec._parse_config(
+        SimpleNamespace(**base, memory_profile="hf", memory_dir=None)
+    )
+    assert hf.prompt_vars["memory_profile"] == "hf"
+    assert Path(hf.prompt_vars["memory_dir"]) == default_memory
+
+    local_memory = tmp_path / "local-memory"
+    local = robot_spec._parse_config(
+        SimpleNamespace(
+            **base,
+            memory_profile="local",
+            memory_dir=str(local_memory),
+        )
+    )
+    assert local.prompt_vars["memory_profile"] == "local"
+    assert Path(local.prompt_vars["memory_dir"]) == local_memory.resolve()
+
+    captured = {}
+
+    class Toolkit:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("robots.robocasa.toolkit.RoboCasaToolkit", Toolkit)
+    robot_spec.get_toolkit(
+        primitives_kwargs={},
+        dashboard_events=SimpleNamespace(),
+        config=local,
+    )
+    assert captured["memory"].root == local_memory.resolve()
+
+
+def test_robot_config_rejects_local_path_in_hf_mode(tmp_path):
+    with pytest.raises(ValueError, match="memory-profile local"):
+        robot_spec._parse_config(
+            SimpleNamespace(
+                task_name="OpenDrawer",
+                split="target",
+                seed=1,
+                output_dir=tmp_path / "output",
+                memory_profile="hf",
+                memory_dir=str(tmp_path / "local-memory"),
+                checkpoint_attestation=None,
+                vla_metadata_path=None,
+            )
+        )
+
+
+def test_attestation_arguments_are_sent_only_to_vla_server(tmp_path, monkeypatch):
+    daemons = []
+
+    class Daemon:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            daemons.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(robot_spec, "ProcessDaemon", Daemon)
+    monkeypatch.setattr(robot_spec, "pick_free_port", lambda: 12345)
+    monkeypatch.setattr(robot_spec, "HttpRpcClient", lambda endpoint: endpoint)
+    args = SimpleNamespace(
+        env_endpoint=None,
+        vla_endpoint=None,
+        task_name="OpenDrawer",
+        split="target",
+        seed=1,
+        cuda_device=0,
+        vla_model_path="/checkpoint",
+        vla_metadata_path="/vlm",
+        checkpoint_attestation="/attestation.json",
+    )
+
+    robot_spec._spawn_env_server(args, Path(tmp_path))
+    robot_spec._spawn_vla_server(args, Path(tmp_path))
+
+    env_command, vla_command = daemons[0].cmd, daemons[1].cmd
+    assert "--vlm-path" not in env_command
+    assert "--checkpoint-attestation" not in env_command
+    assert vla_command[vla_command.index("--vlm-path") + 1] == "/vlm"
+    assert vla_command[vla_command.index("--checkpoint-attestation") + 1] == (
+        "/attestation.json"
+    )
+    assert daemons[1].env_overrides == {"RLDX_VLM_PATH": "/vlm"}

--- a/tests/test_robocasa_runtime.py
+++ b/tests/test_robocasa_runtime.py
@@ -1,0 +1,669 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robots.robocasa.env_client import RoboCasaEnvClient
+from robots.robocasa.env_server import RoboCasaEnvFacade
+from robots.robocasa.primitives import RoboCasaPrimitives
+from robots.robocasa.rldx_skill import ACTION_FIELDS, RLDXSkill
+from robots.robocasa.toolkit import FORMAL_PRIMITIVE_TOOLS, RoboCasaToolkit
+from robots.robocasa.tools import (
+    back_project,
+    back_project_batch,
+    view_camera_meta,
+    view_env_state,
+)
+from robots.robocasa.vla_client import RoboCasaVLAClient
+from robots.robocasa.vla_server import RoboCasaVLAFacade
+from rpent.session import EnvState
+
+ACTION_SCHEMA = {
+    "name": "rldx.robocasa.action.v1",
+    "batch_size": 1,
+    "max_horizon": 512,
+    "flat_dim": 12,
+    "fields": [{"name": name, "size": size} for name, size in ACTION_FIELDS.items()],
+}
+
+
+def _env_runtime(
+    *,
+    episode_id=0,
+    sim_step=0,
+    success=False,
+    perception_isolation=False,
+):
+    return {
+        "protocol_version": 1,
+        "runtime_id": "env-runtime",
+        "episode_id": episode_id,
+        "sim_step": sim_step,
+        "success_latched": success,
+        "perception_isolation": perception_isolation,
+        "robot": "PandaOmron",
+        "action_schema": {
+            "name": "robocasa.panda_omron.flat.v1",
+            "flat_dim": 12,
+            "fields": [
+                {"name": name, "size": size} for name, size in ACTION_FIELDS.items()
+            ],
+        },
+        "cameras": [
+            "mobilebase0_navview",
+            "robot0_agentview_left",
+            "robot0_agentview_right",
+            "robot0_eye_in_hand",
+        ],
+    }
+
+
+def _vla_runtime(*, warmed_up=True, verified=False):
+    return {
+        "protocol_version": 1,
+        "runtime_id": "vla-runtime",
+        "backend": "rldx",
+        "model": {
+            "kind": "local",
+            "fingerprint": "model-fingerprint",
+            "verified": verified,
+        },
+        "warmed_up": warmed_up,
+        "action_schema": ACTION_SCHEMA,
+        "observation_schema": {},
+        "modality": {"video_delta_indices": [-6, -4, -2, 0], "hist_maxlen": 8},
+    }
+
+
+def _raw_obs():
+    return {
+        "language": "pick up the mug",
+        "robot0_eef_pos": np.array([0.0, 0.0, 1.0]),
+        "robot0_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+        "robot0_gripper_qpos": np.array([0.02, 0.02]),
+        "robot0_base_pos": np.array([0.0, 0.0, 0.0]),
+        "robot0_base_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+        "robot0_base_to_eef_pos": np.array([0.0, 0.0, 1.0]),
+        "robot0_base_to_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+    }
+
+
+def _actions(horizon=4, *, fill=0.0):
+    return {
+        name: np.full((1, horizon, size), fill, dtype=np.float32)
+        for name, size in ACTION_FIELDS.items()
+    }
+
+
+class _EnvRpc:
+    def __init__(self):
+        self.episode = 0
+        self.sim_step = 0
+        self.reset_calls = 0
+        self.success = False
+
+    def call(self, method, args=(), kwargs=None, timeout_s=None):
+        if method == "env.get_env_meta":
+            return {
+                "task_name": "OpenDrawer",
+                "split": "target",
+                "seed": 7,
+                "camera_h": 256,
+                "camera_w": 256,
+            }
+        if method == "env.get_runtime_info":
+            return _env_runtime(
+                episode_id=self.episode,
+                sim_step=self.sim_step,
+                success=self.success,
+            )
+        if method == "env.reset":
+            self.reset_calls += 1
+            self.episode += 1
+            self.sim_step = 0
+            self.success = False
+            return _raw_obs()
+        if method == "env.step":
+            self.sim_step += 1
+            return (
+                _raw_obs(),
+                0.0,
+                False,
+                {
+                    "rpent_runtime_id": "env-runtime",
+                    "rpent_episode_id": self.episode,
+                    "rpent_sim_step": self.sim_step,
+                    "rpent_success_latched": self.success,
+                },
+            )
+        if method == "env.check_success":
+            return self.success
+        raise AssertionError(f"unexpected RPC method: {method}")
+
+
+class _FakeVLA:
+    runtime_id = "vla-runtime"
+    action_schema = ACTION_SCHEMA
+
+    def __init__(self, *, horizon=4):
+        self.horizon = horizon
+        self.predict_calls = 0
+        self.reset_calls = []
+
+    def get_modality_config(self):
+        return {"video_delta_indices": [-6, -4, -2, 0], "hist_maxlen": 8}
+
+    def predict(self, obs, options):
+        self.predict_calls += 1
+        return _actions(self.horizon)
+
+    def reset_session(self, session_id):
+        self.reset_calls.append(session_id)
+        return {"ok": True, "runtime_id": self.runtime_id, "session_id": session_id}
+
+
+class _SkillEnv:
+    runtime_id = "env-runtime"
+    action_dim = 12
+
+    def __init__(self, *, succeed_after=1):
+        self.last_obs = _raw_obs()
+        self.step_calls = 0
+        self.succeed_after = succeed_after
+        self.reset_calls = 0
+
+    @property
+    def current_raw_obs(self):
+        return self.last_obs
+
+    @property
+    def eef_pos(self):
+        return self.last_obs["robot0_eef_pos"]
+
+    @property
+    def eef_quat(self):
+        return self.last_obs["robot0_eef_quat"]
+
+    @property
+    def gripper_qpos(self):
+        return self.last_obs["robot0_gripper_qpos"]
+
+    def get_task_language(self):
+        return self.last_obs["language"]
+
+    def render_camera(self, *args, **kwargs):
+        return np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def reassemble_env_action(self, value):
+        return np.zeros(12, dtype=np.float64)
+
+    def step(self, action):
+        assert np.asarray(action).shape == (12,)
+        self.step_calls += 1
+        return self.last_obs, 0.0, False, {}
+
+    def check_success(self):
+        return self.step_calls >= self.succeed_after
+
+    @property
+    def terminated(self):
+        return self.check_success()
+
+    def grasp_contact(self):
+        return False, None
+
+    def reset(self):
+        self.reset_calls += 1
+        return self.last_obs
+
+
+def test_navview_is_required_only_for_formal_isolation():
+    ordinary = _env_runtime()
+    ordinary["cameras"].remove("mobilebase0_navview")
+    RoboCasaEnvClient._validate_runtime_info(ordinary)
+
+    formal = {**ordinary, "perception_isolation": True}
+    with pytest.raises(RuntimeError, match="mobilebase0_navview"):
+        RoboCasaEnvClient._validate_runtime_info(formal)
+
+
+def test_client_and_primitives_only_reset_once_on_startup(tmp_path):
+    rpc = _EnvRpc()
+    client = RoboCasaEnvClient(
+        rpc,
+        expected_meta={
+            "task_name": "OpenDrawer",
+            "split": "target",
+            "seed": 7,
+            "camera_h": 256,
+            "camera_w": 256,
+        },
+    )
+    assert rpc.reset_calls == 1
+
+    RoboCasaPrimitives(client, str(tmp_path), None, _FakeVLA())
+    assert rpc.reset_calls == 1
+
+
+class _RawEnv:
+    action_dim = 12
+
+    def __init__(self, *, reset_success=False):
+        self.success = reset_success
+        self.reset_success = reset_success
+        self.step_calls = 0
+
+    def reset(self):
+        self.success = self.reset_success
+        return {"obs": 0}
+
+    def step(self, action):
+        self.step_calls += 1
+        self.success = True
+        return {"obs": 1}, 0.0, False, {}
+
+    def _check_success(self):
+        return self.success
+
+
+def test_env_server_latches_success_on_each_simulator_action():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv()
+    facade._runtime_id = "runtime"
+    facade._episode_id = 0
+    facade._sim_step = 0
+    facade._success_latched = False
+
+    facade.reset()
+    _, _, _, info = facade.step(np.zeros(12))
+    assert info["rpent_success_now"] is True
+    assert info["rpent_success_latched"] is True
+
+    facade.env.success = False
+    assert facade.check_success() is True
+    with pytest.raises(ValueError, match="shape"):
+        facade.step(np.zeros((1, 12)))
+    bad = np.zeros(12)
+    bad[0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        facade.step(bad)
+
+    facade.reset()
+    observations, rewards, dones, infos = facade.chunk_step(
+        np.zeros((4, 12)), return_all_frames=True
+    )
+    assert len(observations) == len(rewards) == len(dones) == len(infos) == 1
+    assert infos[0]["rpent_success_latched"] is True
+
+
+def test_env_server_latches_reset_success_and_refuses_further_motion():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv(reset_success=True)
+    facade._runtime_id = "runtime"
+    facade._episode_id = 0
+    facade._sim_step = 0
+    facade._success_latched = False
+
+    facade.reset()
+    assert facade.check_success() is True
+    with pytest.raises(RuntimeError, match="further motion is disabled"):
+        facade.step(np.zeros(12))
+    assert facade.env.step_calls == 0
+
+
+def test_rldx_uses_unique_sessions_and_stops_inside_action_chunk():
+    env = _SkillEnv(succeed_after=1)
+    vla = _FakeVLA(horizon=4)
+    skill = RLDXSkill(env, vla_client=vla)
+    other = RLDXSkill(env, vla_client=vla)
+    assert skill._sid != other._sid
+    assert "rc_agent_rldx_0" not in skill._sid
+
+    skill._unmap = lambda value: value
+    result = skill.run("pick up the mug", max_chunks=2, n_action_steps=4)
+    assert result["status"] == "success"
+    assert result["steps_applied"] == 1
+    assert result["chunks"] == 1
+    assert env.step_calls == 1
+    assert vla.predict_calls == 1
+
+
+def test_vla_server_warmup_and_client_handshake():
+    class Policy:
+        def __init__(self):
+            self.predict_calls = 0
+            self.reset_calls = []
+
+        def get_action(self, obs, options):
+            self.predict_calls += 1
+            return _actions(2), {}
+
+        def reset(self, options):
+            self.reset_calls.append(options["session_ids"][0])
+
+    facade = object.__new__(RoboCasaVLAFacade)
+    facade._vdi = np.array([-6, -4, -2, 0])
+    facade._runtime_id = "warmup-runtime"
+    facade._warmed_up = False
+    facade.policy = Policy()
+    facade._warmup()
+    assert facade._warmed_up is True
+    assert facade.policy.predict_calls == 1
+    assert facade.policy.reset_calls == ["warmup:warmup-runtime"]
+
+    class Rpc:
+        def call(self, method, args=(), kwargs=None, timeout_s=None):
+            if method == "vla.get_runtime_info":
+                return _vla_runtime()
+            if method == "vla.get_modality_config":
+                return {"video_delta_indices": [-6, -4, -2, 0], "hist_maxlen": 8}
+            if method == "vla.predict":
+                return _actions(2)
+            if method == "vla.reset_session":
+                return {"ok": True, "runtime_id": "vla-runtime", "session_id": args[0]}
+            raise AssertionError(method)
+
+    client = RoboCasaVLAClient(Rpc())
+    assert client.runtime_id == "vla-runtime"
+    assert client.get_modality_config()["hist_maxlen"] == 8
+    assert client.predict({}, {})["action.base_motion"].shape == (1, 2, 4)
+
+    class ColdRpc(Rpc):
+        def call(self, method, args=(), kwargs=None, timeout_s=None):
+            if method == "vla.get_runtime_info":
+                return _vla_runtime(warmed_up=False)
+            return super().call(method, args=args, kwargs=kwargs, timeout_s=timeout_s)
+
+    with pytest.raises(RuntimeError, match="warmup"):
+        RoboCasaVLAClient(ColdRpc())
+
+    with pytest.raises(RuntimeError, match="verified"):
+        RoboCasaVLAClient(Rpc(), require_verified_model=True)
+
+    class VerifiedRpc(Rpc):
+        def call(self, method, args=(), kwargs=None, timeout_s=None):
+            if method == "vla.get_runtime_info":
+                return _vla_runtime(verified=True)
+            return super().call(method, args=args, kwargs=kwargs, timeout_s=timeout_s)
+
+    verified = RoboCasaVLAClient(
+        VerifiedRpc(),
+        require_verified_model=True,
+        expected_model_fingerprint="model-fingerprint",
+    )
+    assert verified.model_identity["verified"] is True
+    with pytest.raises(RuntimeError, match="fingerprint"):
+        RoboCasaVLAClient(
+            VerifiedRpc(), expected_model_fingerprint="different-fingerprint"
+        )
+
+
+def test_base_and_vla_motion_invalidate_pose_dependent_calibration(tmp_path):
+    env = _SkillEnv(succeed_after=999)
+    primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
+    primitives._pos_jac = np.eye(3)
+    primitives._cam_meta_cache = {
+        "agentview": {"old": True},
+        "navview": {"old": True},
+        "wrist": {"old": True},
+    }
+    primitives.move_base(forward=0.1, steps=1)
+    assert primitives._pos_jac is None
+    assert "agentview" not in primitives._cam_meta_cache
+    assert "navview" not in primitives._cam_meta_cache
+    assert "wrist" in primitives._cam_meta_cache
+
+    primitives._pos_jac = np.eye(3)
+    primitives._fwd_offset = 1.0
+    primitives._cam_meta_cache = {
+        "agentview": {},
+        "navview": {},
+        "wrist": {},
+    }
+    primitives._rldx.run = lambda *args, **kwargs: {"ok": True}
+    primitives.run_rldx_skill(None, 1, True, "pick up the mug", False, 1, 1, 0.01)
+    assert primitives._pos_jac is None
+    assert primitives._fwd_offset is None
+    assert primitives._cam_meta_cache == {}
+
+    with pytest.raises(ValueError, match="steps"):
+        primitives.move_base(steps=0)
+    with pytest.raises(ValueError, match="finite"):
+        primitives.move_base(forward=np.nan)
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("move_base", {"forward": 0.1, "steps": 5}),
+        ("set_gripper", {"gripper": 1.0, "steps": 5}),
+        ("rotate_pitch", {"target_pitch": 0.5, "n": 5}),
+    ],
+)
+def test_analytic_primitives_stop_on_first_success(tmp_path, method, kwargs):
+    env = _SkillEnv(succeed_after=1)
+    primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
+
+    getattr(primitives, method)(**kwargs)
+
+    assert env.step_calls == 1
+
+
+def test_perception_isolation_never_reads_or_exposes_task_progress(
+    tmp_path, monkeypatch
+):
+    class IsolatedEnv(_SkillEnv):
+        def __init__(self):
+            super().__init__(succeed_after=999)
+            self.progress_calls = 0
+            self.criteria_calls = 0
+
+        def get_task_progress(self):
+            self.progress_calls += 1
+            return {"hidden_counter": 7}
+
+        def get_success_criteria_text(self):
+            self.criteria_calls += 1
+            return "hidden predicate"
+
+    monkeypatch.setenv("RLDX_PERCEPTION_ISOLATION", "1")
+    env = IsolatedEnv()
+    primitives = RoboCasaPrimitives(env, str(tmp_path), None, _FakeVLA())
+
+    state = primitives.current_state_dict()
+    assert "task_progress" not in state
+    assert "robocasa_terminated" not in state
+    assert primitives.task_progress() == {}
+    with pytest.raises(PermissionError, match="unavailable"):
+        primitives.dump_success_criteria()
+    assert env.progress_calls == 0
+    assert env.criteria_calls == 0
+
+
+def test_formal_vla_act_uses_exact_prompt_and_frozen_controls(tmp_path, monkeypatch):
+    monkeypatch.setenv("RLDX_PERCEPTION_ISOLATION", "1")
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+    monkeypatch.setenv("RLDX_SETTLE_PATIENCE", "999")
+    primitives = RoboCasaPrimitives(
+        _SkillEnv(succeed_after=999), str(tmp_path), None, _FakeVLA()
+    )
+    calls = []
+
+    def run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "ok": True,
+            "prompt": "pick up the mug",
+            "status": "settled",
+            "chunks": 3,
+            "steps_applied": 24,
+            "grasp_detected": True,
+            "grasped": False,
+            "grasp_obj": "mug",
+        }
+
+    primitives._rldx.run = run
+    result = primitives.vla_act("pick up the mug")
+    args, kwargs = calls[0]
+    assert args == ("pick up the mug", 40, 8)
+    assert kwargs == {
+        "base_clip": None,
+        "settle_patience": 999,
+        "settle_eps": 0.012,
+        "force_reset": True,
+        "recording": False,
+        "record_frame": primitives.record_frame,
+    }
+    assert result == {
+        "ok": True,
+        "status": "settled",
+        "chunks": 3,
+        "steps_applied": 24,
+        "contact_made": True,
+        "holding": False,
+    }
+    with pytest.raises(ValueError, match="verbatim"):
+        primitives.vla_act("pick up a mug")
+    assert len(calls) == 1
+
+
+def test_formal_toolkit_registers_only_frozen_primitive_actions(tmp_path):
+    class PrimitiveHandlers:
+        _perception_isolation = True
+
+        def __getattr__(self, _name):
+            return lambda **_kwargs: {}
+
+    toolkit = object.__new__(RoboCasaToolkit)
+    toolkit._state = EnvState(tmp_path)
+    toolkit._primitives = PrimitiveHandlers()
+    toolkit._tools = {}
+    toolkit._register_robocasa_tools()
+
+    readonly_names = {
+        "view_env_state",
+        "view_camera_meta",
+        "back_project",
+        "back_project_batch",
+        "query_world_map",
+        "finish",
+    }
+    assert set(toolkit._tools) - readonly_names == FORMAL_PRIMITIVE_TOOLS
+    assert {"scripted_grasp", "rldx_skill", "rldx_arm", "reset"}.isdisjoint(
+        toolkit._tools
+    )
+
+
+def test_env_server_removes_privileged_rpcs_in_isolation():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade._perception_isolation = True
+    facade._rpc = {}
+    facade._readonly_methods = set()
+    facade._register_rpc()
+
+    assert "env.get_success_criteria_text" not in facade._rpc
+    assert "env.get_task_progress" not in facade._rpc
+    with pytest.raises(PermissionError, match="unavailable"):
+        facade.get_success_criteria_text()
+    with pytest.raises(PermissionError, match="unavailable"):
+        facade.get_task_progress()
+
+
+def test_env_server_allows_only_initial_reset_in_formal_mode():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv()
+    facade._perception_isolation = True
+    facade._allow_reset = False
+    facade._initial_reset_consumed = False
+    facade._episode_id = 0
+    facade._sim_step = 0
+    facade._success_latched = False
+
+    assert facade.reset() == {"obs": 0}
+    with pytest.raises(PermissionError, match="disabled"):
+        facade.reset()
+    assert facade._episode_id == 1
+
+
+def test_env_server_allows_explicit_exploration_reset():
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _RawEnv()
+    facade._perception_isolation = True
+    facade._allow_reset = True
+    facade._initial_reset_consumed = True
+    facade._episode_id = 1
+    facade._sim_step = 12
+    facade._success_latched = True
+
+    assert facade.reset() == {"obs": 0}
+    assert facade._episode_id == 2
+    assert facade._sim_step == 0
+    assert facade._success_latched is False
+
+
+def test_view_state_omits_absent_progress_field(tmp_path):
+    state = EnvState(tmp_path)
+    with state.record_step(
+        state={"robot0_eef_pos": [0.0, 0.0, 1.0]},
+        terminated=False,
+        extras={
+            "task_language": "pick up the mug",
+            "success": False,
+            "vla_desync": True,
+        },
+    ):
+        pass
+    result = view_env_state(step=0, state=state)
+    assert "task_progress" not in result
+
+
+def test_camera_metadata_and_back_projection_tools(tmp_path):
+    state = EnvState(tmp_path)
+    world = np.zeros((4, 5, 3), dtype=np.float32)
+    world[1, 2] = [1.25, -0.5, 0.9]
+    meta = {
+        "camera_name": "robot0_agentview_left",
+        "height": 4,
+        "width": 5,
+        "intrinsic": np.eye(3).tolist(),
+        "extrinsic_cam2world": np.eye(4).tolist(),
+        "depth_near": 0.01,
+        "depth_far": 10.0,
+        "runtime_id": "env-runtime",
+        "episode_id": 1,
+        "sim_step": 0,
+    }
+    with state.record_step(state={}, terminated=False) as step:
+        state.save("agentview_world.npz", world, step=step)
+        state.save("agentview_world_high.npz", world, step=step)
+        state.save("agentview_metadata.json", meta, step=step)
+
+    camera_meta = view_camera_meta("agentview", step=0, state=state)
+    assert camera_meta["artifact"] == "agentview_metadata.json"
+    assert camera_meta["step"] == 0
+
+    point = back_project(1, 2, step=0, state=state)
+    assert point["valid"] is True
+    assert point["world_xyz"] == [1.25, -0.5, 0.9]
+    assert point["source_artifact"] == "agentview_world_high.npz"
+    assert point["step"] == 0
+
+    invalid = back_project_batch([[1.5, 2]], step=0, state=state)
+    assert invalid["results"][0]["valid"] is False
+    assert "integers" in invalid["results"][0]["error"]
+    assert "error" in back_project_batch([[0, 0]] * 51, step=0, state=state)
+    assert "error" in view_camera_meta("unknown", step=0, state=state)


### PR DESCRIPTION
## Stack

- Draft stacked PR for the RoboCasa integration.
- Depends on #127.
- Review the incremental commit `806e29b` only; earlier commits belong to #125-#127.
- #124 independently introduces configurable Codex, Claude Code, and future SDK-agent runtimes.

## Summary

- add a fail-closed preflight and doctor for the frozen RoboCasa runtime
- execute each benchmark cell behind a root-owned isolation launcher
- supervise readiness, wall-clock deadlines, process groups, and terminal artifacts
- validate artifacts and provenance before accepting a completed cell
- support direct API-key and local subscription-broker planner transports without placing credentials in argv, logs, or the planner worktree
- add a backend-neutral `PlannerAdapter` contract for future audited planner implementations

## Planner audit boundary

The adapter interface is not Codex-specific. The current formal execution registry audits only the frozen `codex-gpt55-xhigh` profile and Codex CLI isolation path. The declared `claude-opus48` profile intentionally fails before process launch until its formal cell adapter and isolation behavior receive the same live audit. Generic Claude Code 4.8 runtime configuration is covered separately by #124.

Audit status is release metadata outside the frozen scientific profile, so scheduler or operational fields cannot silently change result identity.

## Security and reproducibility

- credentials are copied from an owned mode-0600 file into anonymous close-on-exec storage
- Linux `memfd_create` is preferred, with an audited `O_TMPFILE` fallback for compatible Python builds
- short writes are retried and failure paths close the anonymous descriptor
- planner argv remains secret-free
- symlink, ownership, mode, runtime identity, checkpoint, patch, and artifact contracts fail closed
- no API key, private endpoint, server path, model weight, or memory payload is committed

## Validation

- `257 passed` across the complete repository test suite
- Ruff lint: passed
- Ruff format check: passed
- staged sensitive-data scan: clean
- only existing warning: setuptools deprecation for the repository license-table syntax

## Review guide

1. `profiles.py`, `planner_transport.py`, and planner construction in `executor.py`
2. `preflight.py`, `sandbox.py`, and `secure_script.py`
3. `deadline_supervisor.py` and terminal-state handling
4. `validator.py` and `provenance.py`
5. focused security, deadline, executor, provenance, and artifact tests

This is part of #21, but does not close it. The resumable full-run CLI, Hugging Face memory acquisition contract, and bilingual reproduction guide are the next stacked PR.