### PR TITLE
feat(robocasa): complete minimal reproducible integration

### DIFF
--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -23,21 +23,25 @@ the complete RoboCasa365 stack with ``.[robocasa]``:
 .. code-block:: bash
 
    uv venv --python 3.10
-   uv pip install -e ".[robocasa]"
+   uv pip install -e ".[robocasa]" \
+      "torch==2.7.0" "torchvision==0.22.0" \
+      --torch-backend=cu126
 
-To avoid a CUDA-build mismatch between PyPI's torch wheel and the local
-driver, pass ``--index`` to pin a PyTorch CUDA index, e.g.
-``uv pip install -e ".[robocasa]" --index https://download.pytorch.org/whl/cu126``;
-on CUDA 13-only hosts use ``cu130``.
+This pins the Torch pair used by RLDX-1 and lets uv select the official CUDA
+wheel without treating the PyTorch wheel index as a general package index.
+Passing that index through ``--index`` can make uv select stale, unrelated
+packages under its default first-index strategy. The ``cu126`` command above
+is the validated CUDA installation; use another supported Torch backend only
+when required by the host.
 
 For networks closer to Chinese mirrors:
 
 .. code-block:: bash
 
    uv pip install -e ".[robocasa]" \
+      "torch==2.7.0" "torchvision==0.22.0" \
       --default-index https://mirrors.aliyun.com/pypi/simple \
-      --index https://pypi.tuna.tsinghua.edu.cn/simple \
-      --index https://mirrors.aliyun.com/pytorch-wheels/cu126
+      --torch-backend=cu126
 
 .. note::
 

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -75,12 +75,14 @@ Re-run with ``--skip-existing`` to leave downloaded folders alone.
 
 **Navigation camera**
 
-The ``robocasa`` extra pins Robosuite to the exact revision that adds the
-Omron base's fixed ``navview`` camera. On the first environment reset, RPent
-requires its composed MuJoCo name, ``mobilebase0_navview``. A missing camera
-therefore fails immediately with an installation error. Reinstall
-``.[robocasa]`` at this repository revision; no manual ``site-packages`` XML
-patch is required.
+The ``robocasa`` extra installs the ``rpent`` branch of ``RLinf/robosuite``,
+which provides the Omron base's fixed ``navview`` camera. Its composed MuJoCo
+name is ``mobilebase0_navview``. RPent does not run a separate reset-time
+camera preflight; a missing camera fails when navigation RGB-D or world-map
+rendering first requests it. Reinstall ``.[robocasa]`` to refresh that branch;
+no manual ``site-packages`` XML patch is required. During this PR's validation,
+the branch resolved to commit ``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``;
+record the resolved commit when reporting experiments.
 
 **RLDX-1 checkpoint**
 
@@ -119,10 +121,11 @@ before acting. RPent makes those files available through ``read_text_file``
 but does not inject their contents into the prompt.
 
 RoboCasa never asks the planner to use global memory or another task's memory.
-If no pair exists, RPent warns and continues from live observations. A partial
-JSON/JSONL pair, or a Markdown note without its pair, is rejected as incomplete.
-To use reviewed local files instead, select the local profile and pass the
-directory containing this results corpus:
+The runtime does not preflight corpus completeness. If a current-task file is
+absent, ``read_text_file`` reports it as missing and the planner continues with
+the available task files and live observations. The published default corpus
+is validated separately. To use reviewed local files instead, select the local
+profile and pass the directory containing this results corpus:
 
 .. code-block:: bash
 
@@ -192,13 +195,13 @@ RPent can run this robot. See :doc:`configure_planner` for configuration.
 Troubleshooting
 ---------------
 
