### PR TITLE
Fix: sam3 rpc

### DIFF
--- a/rpent/robots/components/sam3_server.py
+++ b/rpent/robots/components/sam3_server.py
@@ -304,7 +304,7 @@ class Sam3Facade(RpcFacade):
     def _dispatch(self, method: str, args: tuple, kwargs: dict) -> Any:
         if method == "segment":
             return self.segment(*args, **kwargs)
-        raise ValueError(f"unknown RPC method: {method!r}")
+        return super()._dispatch(method, args, kwargs)
 
     def segment(
         self,


### PR DESCRIPTION
## Summary

This PR fixes the bug:

SAM3 RPC readiness fails because `Sam3Facade._dispatch()` bypasses the base `RpcFacade` handling of lifecycle methods such as `healthz`.

## Problem
Sam3Facade._dispatch() only handled segment and raised directly for every other method. After RPC lifecycle handling was lifted into RpcFacade, this bypassed the base implementation. As a result, healthz returned:
```
unknown RPC method: 'healthz'
```
Dashboard readiness checks therefore never succeeded, causing the session to wait for 300 seconds and enter a fatal state. Since env_server is task-scoped and starts after shared services become ready, it was never spawned.

## Fix
- Change the SAM3 dispatch fallback from raising an error to calling `super()._dispatch()`.
- This restores base lifecycle methods such as `healthz` and `shutdown`.
- Existing `segment` behavior is unchanged.

## Testing
SAM3 server starts successfully.