-- If reset reports a missing ``mobilebase0_navview``, reinstall this
-  revision's ``.[robocasa]`` extra so the pinned Robosuite commit is used. Do
-  not patch installed XML files manually.
-- A task-memory warning means the current task's seed-0 pair is absent. Check
-  the Hugging Face ``robocasa/results`` corpus or the selected local directory;
-  the optional task note never replaces that pair, and RPent never falls back
-  to another task.
+- If navigation RGB-D or world-map rendering reports a missing
+  ``mobilebase0_navview``, reinstall ``.[robocasa]`` to refresh the
+  ``RLinf/robosuite`` ``rpent`` branch. Do not patch installed XML files
+  manually.
+- If ``read_text_file`` reports a missing current-task result, check the
+  Hugging Face ``robocasa/results`` corpus or the selected local directory.
+  RPent does not preflight the corpus or fall back to another task.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
 

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -102,17 +102,27 @@ If the download is slow, use the HF mirror:
 
 Default evaluation uses RPent's public resource sync to download the
 ``robocasa/**`` subtree from the ``RLinf/RPent-memory`` Hugging Face dataset
-into ``resources/robocasa``. The current task may use only this seed-0 pair:
+into ``resources/robocasa``. The current task may use only these task-matched
+files:
 
 .. code-block:: text
 
    resources/robocasa/memory/task/<Task>_s0.json
    resources/robocasa/memory/task/recipe_<Task>_s0.jsonl
+   resources/robocasa/memory/task/<Task>.md  # optional
 
-RPent does not use global memory or another task's memory for RoboCasa. If
-neither file exists, it warns and continues from live observations; if only
-one exists, it stops because the pair is incomplete. To use a reviewed local
-pair instead, select the local profile and pass its memory root:
+The JSON/JSONL pair contains reviewed seed-0 evidence. The optional Markdown
+file contains task-specific exploration memory and may summarize multiple
+attempts; 16 Composite-Seen and 9 Composite-Unseen tasks currently provide one.
+The prompt requires the planner to read every current-task file that exists
+before acting. RPent makes those files available through ``read_text_file``
+but does not inject their contents into the prompt.
+
+RoboCasa never asks the planner to use global memory or another task's memory.
+If no pair exists, RPent warns and continues from live observations. A partial
+JSON/JSONL pair, or a Markdown note without its pair, is rejected as incomplete.
+To use reviewed local files instead, select the local profile and pass their
+memory root:
 
 .. code-block:: bash
 
@@ -185,9 +195,9 @@ Troubleshooting
 - If reset reports a missing ``mobilebase0_navview``, reinstall this
   revision's ``.[robocasa]`` extra so the pinned Robosuite commit is used. Do
   not patch installed XML files manually.
-- A task-memory warning means the current task's two seed-0 files are absent.
-  Check the Hugging Face subtree or the selected local directory; RPent never
-  falls back to another task.
+- A task-memory warning means the current task's seed-0 pair is absent. Check
+  the Hugging Face subtree or the selected local directory; the optional task
+  note never replaces that pair, and RPent never falls back to another task.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
 

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -10,9 +10,9 @@ for the wire/transport selection.
 
 .. note::
 
-   The current code does not yet fully match the results shown at
-   `harnessvla.github.io <https://harnessvla.github.io>`_; a full
-   reproduction will be released later.
+   This page documents ordinary single-task ``rpent --robot robocasa`` runs.
+   It does not define the full Atomic/Seen/Unseen benchmark reproduction
+   protocol.
 
 Installation
 ------------
@@ -73,6 +73,15 @@ shell that launches ``rpent``:
 
 Re-run with ``--skip-existing`` to leave downloaded folders alone.
 
+**Navigation camera**
+
+The ``robocasa`` extra pins Robosuite to the exact revision that adds the
+Omron base's fixed ``navview`` camera. On the first environment reset, RPent
+requires its composed MuJoCo name, ``mobilebase0_navview``. A missing camera
+therefore fails immediately with an installation error. Reinstall
+``.[robocasa]`` at this repository revision; no manual ``site-packages`` XML
+patch is required.
+
 **RLDX-1 checkpoint**
 
 The ``--vla-model-path`` flag on the run commands below expects a
@@ -88,6 +97,28 @@ If the download is slow, use the HF mirror:
 .. code-block:: bash
 
    HF_ENDPOINT=https://hf-mirror.com hf download RLWRLD/RLDX-1-FT-RC365 --local-dir ./checkpoints/rldx-1-ft-rc365
+
+**Task memory**
+
+Default evaluation uses RPent's public resource sync to download the
+``robocasa/**`` subtree from the ``RLinf/RPent-memory`` Hugging Face dataset
+into ``resources/robocasa``. The current task may use only this seed-0 pair:
+
+.. code-block:: text
+
+   resources/robocasa/memory/task/<Task>_s0.json
+   resources/robocasa/memory/task/recipe_<Task>_s0.jsonl
+
+RPent does not use global memory or another task's memory for RoboCasa. If
+neither file exists, it warns and continues from live observations; if only
+one exists, it stops because the pair is incomplete. To use a reviewed local
+pair instead, select the local profile and pass its memory root:
+
+.. code-block:: bash
+
+   rpent --robot robocasa --task-name OpenDrawer --seed 1 \
+         --vla-model-path /path/to/rldx --planner claude_code \
+         --memory-profile local --memory-dir /path/to/robocasa-memory
 
 Available task list
 -------------------
@@ -138,12 +169,27 @@ are visible under ``rpent --robot robocasa --help``:
          --planner claude_code \
          --model claude-opus-4-8
 
+RoboCasa does not select a planner implementation; any planner supported by
+RPent can run this robot. See :doc:`configure_planner` for configuration.
+
 .. note::
 
    Use ``--env-endpoint`` / ``--vla-endpoint`` to point at already-running
    servers (``[protocol://]host:port``); when omitted, RPent spawns the env
    and VLA daemons in-process and writes their logs to
    ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
+
+Troubleshooting
+---------------
+
+- If reset reports a missing ``mobilebase0_navview``, reinstall this
+  revision's ``.[robocasa]`` extra so the pinned Robosuite commit is used. Do
+  not patch installed XML files manually.
+- A task-memory warning means the current task's two seed-0 files are absent.
+  Check the Hugging Face subtree or the selected local directory; RPent never
+  falls back to another task.
+- Environment and VLA startup failures are recorded in
+  ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
 
 Toolkit design vs. LIBERO
 -------------------------

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -107,9 +107,9 @@ files:
 
 .. code-block:: text
 
-   resources/robocasa/memory/task/<Task>_s0.json
-   resources/robocasa/memory/task/recipe_<Task>_s0.jsonl
-   resources/robocasa/memory/task/<Task>.md  # optional
+   resources/robocasa/results/<Task>_s0.json
+   resources/robocasa/results/recipe_<Task>_s0.jsonl
+   resources/robocasa/results/<Task>.md  # optional
 
 The JSON/JSONL pair contains reviewed seed-0 evidence. The optional Markdown
 file contains task-specific exploration memory and may summarize multiple
@@ -121,14 +121,14 @@ but does not inject their contents into the prompt.
 RoboCasa never asks the planner to use global memory or another task's memory.
 If no pair exists, RPent warns and continues from live observations. A partial
 JSON/JSONL pair, or a Markdown note without its pair, is rejected as incomplete.
-To use reviewed local files instead, select the local profile and pass their
-memory root:
+To use reviewed local files instead, select the local profile and pass the
+directory containing this results corpus:
 
 .. code-block:: bash
 
    rpent --robot robocasa --task-name OpenDrawer --seed 1 \
          --vla-model-path /path/to/rldx --planner claude_code \
-         --memory-profile local --memory-dir /path/to/robocasa-memory
+         --memory-profile local --memory-dir /path/to/robocasa-results
 
 Available task list
 -------------------
@@ -196,8 +196,9 @@ Troubleshooting
   revision's ``.[robocasa]`` extra so the pinned Robosuite commit is used. Do
   not patch installed XML files manually.
 - A task-memory warning means the current task's seed-0 pair is absent. Check
-  the Hugging Face subtree or the selected local directory; the optional task
-  note never replaces that pair, and RPent never falls back to another task.
+  the Hugging Face ``robocasa/results`` corpus or the selected local directory;
+  the optional task note never replaces that pair, and RPent never falls back
+  to another task.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
 

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -98,9 +98,9 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 
 .. code-block:: text
 
-   resources/robocasa/memory/task/<Task>_s0.json
-   resources/robocasa/memory/task/recipe_<Task>_s0.jsonl
-   resources/robocasa/memory/task/<Task>.md  # 可选
+   resources/robocasa/results/<Task>_s0.json
+   resources/robocasa/results/recipe_<Task>_s0.jsonl
+   resources/robocasa/results/<Task>.md  # 可选
 
 JSON/JSONL pair 保存经过审核的 seed-0 证据。可选的 Markdown 文件保存同任务
 探索 memory，可能汇总多次尝试；当前 16 个 Composite-Seen 和 9 个
@@ -111,13 +111,13 @@ Composite-Unseen 任务包含此文件。Prompt 要求 planner 在开始动作�
 RoboCasa 不要求 planner 使用 global memory，也不会退回读取其他任务的 memory。
 pair 不存在时会明确警告并根据实时观测继续；JSON/JSONL 只存在一份，或只有
 Markdown 而没有 pair 时，会因 memory 不完整而停止。如需使用经过审核的本地
-文件，请选择 local profile 并传入 memory 根目录：
+文件，请选择 local profile 并传入 results corpus 所在目录：
 
 .. code-block:: bash
 
    rpent --robot robocasa --task-name OpenDrawer --seed 1 \
          --vla-model-path /path/to/rldx --planner claude_code \
-         --memory-profile local --memory-dir /path/to/robocasa-memory
+         --memory-profile local --memory-dir /path/to/robocasa-results
 
 可用任务列表
 ------------
@@ -182,9 +182,9 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 
 - reset 报告缺少 ``mobilebase0_navview`` 时，应重新安装当前版本的
   ``.[robocasa]``，确保使用固定的 Robosuite commit；不要手工修改已安装的 XML。
-- task-memory 警告表示当前任务缺少 seed-0 pair。请检查 Hugging Face 子目录
-  或所选本地目录；可选任务 Markdown 不能替代该 pair，RPent 也不会退回读取
-  其他任务。
+- task-memory 警告表示当前任务缺少 seed-0 pair。请检查 Hugging Face 的
+  ``robocasa/results`` corpus 或所选本地目录；可选任务 Markdown 不能替代该
+  pair，RPent 也不会退回读取其他任务。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
 

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -9,8 +9,8 @@ RoboCasa
 
 .. note::
 
-   当前代码尚未完全对齐 `harnessvla.github.io <https://harnessvla.github.io>`_
-   展示的效果，完整复现将在后续放出。
+   本页只说明普通的单任务 ``rpent --robot robocasa`` 运行方式，不定义
+   Atomic/Seen/Unseen 全量 benchmark 的正式复现协议。
 
 安装
 ----
@@ -68,6 +68,13 @@ CUDA 13-only 的机器换成 ``cu130``。
 
 加 ``--skip-existing`` 重跑会跳过已下载的目录。
 
+**移动相机**
+
+``robocasa`` extra 将 Robosuite 固定到包含 Omron 底盘 ``navview``
+相机的精确版本。首次环境 reset 后，RPent 会检查组合后的 MuJoCo 相机名
+``mobilebase0_navview``；缺失时会立即报告安装错误。此时应在当前 RPent
+版本下重新安装 ``.[robocasa]``，无需手工修改 ``site-packages`` 中的 XML。
+
 **RLDX-1 checkpoint**
 
 下面运行命令的 ``--vla-model-path`` 期望一个本地 ``RLDX-1-FT-RC365``
@@ -82,6 +89,27 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 .. code-block:: bash
 
    HF_ENDPOINT=https://hf-mirror.com hf download RLWRLD/RLDX-1-FT-RC365 --local-dir ./checkpoints/rldx-1-ft-rc365
+
+**任务 Memory**
+
+默认评测会复用 RPent 的公共资源同步机制，从 Hugging Face 数据集
+``RLinf/RPent-memory`` 下载 ``robocasa/**`` 到 ``resources/robocasa``。
+当前任务只能使用下面这一组 seed-0 memory：
+
+.. code-block:: text
+
+   resources/robocasa/memory/task/<Task>_s0.json
+   resources/robocasa/memory/task/recipe_<Task>_s0.jsonl
+
+RoboCasa 不使用 global memory，也不会读取其他任务的 memory。两份文件都
+不存在时会明确警告并根据实时观测继续；只存在一份时会因 pair 不完整而停止。
+如需使用经过审核的本地 pair，请选择 local profile 并传入 memory 根目录：
+
+.. code-block:: bash
+
+   rpent --robot robocasa --task-name OpenDrawer --seed 1 \
+         --vla-model-path /path/to/rldx --planner claude_code \
+         --memory-profile local --memory-dir /path/to/robocasa-memory
 
 可用任务列表
 ------------
@@ -131,12 +159,25 @@ RoboCasa 的 CLI 参数由 ``robots/robocasa/__init__`` 注册，可通过
          --planner claude_code \
          --model claude-opus-4-8
 
+RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该机器人。
+配置方式参见 :doc:`configure_planner`。
+
 .. note::
 
    使用 ``--env-endpoint`` / ``--vla-endpoint`` 指向已运行的服务器
    (``[protocol://]host:port``)；不指定时，RPent 会就地启动 env 和 VLA
    子进程，日志分别写到 ``<output_dir>/env_server.log`` 和
    ``<output_dir>/vla_server.log``。
+
+常见错误
+--------
+
+- reset 报告缺少 ``mobilebase0_navview`` 时，应重新安装当前版本的
+  ``.[robocasa]``，确保使用固定的 Robosuite commit；不要手工修改已安装的 XML。
+- task-memory 警告表示当前任务缺少两份 seed-0 文件。请检查 Hugging Face
+  子目录或所选本地目录；RPent 不会退回读取其他任务。
+- 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
+  ``<output_dir>/vla_server.log``。
 
 Toolkit 与 LIBERO 的差异
 ------------------------

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -21,21 +21,23 @@ RLDX-1 要求 Python ``3.10``。请创建独立环境，并通过 ``.[robocasa]`
 .. code-block:: bash
 
    uv venv --python 3.10
-   uv pip install -e ".[robocasa]"
+   uv pip install -e ".[robocasa]" \
+      "torch==2.7.0" "torchvision==0.22.0" \
+      --torch-backend=cu126
 
-为避免 PyPI 上 torch 的 CUDA build 与本地驱动不匹配，建议通过
-``--index`` 指定 PyTorch CUDA 索引，例如
-``uv pip install -e ".[robocasa]" --index https://download.pytorch.org/whl/cu126``；
-CUDA 13-only 的机器换成 ``cu130``。
+该命令固定 RLDX-1 使用的 Torch 版本组合，并让 uv 只为 Torch 选择官方 CUDA
+wheel，避免把 PyTorch wheel 源作为通用 ``--index`` 后，在默认 first-index
+策略下误选其中的旧版无关依赖。上面的 ``cu126`` 是已验证的 CUDA 安装方式；
+仅当宿主机确有需要时才切换到其他受支持的 Torch backend。
 
 国内网络可使用 PyPI 镜像加速：\
 
 .. code-block:: bash
 
    uv pip install -e ".[robocasa]" \
+      "torch==2.7.0" "torchvision==0.22.0" \
       --default-index https://mirrors.aliyun.com/pypi/simple \
-      --index https://pypi.tuna.tsinghua.edu.cn/simple \
-      --index https://mirrors.aliyun.com/pytorch-wheels/cu126
+      --torch-backend=cu126
 
 .. note::
 

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -70,10 +70,14 @@ CUDA 13-only 的机器换成 ``cu130``。
 
 **移动相机**
 
-``robocasa`` extra 将 Robosuite 固定到包含 Omron 底盘 ``navview``
-相机的精确版本。首次环境 reset 后，RPent 会检查组合后的 MuJoCo 相机名
-``mobilebase0_navview``；缺失时会立即报告安装错误。此时应在当前 RPent
-版本下重新安装 ``.[robocasa]``，无需手工修改 ``site-packages`` 中的 XML。
+``robocasa`` extra 会安装 ``RLinf/robosuite`` 的 ``rpent`` 分支，该分支
+包含 Omron 底盘固定的 ``navview`` 相机，其组合后的 MuJoCo 相机名为
+``mobilebase0_navview``。RPent 不再执行单独的 reset-time 相机预检；如果相机
+缺失，首次请求导航 RGB-D 或 world map 渲染时会自然报错。此时重新安装
+``.[robocasa]`` 以刷新该分支即可，无需手工修改 ``site-packages`` 中的 XML。
+本 PR 验证时该分支解析为 commit
+``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``；发布实验结果时应记录实际解析
+到的 commit。
 
 **RLDX-1 checkpoint**
 
@@ -109,9 +113,10 @@ Composite-Unseen 任务包含此文件。Prompt 要求 planner 在开始动作�
 强制注入 prompt。
 
 RoboCasa 不要求 planner 使用 global memory，也不会退回读取其他任务的 memory。
-pair 不存在时会明确警告并根据实时观测继续；JSON/JSONL 只存在一份，或只有
-Markdown 而没有 pair 时，会因 memory 不完整而停止。如需使用经过审核的本地
-文件，请选择 local profile 并传入 results corpus 所在目录：
+运行时不预检 corpus 的完整性；当前任务文件缺失时，``read_text_file`` 会报告
+该文件不存在，planner 使用其余可用的同任务文件和实时观测继续。公开的默认
+corpus 会在发布阶段单独校验。如需使用经过审核的本地文件，请选择 local
+profile 并传入 results corpus 所在目录：
 
 .. code-block:: bash
 
@@ -180,11 +185,12 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 常见错误
 --------
 
-- reset 报告缺少 ``mobilebase0_navview`` 时，应重新安装当前版本的
-  ``.[robocasa]``，确保使用固定的 Robosuite commit；不要手工修改已安装的 XML。
-- task-memory 警告表示当前任务缺少 seed-0 pair。请检查 Hugging Face 的
-  ``robocasa/results`` corpus 或所选本地目录；可选任务 Markdown 不能替代该
-  pair，RPent 也不会退回读取其他任务。
+- 导航 RGB-D 或 world map 渲染报告缺少 ``mobilebase0_navview`` 时，应重新
+  安装 ``.[robocasa]`` 以刷新 ``RLinf/robosuite`` 的 ``rpent`` 分支；不要手工
+  修改已安装的 XML。
+- ``read_text_file`` 报告缺少当前任务结果时，请检查 Hugging Face 的
+  ``robocasa/results`` corpus 或所选本地目录。RPent 不预检 corpus，也不会
+  退回读取其他任务。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
 

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -94,16 +94,24 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 
 默认评测会复用 RPent 的公共资源同步机制，从 Hugging Face 数据集
 ``RLinf/RPent-memory`` 下载 ``robocasa/**`` 到 ``resources/robocasa``。
-当前任务只能使用下面这一组 seed-0 memory：
+当前任务只能使用下面这些同任务 memory：
 
 .. code-block:: text
 
    resources/robocasa/memory/task/<Task>_s0.json
    resources/robocasa/memory/task/recipe_<Task>_s0.jsonl
+   resources/robocasa/memory/task/<Task>.md  # 可选
 
-RoboCasa 不使用 global memory，也不会读取其他任务的 memory。两份文件都
-不存在时会明确警告并根据实时观测继续；只存在一份时会因 pair 不完整而停止。
-如需使用经过审核的本地 pair，请选择 local profile 并传入 memory 根目录：
+JSON/JSONL pair 保存经过审核的 seed-0 证据。可选的 Markdown 文件保存同任务
+探索 memory，可能汇总多次尝试；当前 16 个 Composite-Seen 和 9 个
+Composite-Unseen 任务包含此文件。Prompt 要求 planner 在开始动作前主动通过
+``read_text_file`` 读取当前任务所有存在的文件；RPent 不会把 Markdown 内容
+强制注入 prompt。
+
+RoboCasa 不要求 planner 使用 global memory，也不会退回读取其他任务的 memory。
+pair 不存在时会明确警告并根据实时观测继续；JSON/JSONL 只存在一份，或只有
+Markdown 而没有 pair 时，会因 memory 不完整而停止。如需使用经过审核的本地
+文件，请选择 local profile 并传入 memory 根目录：
 
 .. code-block:: bash
 
@@ -174,8 +182,9 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 
 - reset 报告缺少 ``mobilebase0_navview`` 时，应重新安装当前版本的
   ``.[robocasa]``，确保使用固定的 Robosuite commit；不要手工修改已安装的 XML。
-- task-memory 警告表示当前任务缺少两份 seed-0 文件。请检查 Hugging Face
-  子目录或所选本地目录；RPent 不会退回读取其他任务。
+- task-memory 警告表示当前任务缺少 seed-0 pair。请检查 Hugging Face 子目录
+  或所选本地目录；可选任务 Markdown 不能替代该 pair，RPent 也不会退回读取
+  其他任务。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ robocasa = [
     "rpent[rlinf]",
     "rlinf-robocasa365",
     "rlinf-rldx>=1.0.1.post10",
-    "robosuite @ git+https://github.com/RLinf/robosuite.git@0d88d0174c4f633cc7a89fd32cebdd27c79e745d",
+    "robosuite @ git+https://github.com/RLinf/robosuite.git@rpent",
 ]
 robotwin = [
     # TODO: replace fixed owner-controlled revisions with released versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ robocasa = [
     "rpent[rlinf]",
     "rlinf-robocasa365",
     "rlinf-rldx>=1.0.1.post10",
-    "robosuite @ git+https://github.com/RLinf/robosuite.git@rlinf",
+    "robosuite @ git+https://github.com/RLinf/robosuite.git@0d88d0174c4f633cc7a89fd32cebdd27c79e745d",
 ]
 robotwin = [
     # TODO: replace fixed owner-controlled revisions with released versions.

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -40,6 +40,8 @@ DEFAULT_CAMS = [
     "robot0_eye_in_hand",
 ]
 
+REQUIRED_CAMERAS = ("mobilebase0_navview",)
+
 
 def _split_kwargs(split):
     """Replicate robocasa.utils.env_utils.create_env's split -> layout logic."""
@@ -150,6 +152,22 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         return self._meta
 
     # ---- lifecycle ----
+    def _validate_required_cameras(self):
+        """Validate model cameras after reset has initialized the simulator."""
+        if self.env.sim is None:
+            raise RuntimeError("RoboCasa camera validation requires a reset simulator")
+        for camera_name in REQUIRED_CAMERAS:
+            try:
+                camera_id = int(self.env.sim.model.camera_name2id(camera_name))
+                if camera_id < 0:
+                    raise ValueError(camera_name)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"RoboCasa requires the base-mounted camera {camera_name!r}. "
+                    "Install the Robosuite commit pinned by RPent and reinstall "
+                    "the robocasa extra."
+                ) from exc
+
     def reset(self):
         # RLDX_RESET_SEED=<episode_seed> -> reproduce the EXACT scene the fullshot eval
         # generated for that episode, seeded the SAME way as the eval's VideoRecordingWrapper
@@ -167,7 +185,9 @@ class RoboCasaEnvFacade(BaseEnvFacade):
                 self.env.seed = sd
             if hasattr(self.env, "rng"):
                 self.env.rng = np.random.default_rng(sd)
-        return self.env.reset()
+        obs = self.env.reset()
+        self._validate_required_cameras()
+        return obs
 
     def step(self, flat_action):
         """flat_action: np.ndarray[12] = [eef_pos(3), eef_rot(3), gripper(1),

--- a/robots/robocasa/env_server.py
+++ b/robots/robocasa/env_server.py
@@ -40,8 +40,6 @@ DEFAULT_CAMS = [
     "robot0_eye_in_hand",
 ]
 
-REQUIRED_CAMERAS = ("mobilebase0_navview",)
-
 
 def _split_kwargs(split):
     """Replicate robocasa.utils.env_utils.create_env's split -> layout logic."""
@@ -152,22 +150,6 @@ class RoboCasaEnvFacade(BaseEnvFacade):
         return self._meta
 
     # ---- lifecycle ----
-    def _validate_required_cameras(self):
-        """Validate model cameras after reset has initialized the simulator."""
-        if self.env.sim is None:
-            raise RuntimeError("RoboCasa camera validation requires a reset simulator")
-        for camera_name in REQUIRED_CAMERAS:
-            try:
-                camera_id = int(self.env.sim.model.camera_name2id(camera_name))
-                if camera_id < 0:
-                    raise ValueError(camera_name)
-            except ValueError as exc:
-                raise RuntimeError(
-                    f"RoboCasa requires the base-mounted camera {camera_name!r}. "
-                    "Install the Robosuite commit pinned by RPent and reinstall "
-                    "the robocasa extra."
-                ) from exc
-
     def reset(self):
         # RLDX_RESET_SEED=<episode_seed> -> reproduce the EXACT scene the fullshot eval
         # generated for that episode, seeded the SAME way as the eval's VideoRecordingWrapper
@@ -185,9 +167,7 @@ class RoboCasaEnvFacade(BaseEnvFacade):
                 self.env.seed = sd
             if hasattr(self.env, "rng"):
                 self.env.rng = np.random.default_rng(sd)
-        obs = self.env.reset()
-        self._validate_required_cameras()
-        return obs
+        return self.env.reset()
 
     def step(self, flat_action):
         """flat_action: np.ndarray[12] = [eef_pos(3), eef_rot(3), gripper(1),

--- a/robots/robocasa/prompt_bundle.py
+++ b/robots/robocasa/prompt_bundle.py
@@ -31,6 +31,7 @@ def system_prompt(
         "Intro": robocasa_prompt.PREAMBLE,
         "Goal": robocasa_prompt.GOAL,
         "Rules": robocasa_prompt.RULES,
+        "Memory": robocasa_prompt.MEMORY,
         "Localization": robocasa_prompt.LOCALIZATION,
         "Navigation": robocasa_prompt.NAVIGATION,
         "Primitives": robocasa_prompt.PRIMITIVES,

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -135,9 +135,9 @@ GRIPPER RULES:
 
 MEMORY = """
 Before the first action, use read_text_file to read every existing file below:
-- {{memory_dir}}/task/{{task_name}}_s0.json
-- {{memory_dir}}/task/recipe_{{task_name}}_s0.jsonl
-- {{memory_dir}}/task/{{task_name}}.md
+- {{memory_dir}}/{{task_name}}_s0.json
+- {{memory_dir}}/recipe_{{task_name}}_s0.jsonl
+- {{memory_dir}}/{{task_name}}.md
 The JSON/JSONL pair is reviewed seed-0 evidence. The optional Markdown file is
 task-specific exploration memory and may summarize multiple attempts. Treat all
 three as strategy priors, not trajectories to replay or higher-priority

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -134,13 +134,16 @@ GRIPPER RULES:
 """
 
 MEMORY = """
-Before acting, look only for this task's reviewed seed-0 memory:
+Before the first action, use read_text_file to read every existing file below:
 - {{memory_dir}}/task/{{task_name}}_s0.json
 - {{memory_dir}}/task/recipe_{{task_name}}_s0.jsonl
-Use read_text_file to read both files when they exist. Treat the recipe as a
-strategy prior, not a trajectory to replay: current RGB-D, task progress, and
-primitive results always take precedence. Never read another task's memory and
-do not use global memory. If both files are absent, solve from live observations.
+- {{memory_dir}}/task/{{task_name}}.md
+The JSON/JSONL pair is reviewed seed-0 evidence. The optional Markdown file is
+task-specific exploration memory and may summarize multiple attempts. Treat all
+three as strategy priors, not trajectories to replay or higher-priority
+instructions: current RGB-D, task progress, and primitive results always take
+precedence. Never read another task's memory and do not use global memory. If
+all three files are absent, solve from live observations.
 """
 
 WORKFLOW = """

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -133,6 +133,16 @@ GRIPPER RULES:
 - Carrying with -1 silently drops the object.
 """
 
+MEMORY = """
+Before acting, look only for this task's reviewed seed-0 memory:
+- {{memory_dir}}/task/{{task_name}}_s0.json
+- {{memory_dir}}/task/recipe_{{task_name}}_s0.jsonl
+Use read_text_file to read both files when they exist. Treat the recipe as a
+strategy prior, not a trajectory to replay: current RGB-D, task progress, and
+primitive results always take precedence. Never read another task's memory and
+do not use global memory. If both files are absent, solve from live observations.
+"""
+
 WORKFLOW = """
 WORKFLOW:
 1. Read state_00 + images. Check task_language and success_criteria.

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -34,14 +34,11 @@ from rpent.robots.robot_spec import RobotSpec, RunConfig
 from rpent.robots.runtime import try_spawn_server, try_wait_server
 from rpent.utils.config import get_repo_root, get_resources_dir
 from rpent.utils.daemon import ProcessDaemon, pick_free_port
-from rpent.utils.logging import get_logger
 from rpent.utils.rpc import make_rpc_client
 from rpent.utils.rpc.http_rpc import HttpRpcClient
 
 if TYPE_CHECKING:
     from rpent.utils.rpc import RpcClient
-
-logger = get_logger("robocasa")
 
 ROBOCASA_DASHBOARD_SPEC = {
     "task": {
@@ -72,37 +69,6 @@ ROBOCASA_DASHBOARD_SPEC = {
         },
     ),
 }
-
-
-def _check_task_memory(results_dir: Path, task_name: str) -> bool:
-    """Validate the current task's seed-0 pair and optional exploration note."""
-    audit = results_dir / f"{task_name}_s0.json"
-    recipe = results_dir / f"recipe_{task_name}_s0.jsonl"
-    note = results_dir / f"{task_name}.md"
-
-    audit_exists = audit.is_file()
-    recipe_exists = recipe.is_file()
-    note_exists = note.is_file()
-    if audit_exists != recipe_exists:
-        raise ValueError(
-            f"RoboCasa task memory for {task_name!r} is incomplete: expected "
-            f"both {audit.name!r} and {recipe.name!r} under {results_dir}"
-        )
-    if note_exists and not audit_exists:
-        raise ValueError(
-            f"RoboCasa task memory for {task_name!r} is incomplete: "
-            f"{note.name!r} requires the seed-0 audit and recipe pair under "
-            f"{results_dir}"
-        )
-    if not audit_exists:
-        logger.warning(
-            "no task-matched seed-0 memory found for %s under %s; continuing "
-            "without task memory",
-            task_name,
-            results_dir,
-        )
-        return False
-    return True
 
 
 def get_robot_spec() -> RobotSpec:
@@ -137,7 +103,6 @@ def get_toolkit(
         config.prompt_vars.get("memory_dir")
         or (get_resources_dir("robocasa") / "results")
     )
-    _check_task_memory(results_dir, str(config.task_desc["task_name"]))
     # Reference results are a sibling of persistent memory, matching LIBERO.
     memory = MemoryManager(root=results_dir.parent / "memory")
     return RoboCasaToolkit(

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -32,7 +32,7 @@ from rpent.memory import MemoryManager
 from rpent.robots.prompt_bundle import PromptBundle
 from rpent.robots.robot_spec import RobotSpec, RunConfig
 from rpent.robots.runtime import try_spawn_server, try_wait_server
-from rpent.utils.config import get_memory_dir, get_repo_root
+from rpent.utils.config import get_repo_root, get_resources_dir
 from rpent.utils.daemon import ProcessDaemon, pick_free_port
 from rpent.utils.logging import get_logger
 from rpent.utils.rpc import make_rpc_client
@@ -74,12 +74,11 @@ ROBOCASA_DASHBOARD_SPEC = {
 }
 
 
-def _check_task_memory(memory_dir: Path, task_name: str) -> bool:
+def _check_task_memory(results_dir: Path, task_name: str) -> bool:
     """Validate the current task's seed-0 pair and optional exploration note."""
-    task_dir = memory_dir / "task"
-    audit = task_dir / f"{task_name}_s0.json"
-    recipe = task_dir / f"recipe_{task_name}_s0.jsonl"
-    note = task_dir / f"{task_name}.md"
+    audit = results_dir / f"{task_name}_s0.json"
+    recipe = results_dir / f"recipe_{task_name}_s0.jsonl"
+    note = results_dir / f"{task_name}.md"
 
     audit_exists = audit.is_file()
     recipe_exists = recipe.is_file()
@@ -87,20 +86,20 @@ def _check_task_memory(memory_dir: Path, task_name: str) -> bool:
     if audit_exists != recipe_exists:
         raise ValueError(
             f"RoboCasa task memory for {task_name!r} is incomplete: expected "
-            f"both {audit.name!r} and {recipe.name!r} under {task_dir}"
+            f"both {audit.name!r} and {recipe.name!r} under {results_dir}"
         )
     if note_exists and not audit_exists:
         raise ValueError(
             f"RoboCasa task memory for {task_name!r} is incomplete: "
             f"{note.name!r} requires the seed-0 audit and recipe pair under "
-            f"{task_dir}"
+            f"{results_dir}"
         )
     if not audit_exists:
         logger.warning(
             "no task-matched seed-0 memory found for %s under %s; continuing "
             "without task memory",
             task_name,
-            task_dir,
+            results_dir,
         )
         return False
     return True
@@ -134,11 +133,13 @@ def get_toolkit(
     """Return the RoboCasa toolkit for the current session."""
     from robots.robocasa.toolkit import RoboCasaToolkit
 
-    memory_dir = Path(
-        config.prompt_vars.get("memory_dir") or get_memory_dir("robocasa")
+    results_dir = Path(
+        config.prompt_vars.get("memory_dir")
+        or (get_resources_dir("robocasa") / "results")
     )
-    _check_task_memory(memory_dir, str(config.task_desc["task_name"]))
-    memory = MemoryManager(root=memory_dir)
+    _check_task_memory(results_dir, str(config.task_desc["task_name"]))
+    # Reference results are a sibling of persistent memory, matching LIBERO.
+    memory = MemoryManager(root=results_dir.parent / "memory")
     return RoboCasaToolkit(
         primitives_kwargs=primitives_kwargs,
         dashboard_events=dashboard_events,
@@ -194,10 +195,10 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
         raise ValueError("--task-name is required")
 
     memory_arg = getattr(args, "memory_dir", None)
-    memory_dir = (
+    results_dir = (
         Path(memory_arg).expanduser().resolve()
         if memory_arg
-        else get_memory_dir("robocasa")
+        else get_resources_dir("robocasa") / "results"
     )
     memory_profile = getattr(args, "memory_profile", None) or "hf"
 
@@ -208,7 +209,7 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
         "seed": args.seed,
         "recipe_tag": recipe_tag,
         "memory_profile": memory_profile,
-        "memory_dir": str(memory_dir),
+        "memory_dir": str(results_dir),
     }
 
     output_dir = args.output_dir

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -165,7 +165,6 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
         if memory_arg
         else get_resources_dir("robocasa") / "results"
     )
-    memory_profile = getattr(args, "memory_profile", None) or "hf"
 
     recipe_tag = f"{args.task_name}_{args.split}_s{args.seed}"
     prompt_vars = {
@@ -173,7 +172,6 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
         "split": args.split,
         "seed": args.seed,
         "recipe_tag": recipe_tag,
-        "memory_profile": memory_profile,
         "memory_dir": str(results_dir),
     }
 

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -75,17 +75,25 @@ ROBOCASA_DASHBOARD_SPEC = {
 
 
 def _check_task_memory(memory_dir: Path, task_name: str) -> bool:
-    """Require a complete task-matched seed-0 pair when either file exists."""
+    """Validate the current task's seed-0 pair and optional exploration note."""
     task_dir = memory_dir / "task"
     audit = task_dir / f"{task_name}_s0.json"
     recipe = task_dir / f"recipe_{task_name}_s0.jsonl"
+    note = task_dir / f"{task_name}.md"
 
     audit_exists = audit.is_file()
     recipe_exists = recipe.is_file()
+    note_exists = note.is_file()
     if audit_exists != recipe_exists:
         raise ValueError(
             f"RoboCasa task memory for {task_name!r} is incomplete: expected "
             f"both {audit.name!r} and {recipe.name!r} under {task_dir}"
+        )
+    if note_exists and not audit_exists:
+        raise ValueError(
+            f"RoboCasa task memory for {task_name!r} is incomplete: "
+            f"{note.name!r} requires the seed-0 audit and recipe pair under "
+            f"{task_dir}"
         )
     if not audit_exists:
         logger.warning(

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -34,12 +34,14 @@ from rpent.robots.robot_spec import RobotSpec, RunConfig
 from rpent.robots.runtime import try_spawn_server, try_wait_server
 from rpent.utils.config import get_memory_dir, get_repo_root
 from rpent.utils.daemon import ProcessDaemon, pick_free_port
+from rpent.utils.logging import get_logger
 from rpent.utils.rpc import make_rpc_client
 from rpent.utils.rpc.http_rpc import HttpRpcClient
 
 if TYPE_CHECKING:
     from rpent.utils.rpc import RpcClient
 
+logger = get_logger("robocasa")
 
 ROBOCASA_DASHBOARD_SPEC = {
     "task": {
@@ -72,6 +74,30 @@ ROBOCASA_DASHBOARD_SPEC = {
 }
 
 
+def _check_task_memory(memory_dir: Path, task_name: str) -> bool:
+    """Require a complete task-matched seed-0 pair when either file exists."""
+    task_dir = memory_dir / "task"
+    audit = task_dir / f"{task_name}_s0.json"
+    recipe = task_dir / f"recipe_{task_name}_s0.jsonl"
+
+    audit_exists = audit.is_file()
+    recipe_exists = recipe.is_file()
+    if audit_exists != recipe_exists:
+        raise ValueError(
+            f"RoboCasa task memory for {task_name!r} is incomplete: expected "
+            f"both {audit.name!r} and {recipe.name!r} under {task_dir}"
+        )
+    if not audit_exists:
+        logger.warning(
+            "no task-matched seed-0 memory found for %s under %s; continuing "
+            "without task memory",
+            task_name,
+            task_dir,
+        )
+        return False
+    return True
+
+
 def get_robot_spec() -> RobotSpec:
     """Return the RoboCasa robot identity, prompt bundle, and runner hooks.
 
@@ -100,9 +126,11 @@ def get_toolkit(
     """Return the RoboCasa toolkit for the current session."""
     from robots.robocasa.toolkit import RoboCasaToolkit
 
-    memory = MemoryManager(
-        root=config.prompt_vars.get("memory_dir") or get_memory_dir("robocasa"),
+    memory_dir = Path(
+        config.prompt_vars.get("memory_dir") or get_memory_dir("robocasa")
     )
+    _check_task_memory(memory_dir, str(config.task_desc["task_name"]))
+    memory = MemoryManager(root=memory_dir)
     return RoboCasaToolkit(
         primitives_kwargs=primitives_kwargs,
         dashboard_events=dashboard_events,
@@ -157,12 +185,22 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
     if not args.task_name:
         raise ValueError("--task-name is required")
 
+    memory_arg = getattr(args, "memory_dir", None)
+    memory_dir = (
+        Path(memory_arg).expanduser().resolve()
+        if memory_arg
+        else get_memory_dir("robocasa")
+    )
+    memory_profile = getattr(args, "memory_profile", None) or "hf"
+
     recipe_tag = f"{args.task_name}_{args.split}_s{args.seed}"
     prompt_vars = {
         "task_name": args.task_name,
         "split": args.split,
         "seed": args.seed,
         "recipe_tag": recipe_tag,
+        "memory_profile": memory_profile,
+        "memory_dir": str(memory_dir),
     }
 
     output_dir = args.output_dir

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -746,17 +746,14 @@ def _save_observation_artifacts(
         )
 
     # ---- navview: base-mounted forward-down floor camera (follows the base) ----
-    try:
-        nrgb, _ = env.render_camera("navview", depth=True)
-        nworld = env.world_map("navview").astype(np.float32)
-        env_state.save("navview.png", nrgb, step=step_idx)
-        env_state.save("navview_world.npz", nworld, step=step_idx)
-        floor = (nworld[:, :, 2] < 0.12) & (nworld[:, :, 2] > -0.2)
-        overlay = nrgb.copy()
-        overlay[floor] = [0, 255, 0]
-        env_state.save("navview_floor.png", overlay, step=step_idx)
-    except Exception as e:
-        print(f"[tools] navcam render failed at step {step_idx}: {e}", flush=True)
+    nrgb, _ = env.render_camera("navview", depth=True)
+    nworld = env.world_map("navview").astype(np.float32)
+    env_state.save("navview.png", nrgb, step=step_idx)
+    env_state.save("navview_world.npz", nworld, step=step_idx)
+    floor = (nworld[:, :, 2] < 0.12) & (nworld[:, :, 2] > -0.2)
+    overlay = nrgb.copy()
+    overlay[floor] = [0, 255, 0]
+    env_state.save("navview_floor.png", overlay, step=step_idx)
 
 
 def _prune_heavy_artifacts(

--- a/tests/robocasa/test_minimal_integration.py
+++ b/tests/robocasa/test_minimal_integration.py
@@ -1,0 +1,251 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused tests for the minimal RoboCasa integration."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robots.robocasa.env_client import RoboCasaEnvClient
+from robots.robocasa.env_server import RoboCasaEnvFacade
+from robots.robocasa.prompt_bundle import system_prompt
+from robots.robocasa.robot_spec import (
+    _check_task_memory,
+    _parse_config,
+    get_robot_spec,
+)
+from rpent.prompt.utils import format_prompt
+from rpent.utils.resources import ensure_resources
+
+
+class _FakeModel:
+    def __init__(self, *, has_navview: bool) -> None:
+        self.has_navview = has_navview
+
+    def camera_name2id(self, camera_name: str) -> int:
+        if self.has_navview and camera_name == "mobilebase0_navview":
+            return 0
+        raise ValueError(camera_name)
+
+
+class _ResetOnlyEnv:
+    def __init__(self, *, has_navview: bool) -> None:
+        self.has_navview = has_navview
+        self.sim = None
+        self.reset_calls = 0
+
+    def reset(self) -> dict[str, bool]:
+        self.reset_calls += 1
+        self.sim = SimpleNamespace(model=_FakeModel(has_navview=self.has_navview))
+        return {"reset": True}
+
+
+class _DirectRpc:
+    def __init__(self, facade: RoboCasaEnvFacade) -> None:
+        self.facade = facade
+
+    def call(
+        self,
+        method: str,
+        args: tuple = (),
+        kwargs: dict | None = None,
+        timeout_s: float | None = None,
+    ):
+        del timeout_s
+        handler = getattr(self.facade, method.removeprefix("env."))
+        return handler(*args, **(kwargs or {}))
+
+
+def _args(
+    tmp_path: Path,
+    *,
+    memory_profile: str | None,
+    memory_dir: Path | None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        task_name="OpenDrawer",
+        split="target",
+        seed=1,
+        output_dir=tmp_path / "run",
+        memory_profile=memory_profile,
+        memory_dir=memory_dir,
+    )
+
+
+def test_reset_validates_navview_only_after_sim_initialization(monkeypatch):
+    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _ResetOnlyEnv(has_navview=True)
+
+    assert facade.env.sim is None
+    assert facade.reset() == {"reset": True}
+    assert facade.env.reset_calls == 1
+    assert facade.env.sim is not None
+
+
+def test_reset_rejects_missing_navview_after_sim_initialization(monkeypatch):
+    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
+    facade = object.__new__(RoboCasaEnvFacade)
+    facade.env = _ResetOnlyEnv(has_navview=False)
+
+    with pytest.raises(RuntimeError, match="mobilebase0_navview"):
+        facade.reset()
+
+    assert facade.env.reset_calls == 1
+    assert facade.env.sim is not None
+
+
+def test_parse_config_uses_default_hf_memory(monkeypatch, tmp_path):
+    monkeypatch.setenv("RPENT_REPO_ROOT", str(tmp_path))
+
+    config = _parse_config(
+        _args(tmp_path, memory_profile=None, memory_dir=None),
+    )
+
+    assert config.prompt_vars["memory_profile"] == "hf"
+    assert config.prompt_vars["memory_dir"] == str(
+        tmp_path / "resources" / "robocasa" / "memory"
+    )
+
+
+def test_default_resources_sync_uses_robocasa_subtree(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_snapshot_download(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setenv("RPENT_REPO_ROOT", str(tmp_path))
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("RPENT_RESOURCES_HF_REPO", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+
+    resources_dir = ensure_resources(get_robot_spec())
+
+    assert resources_dir == tmp_path / "resources" / "robocasa"
+    assert calls == {
+        "repo_id": "RLinf/RPent-memory",
+        "repo_type": "dataset",
+        "local_dir": str(tmp_path / "resources"),
+        "allow_patterns": ["robocasa/**"],
+    }
+
+
+def test_parse_config_resolves_local_memory(tmp_path):
+    memory_dir = tmp_path / "local-memory"
+
+    config = _parse_config(
+        _args(tmp_path, memory_profile="local", memory_dir=memory_dir),
+    )
+
+    assert config.prompt_vars["memory_profile"] == "local"
+    assert config.prompt_vars["memory_dir"] == str(memory_dir.resolve())
+
+
+def test_task_memory_requires_a_complete_seed_zero_pair(tmp_path):
+    memory_dir = tmp_path / "memory"
+    task_dir = memory_dir / "task"
+
+    assert _check_task_memory(memory_dir, "OpenDrawer") is False
+
+    task_dir.mkdir(parents=True)
+    (task_dir / "OpenDrawer_s0.json").write_text("{}")
+    with pytest.raises(ValueError, match="incomplete"):
+        _check_task_memory(memory_dir, "OpenDrawer")
+
+    (task_dir / "recipe_OpenDrawer_s0.jsonl").write_text("{}\n")
+    assert _check_task_memory(memory_dir, "OpenDrawer") is True
+
+
+def test_prompt_names_only_current_task_memory(tmp_path):
+    memory_dir = tmp_path / "memory"
+    rendered = format_prompt(
+        system_prompt(),
+        variables={
+            "task_name": "OpenDrawer",
+            "memory_dir": str(memory_dir),
+        },
+    )
+
+    assert str(memory_dir / "task" / "OpenDrawer_s0.json") in rendered
+    assert str(memory_dir / "task" / "recipe_OpenDrawer_s0.jsonl") in rendered
+    assert "ArrangeTea_s0" not in rendered
+    assert "GLOBAL_MEMORY" not in rendered
+    assert "{{" not in rendered
+
+
+def test_real_navview_follows_mobile_base(monkeypatch):
+    if os.environ.get("RPENT_RUN_ROBOCASA_INTEGRATION") != "1":
+        pytest.skip("set RPENT_RUN_ROBOCASA_INTEGRATION=1 for the GPU integration test")
+
+    pytest.importorskip("robocasa")
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    monkeypatch.setenv("ROBOT_PLATFORM", "ROBOCASA")
+    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
+
+    facade = RoboCasaEnvFacade(
+        task_name="OpenDrawer",
+        split="target",
+        seed=1,
+        camera_h=256,
+        camera_w=256,
+    )
+    try:
+        assert facade.env.sim is None
+        client = RoboCasaEnvClient(
+            _DirectRpc(facade),
+            expected_meta=facade.get_env_meta(),
+        )
+
+        rgb_before, depth = client.render_camera("navview", depth=True)
+        world = client.world_map("navview")
+        meta_before = client.get_camera_meta("navview")
+
+        assert rgb_before.shape == (256, 256, 3)
+        assert depth.shape == (256, 256)
+        assert world.shape == (256, 256, 3)
+        assert np.isfinite(rgb_before).all()
+        assert np.isfinite(depth).all()
+        assert np.isfinite(world).all()
+
+        action = np.zeros(int(facade.env.action_dim), dtype=np.float64)
+        assert action.shape == (12,)
+        action[6] = -1.0
+        action[7] = 1.0
+        action[11] = 1.0
+        for _ in range(8):
+            client.step(action)
+
+        rgb_after = client.render_camera("navview")
+        meta_after = client.get_camera_meta("navview")
+        pose_before = np.asarray(meta_before["extrinsic_cam2world"])
+        pose_after = np.asarray(meta_after["extrinsic_cam2world"])
+
+        assert np.linalg.norm(pose_after[:3, 3] - pose_before[:3, 3]) > 1e-4
+        assert not np.array_equal(rgb_before, rgb_after)
+    finally:
+        close = getattr(facade.env, "close", None)
+        if close is not None:
+            close()

--- a/tests/robocasa/test_minimal_integration.py
+++ b/tests/robocasa/test_minimal_integration.py
@@ -33,6 +33,7 @@ from robots.robocasa.robot_spec import (
     _parse_config,
     get_robot_spec,
 )
+from rpent.memory import MemoryManager
 from rpent.prompt.utils import format_prompt
 from rpent.utils.resources import ensure_resources
 
@@ -123,7 +124,7 @@ def test_parse_config_uses_default_hf_memory(monkeypatch, tmp_path):
 
     assert config.prompt_vars["memory_profile"] == "hf"
     assert config.prompt_vars["memory_dir"] == str(
-        tmp_path / "resources" / "robocasa" / "memory"
+        tmp_path / "resources" / "robocasa" / "results"
     )
 
 
@@ -153,6 +154,20 @@ def test_default_resources_sync_uses_robocasa_subtree(monkeypatch, tmp_path):
     }
 
 
+def test_results_corpus_is_readable_through_memory_tool(monkeypatch, tmp_path):
+    monkeypatch.setenv("RPENT_REPO_ROOT", str(tmp_path))
+    robot_resources = tmp_path / "resources" / "robocasa"
+    results_dir = robot_resources / "results"
+    results_dir.mkdir(parents=True)
+    audit = results_dir / "OpenDrawer_s0.json"
+    audit.write_text('{"success": true}\n')
+
+    manager = MemoryManager(root=robot_resources / "memory")
+    read_text_file = manager.get_common_tool_bindings()["read_text_file"][1]
+
+    assert read_text_file(path=str(audit))["content"] == '{"success": true}\n'
+
+
 def test_parse_config_resolves_local_memory(tmp_path):
     memory_dir = tmp_path / "local-memory"
 
@@ -165,35 +180,33 @@ def test_parse_config_resolves_local_memory(tmp_path):
 
 
 def test_task_memory_requires_a_complete_seed_zero_pair(tmp_path):
-    memory_dir = tmp_path / "memory"
-    task_dir = memory_dir / "task"
+    results_dir = tmp_path / "results"
 
-    assert _check_task_memory(memory_dir, "OpenDrawer") is False
+    assert _check_task_memory(results_dir, "OpenDrawer") is False
 
-    task_dir.mkdir(parents=True)
-    (task_dir / "OpenDrawer_s0.json").write_text("{}")
+    results_dir.mkdir(parents=True)
+    (results_dir / "OpenDrawer_s0.json").write_text("{}")
     with pytest.raises(ValueError, match="incomplete"):
-        _check_task_memory(memory_dir, "OpenDrawer")
+        _check_task_memory(results_dir, "OpenDrawer")
 
-    (task_dir / "recipe_OpenDrawer_s0.jsonl").write_text("{}\n")
-    assert _check_task_memory(memory_dir, "OpenDrawer") is True
+    (results_dir / "recipe_OpenDrawer_s0.jsonl").write_text("{}\n")
+    assert _check_task_memory(results_dir, "OpenDrawer") is True
 
-    (task_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
-    assert _check_task_memory(memory_dir, "OpenDrawer") is True
+    (results_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
+    assert _check_task_memory(results_dir, "OpenDrawer") is True
 
 
 def test_task_memory_rejects_an_orphan_markdown_note(tmp_path):
-    memory_dir = tmp_path / "memory"
-    task_dir = memory_dir / "task"
-    task_dir.mkdir(parents=True)
-    (task_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    (results_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
 
     with pytest.raises(ValueError, match="requires the seed-0 audit and recipe"):
-        _check_task_memory(memory_dir, "OpenDrawer")
+        _check_task_memory(results_dir, "OpenDrawer")
 
 
 def test_prompt_names_only_current_task_memory(tmp_path):
-    memory_dir = tmp_path / "memory"
+    memory_dir = tmp_path / "results"
     rendered = format_prompt(
         system_prompt(),
         variables={
@@ -202,9 +215,9 @@ def test_prompt_names_only_current_task_memory(tmp_path):
         },
     )
 
-    assert str(memory_dir / "task" / "OpenDrawer_s0.json") in rendered
-    assert str(memory_dir / "task" / "recipe_OpenDrawer_s0.jsonl") in rendered
-    assert str(memory_dir / "task" / "OpenDrawer.md") in rendered
+    assert str(memory_dir / "OpenDrawer_s0.json") in rendered
+    assert str(memory_dir / "recipe_OpenDrawer_s0.jsonl") in rendered
+    assert str(memory_dir / "OpenDrawer.md") in rendered
     assert "read every existing file" in rendered
     assert "ArrangeTea_s0" not in rendered
     assert "GLOBAL_MEMORY" not in rendered

--- a/tests/robocasa/test_minimal_integration.py
+++ b/tests/robocasa/test_minimal_integration.py
@@ -178,6 +178,19 @@ def test_task_memory_requires_a_complete_seed_zero_pair(tmp_path):
     (task_dir / "recipe_OpenDrawer_s0.jsonl").write_text("{}\n")
     assert _check_task_memory(memory_dir, "OpenDrawer") is True
 
+    (task_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
+    assert _check_task_memory(memory_dir, "OpenDrawer") is True
+
+
+def test_task_memory_rejects_an_orphan_markdown_note(tmp_path):
+    memory_dir = tmp_path / "memory"
+    task_dir = memory_dir / "task"
+    task_dir.mkdir(parents=True)
+    (task_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
+
+    with pytest.raises(ValueError, match="requires the seed-0 audit and recipe"):
+        _check_task_memory(memory_dir, "OpenDrawer")
+
 
 def test_prompt_names_only_current_task_memory(tmp_path):
     memory_dir = tmp_path / "memory"
@@ -191,6 +204,8 @@ def test_prompt_names_only_current_task_memory(tmp_path):
 
     assert str(memory_dir / "task" / "OpenDrawer_s0.json") in rendered
     assert str(memory_dir / "task" / "recipe_OpenDrawer_s0.jsonl") in rendered
+    assert str(memory_dir / "task" / "OpenDrawer.md") in rendered
+    assert "read every existing file" in rendered
     assert "ArrangeTea_s0" not in rendered
     assert "GLOBAL_MEMORY" not in rendered
     assert "{{" not in rendered

--- a/tests/robocasa/test_minimal_integration.py
+++ b/tests/robocasa/test_minimal_integration.py
@@ -53,7 +53,6 @@ class _DirectRpc:
 def _args(
     tmp_path: Path,
     *,
-    memory_profile: str | None,
     memory_dir: Path | None,
 ) -> argparse.Namespace:
     return argparse.Namespace(
@@ -61,19 +60,17 @@ def _args(
         split="target",
         seed=1,
         output_dir=tmp_path / "run",
-        memory_profile=memory_profile,
         memory_dir=memory_dir,
     )
 
 
-def test_parse_config_uses_default_hf_memory(monkeypatch, tmp_path):
+def test_parse_config_uses_default_results_dir(monkeypatch, tmp_path):
     monkeypatch.setenv("RPENT_REPO_ROOT", str(tmp_path))
 
     config = _parse_config(
-        _args(tmp_path, memory_profile=None, memory_dir=None),
+        _args(tmp_path, memory_dir=None),
     )
 
-    assert config.prompt_vars["memory_profile"] == "hf"
     assert config.prompt_vars["memory_dir"] == str(
         tmp_path / "resources" / "robocasa" / "results"
     )
@@ -119,14 +116,13 @@ def test_results_corpus_is_readable_through_memory_tool(monkeypatch, tmp_path):
     assert read_text_file(path=str(audit))["content"] == '{"success": true}\n'
 
 
-def test_parse_config_resolves_local_memory(tmp_path):
+def test_parse_config_resolves_local_results_dir(tmp_path):
     memory_dir = tmp_path / "local-memory"
 
     config = _parse_config(
-        _args(tmp_path, memory_profile="local", memory_dir=memory_dir),
+        _args(tmp_path, memory_dir=memory_dir),
     )
 
-    assert config.prompt_vars["memory_profile"] == "local"
     assert config.prompt_vars["memory_dir"] == str(memory_dir.resolve())
 
 

--- a/tests/robocasa/test_minimal_integration.py
+++ b/tests/robocasa/test_minimal_integration.py
@@ -28,36 +28,10 @@ import pytest
 from robots.robocasa.env_client import RoboCasaEnvClient
 from robots.robocasa.env_server import RoboCasaEnvFacade
 from robots.robocasa.prompt_bundle import system_prompt
-from robots.robocasa.robot_spec import (
-    _check_task_memory,
-    _parse_config,
-    get_robot_spec,
-)
+from robots.robocasa.robot_spec import _parse_config, get_robot_spec
 from rpent.memory import MemoryManager
 from rpent.prompt.utils import format_prompt
 from rpent.utils.resources import ensure_resources
-
-
-class _FakeModel:
-    def __init__(self, *, has_navview: bool) -> None:
-        self.has_navview = has_navview
-
-    def camera_name2id(self, camera_name: str) -> int:
-        if self.has_navview and camera_name == "mobilebase0_navview":
-            return 0
-        raise ValueError(camera_name)
-
-
-class _ResetOnlyEnv:
-    def __init__(self, *, has_navview: bool) -> None:
-        self.has_navview = has_navview
-        self.sim = None
-        self.reset_calls = 0
-
-    def reset(self) -> dict[str, bool]:
-        self.reset_calls += 1
-        self.sim = SimpleNamespace(model=_FakeModel(has_navview=self.has_navview))
-        return {"reset": True}
 
 
 class _DirectRpc:
@@ -90,29 +64,6 @@ def _args(
         memory_profile=memory_profile,
         memory_dir=memory_dir,
     )
-
-
-def test_reset_validates_navview_only_after_sim_initialization(monkeypatch):
-    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
-    facade = object.__new__(RoboCasaEnvFacade)
-    facade.env = _ResetOnlyEnv(has_navview=True)
-
-    assert facade.env.sim is None
-    assert facade.reset() == {"reset": True}
-    assert facade.env.reset_calls == 1
-    assert facade.env.sim is not None
-
-
-def test_reset_rejects_missing_navview_after_sim_initialization(monkeypatch):
-    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
-    facade = object.__new__(RoboCasaEnvFacade)
-    facade.env = _ResetOnlyEnv(has_navview=False)
-
-    with pytest.raises(RuntimeError, match="mobilebase0_navview"):
-        facade.reset()
-
-    assert facade.env.reset_calls == 1
-    assert facade.env.sim is not None
 
 
 def test_parse_config_uses_default_hf_memory(monkeypatch, tmp_path):
@@ -177,32 +128,6 @@ def test_parse_config_resolves_local_memory(tmp_path):
 
     assert config.prompt_vars["memory_profile"] == "local"
     assert config.prompt_vars["memory_dir"] == str(memory_dir.resolve())
-
-
-def test_task_memory_requires_a_complete_seed_zero_pair(tmp_path):
-    results_dir = tmp_path / "results"
-
-    assert _check_task_memory(results_dir, "OpenDrawer") is False
-
-    results_dir.mkdir(parents=True)
-    (results_dir / "OpenDrawer_s0.json").write_text("{}")
-    with pytest.raises(ValueError, match="incomplete"):
-        _check_task_memory(results_dir, "OpenDrawer")
-
-    (results_dir / "recipe_OpenDrawer_s0.jsonl").write_text("{}\n")
-    assert _check_task_memory(results_dir, "OpenDrawer") is True
-
-    (results_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
-    assert _check_task_memory(results_dir, "OpenDrawer") is True
-
-
-def test_task_memory_rejects_an_orphan_markdown_note(tmp_path):
-    results_dir = tmp_path / "results"
-    results_dir.mkdir(parents=True)
-    (results_dir / "OpenDrawer.md").write_text("# OpenDrawer task memory\n")
-
-    with pytest.raises(ValueError, match="requires the seed-0 audit and recipe"):
-        _check_task_memory(results_dir, "OpenDrawer")
 
 
 def test_prompt_names_only_current_task_memory(tmp_path):


### PR DESCRIPTION
## Summary

This PR completes the minimal RoboCasa integration needed for ordinary single-task `rpent --robot robocasa` runs:

- use the Omron base-mounted `navview` camera from the `rpent` branch of `RLinf/robosuite` for navigation RGB-D and world maps;
- expose only the current task's reference results through RPent's existing Hugging Face/local resource flow;
- add one short, planner-neutral Memory prompt section; and
- document and test installation, camera behavior, reference-result paths, and local overrides.

The branch is based directly on current `upstream/main` (`f29a69c`) and is 0 commits behind it. It does not carry over the reproduction framework from #125-#129.

## Runtime behavior

### Navigation camera

`.[robocasa]` installs:

```text
robosuite @ git+https://github.com/RLinf/robosuite.git@rpent
```

The branch resolves to `97cfbde4b68d8ec43dad20cf4747297866a6ca2e`, which contains the Omron `navview` camera. RPent does not add a reset-time capability preflight. A missing `mobilebase0_navview` fails at the first navigation RGB-D/world-map render, and the broad exception that previously hid navview rendering failures has been removed.

### Task reference results

The default resource sync requests `robocasa/**` from `RLinf/RPent-memory`. The planner is asked to read every existing current-task file below before acting:

```text
robocasa/results/<Task>_s0.json
robocasa/results/recipe_<Task>_s0.jsonl
robocasa/results/<Task>.md  # optional task-specific exploration note
```

The files are exposed through the existing `read_text_file` tool; their contents are not injected into the prompt. They are strategy priors, while live observations and primitive results remain authoritative. RoboCasa does not request global memory or cross-task memory.

The runtime intentionally does not preflight corpus completeness. Missing files are reported by `read_text_file`, and the planner continues with available current-task files and live observations. `--memory-profile local --memory-dir ...` overrides the default results directory through the shared RPent entry-point handling; RoboCasa does not pass a redundant memory profile through its prompt variables or add another downloader.

## Published data dependency

[RLinf/RPent-memory discussion #3](https://huggingface.co/datasets/RLinf/RPent-memory/discussions/3) is merged. Dataset `main` resolved to immutable snapshot [`551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b`](https://huggingface.co/datasets/RLinf/RPent-memory/tree/551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b/robocasa/results) during final validation.

The published `robocasa/results/` corpus contains 43 JSON audits, 43 JSONL recipes, and 25 task-specific Markdown notes (111 files total). Every JSON and JSONL record parses, audit/recipe task pairs match exactly, all Markdown notes are non-empty and task-scoped, no global-memory filename or content is present, and the old `robocasa/memory/task` path is absent.

## Scope

The final diff is limited to 8 files:

- the RoboCasa Robosuite dependency;
- RoboCasa prompt/config/tool behavior required for task-specific results and visible navview failures;
- focused RoboCasa tests; and
- the existing English and Chinese RoboCasa usage pages.

No planner implementation, common RPC/CLI/RobotSpec contract, scheduler, sandbox, supervisor, validator, checkpoint identity, or benchmark protocol is changed. No launch script, credential, private endpoint, server path, generated report, global memory, or cross-task memory is included.

## Final validation

Validation on head `b0452a6`:

- A fresh Python 3.10.12 environment installed 261 packages with the documented pinned command: `torch==2.7.0`, `torchvision==0.22.0`, and `--torch-backend=cu126`.
- `uv pip check` reports all 261 installed packages compatible; Torch `2.7.0+cu126` detects the RTX 4090.
- The installed Robosuite package resolves to `97cfbde4...`; direct XML inspection confirms the required `navview` camera declaration.
- From a completely empty resource root, the default HF profile downloaded the public `robocasa/**` subtree. The downloaded corpus is byte-identical to the reviewed snapshot, and `read_text_file` reads the task audit.
- The local profile was checked separately and resolves to the supplied `--memory-dir`.
- The opt-in real GPU regression passed: construction completed while `sim is None`; reset produced finite RGB, depth, and world-map values; the action space was 12D; and camera pose and pixels changed after eight base-forward steps.
- `python -m pytest tests -q`: 6 passed, 1 opt-in GPU test skipped; the GPU test also passed when enabled separately.
- `pre-commit run --all-files`: passed.
- English Sphinx build with warnings as errors: passed. Chinese Sphinx rendered successfully and retains the pre-existing unrelated title-underline warning in `configure_primitives.rst`.
- Wheel build and RoboCasa extra METADATA inspection: passed. As on current `main`, the repository-wide wheel configuration does not package top-level `robots/**`; this PR's validated path is a source checkout with editable installation, and a cross-robot wheel fix remains separate.
- Secret, private-endpoint, and local absolute-path scan over the submitted diff: clean.

The original generic PyTorch `--index` example failed in a clean uv environment because first-index resolution selected stale unrelated packages. The English and Chinese docs now use the tested Torch pair with `--torch-backend=cu126`; both the default and Chinese-mirror variants resolve all 261 packages.

## Deferred evaluation

Full Atomic/Seen/Unseen effect evaluation and publication of benchmark results remain intentionally outside this minimal integration PR. They will use the merged prerequisites and a separately reviewed immutable evaluation protocol; valid policy failures will not be hidden by selective reruns.
