### PR TITLE
feat(libero): add an opt-in data flywheel

### DIFF
--- a/flywheel/__init__.py
+++ b/flywheel/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional LIBERO data collection and training tools."""

--- a/flywheel/cli.py
+++ b/flywheel/cli.py
@@ -1,0 +1,103 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command-line entry point for RPent Flywheel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="rpent-flywheel")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    validate = commands.add_parser("validate", help="validate one raw episode")
+    validate.add_argument("episode", type=Path)
+
+    export = commands.add_parser(
+        "export-lerobot", help="export successful episodes to LeRobot"
+    )
+    export.add_argument(
+        "--data-root",
+        type=Path,
+        default=Path("datacollection"),
+        help="root containing raw Flywheel episodes",
+    )
+    export.add_argument("--suite", required=True)
+    export.add_argument("--task", type=int, required=True)
+    export.add_argument("--dataset-id")
+    export.add_argument(
+        "--output-root",
+        type=Path,
+        help="parent directory for the exported LeRobot dataset",
+    )
+
+    train = commands.add_parser(
+        "train-rlinf", help="train Pi0.5 with an official RLinf checkout"
+    )
+    train.add_argument(
+        "--dataset", type=Path, required=True, help="exported LeRobot dataset"
+    )
+    train.add_argument(
+        "--checkpoint", type=Path, required=True, help="initial Pi0.5 checkpoint"
+    )
+    train.add_argument(
+        "--rlinf-root", type=Path, required=True, help="official RLinf source checkout"
+    )
+    train.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="new directory for RLinf training output",
+    )
+    train.add_argument("--max-steps", type=int, required=True)
+    train.add_argument("--save-interval", type=int, default=100)
+    train.add_argument("--cuda-device", type=int, default=0)
+
+    args = parser.parse_args(argv)
+    if args.command == "validate":
+        from flywheel.episode import validate_episode
+
+        result = validate_episode(args.episode)
+    elif args.command == "export-lerobot":
+        from flywheel.export import export_lerobot
+
+        result = export_lerobot(
+            args.data_root,
+            suite=args.suite,
+            task_id=args.task,
+            dataset_id=args.dataset_id,
+            output_root=args.output_root,
+        )
+    else:
+        from flywheel.train import train_rlinf
+
+        result = train_rlinf(
+            dataset=args.dataset,
+            checkpoint=args.checkpoint,
+            rlinf_root=args.rlinf_root,
+            output_dir=args.output_dir,
+            max_steps=args.max_steps,
+            save_interval=args.save_interval,
+            cuda_device=args.cuda_device,
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/flywheel/config/pi05_sft.yaml
+++ b/flywheel/config/pi05_sft.yaml
@@ -1,0 +1,56 @@
+defaults:
+  - model/pi0_5@actor.model
+  - hybrid_engines/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:RLINF_SFT_CONFIG}
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor: "0"
+
+runner:
+  task_type: sft
+  logger:
+    log_path: ${oc.env:RPENT_FLYWHEEL_OUTPUT}
+    project_name: rpent
+    experiment_name: flywheel_pi05_sft
+    logger_backends: []
+  max_epochs: -1
+  max_steps: 1000
+  val_check_interval: -1
+  save_interval: 100
+
+data:
+  train_data_paths: ${oc.env:RPENT_FLYWHEEL_DATASET}
+
+actor:
+  group_name: ActorGroup
+  training_backend: fsdp
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 0
+  model:
+    model_path: ${oc.env:RPENT_FLYWHEEL_CHECKPOINT}
+    is_lora: false
+    openpi:
+      train_expert_only: false
+  fsdp_config:
+    use_orig_params: false
+  optim:
+    lr: 7.91e-6
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 0.01
+    clip_grad: 1.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+    total_training_steps: ${runner.max_steps}

--- a/flywheel/episode.py
+++ b/flywheel/episode.py
@@ -173,9 +173,9 @@ class EpisodeWriter:
                 rewards=np.asarray(self._rewards, np.float32),
                 terminated=np.asarray(self._terminated, np.bool_),
                 truncated=np.asarray(self._truncated, np.bool_),
-                action_source=(
-                    np.asarray(self._vla_ids, np.int32) >= 0
-                ).astype(np.uint8),
+                action_source=(np.asarray(self._vla_ids, np.int32) >= 0).astype(
+                    np.uint8
+                ),
                 primitive_id=np.asarray(self._primitive_ids, np.int32),
                 vla_chunk_id=np.asarray(self._vla_ids, np.int32),
                 proposal_index=np.asarray(self._proposal_indices, np.int16),

--- a/flywheel/episode.py
+++ b/flywheel/episode.py
@@ -1,0 +1,280 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Small in-memory writer for one LIBERO episode."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+SCHEMA_VERSION = 1
+_SUITE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+
+def _observation(obs: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Copy the policy inputs before LIBERO can reuse their buffers."""
+    main = np.array(obs["main_images"], dtype=np.uint8, copy=True, order="C")
+    wrist = np.array(obs["wrist_images"], dtype=np.uint8, copy=True, order="C")
+    state = np.array(obs["states"], dtype=np.float32, copy=True, order="C")
+    if main.shape != (256, 256, 3) or wrist.shape != main.shape:
+        raise ValueError("LIBERO policy images must have shape (256, 256, 3)")
+    if state.shape != (8,):
+        raise ValueError("LIBERO policy state must have shape (8,)")
+    return main, wrist, state
+
+
+def _action(value: Any) -> np.ndarray:
+    action = np.array(value, dtype=np.float32, copy=True, order="C")
+    if action.shape != (7,) or not np.isfinite(action).all():
+        raise ValueError("LIBERO action must be finite with shape (7,)")
+    return action
+
+
+class EpisodeWriter:
+    """Collect one normal evaluation episode and publish it on close."""
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        suite: str,
+        task_id: int,
+        seed: int,
+        initial_observation: dict[str, Any],
+    ) -> None:
+        if not _SUITE.fullmatch(suite):
+            raise ValueError(f"invalid LIBERO suite: {suite!r}")
+        if any(type(value) is not int or value < 0 for value in (task_id, seed)):
+            raise ValueError("task_id and seed must be non-negative integers")
+        language = initial_observation.get("task_descriptions")
+        if not isinstance(language, str) or not language:
+            raise ValueError("LIBERO observation has no task description")
+        first_observation = _observation(initial_observation)
+
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+        self.episode_id = f"episode_{stamp}_{uuid.uuid4().hex[:8]}"
+        parent = (
+            Path(root).expanduser().resolve()
+            / "raw"
+            / "libero"
+            / suite
+            / f"task_{task_id:02d}"
+            / f"seed_{seed:03d}"
+        )
+        parent.mkdir(parents=True, exist_ok=True)
+        self.path = parent / self.episode_id
+        self._partial = self.path.with_name(f"{self.episode_id}.partial")
+        self._partial.mkdir()
+
+        self._metadata = {
+            "schema_version": SCHEMA_VERSION,
+            "episode_id": self.episode_id,
+            "suite": suite,
+            "task_id": task_id,
+            "seed": seed,
+            "task_language": language,
+        }
+        self._observations = [first_observation]
+        self._actions: list[np.ndarray] = []
+        self._rewards: list[float] = []
+        self._terminated: list[bool] = []
+        self._truncated: list[bool] = []
+        self._primitive_ids: list[int] = []
+        self._vla_ids: list[int] = []
+        self._proposal_indices: list[int] = []
+        self._primitive_names: list[str] = []
+        self._active_primitive = -1
+        self._proposals: list[dict[str, Any]] = []
+        self._closed = False
+
+    @property
+    def step_count(self) -> int:
+        return len(self._actions)
+
+    def begin_primitive(self, name: str) -> None:
+        self._active_primitive = len(self._primitive_names)
+        self._primitive_names.append(name)
+
+    def end_primitive(self) -> None:
+        self._active_primitive = -1
+
+    def add_proposal(self, instruction: str, actions: Any) -> int:
+        proposal = np.array(actions, dtype=np.float32, copy=True, order="C")
+        if (
+            proposal.ndim != 2
+            or proposal.shape[1] != 7
+            or not np.isfinite(proposal).all()
+        ):
+            raise ValueError("VLA proposal must be finite with shape (horizon, 7)")
+        vla_id = len(self._proposals)
+        self._proposals.append(
+            {
+                "created_step": self.step_count,
+                "primitive_id": self._active_primitive,
+                "instruction": instruction,
+                "actions": proposal,
+            }
+        )
+        return vla_id
+
+    def add_transition(
+        self,
+        action: Any,
+        next_observation: dict[str, Any],
+        reward: Any,
+        terminated: Any,
+        truncated: Any,
+        *,
+        vla_id: int = -1,
+        proposal_index: int = -1,
+    ) -> None:
+        self._actions.append(_action(action))
+        self._observations.append(_observation(next_observation))
+        self._rewards.append(float(reward))
+        self._terminated.append(bool(terminated))
+        self._truncated.append(bool(truncated))
+        self._primitive_ids.append(self._active_primitive)
+        self._vla_ids.append(vla_id)
+        self._proposal_indices.append(proposal_index)
+
+    def finalize(self) -> Path:
+        if self._closed:
+            return self.path
+        main, wrist, state = map(np.stack, zip(*self._observations, strict=True))
+        actions = (
+            np.stack(self._actions) if self._actions else np.empty((0, 7), np.float32)
+        )
+        with (self._partial / "transitions.npz").open("wb") as stream:
+            np.savez_compressed(
+                stream,
+                main_images=main,
+                wrist_images=wrist,
+                states=state,
+                actions=actions,
+                rewards=np.asarray(self._rewards, np.float32),
+                terminated=np.asarray(self._terminated, np.bool_),
+                truncated=np.asarray(self._truncated, np.bool_),
+                action_source=(
+                    np.asarray(self._vla_ids, np.int32) >= 0
+                ).astype(np.uint8),
+                primitive_id=np.asarray(self._primitive_ids, np.int32),
+                vla_chunk_id=np.asarray(self._vla_ids, np.int32),
+                proposal_index=np.asarray(self._proposal_indices, np.int16),
+            )
+
+        proposal_actions = (
+            np.stack([item["actions"] for item in self._proposals])
+            if self._proposals
+            else np.empty((0, 0, 7), np.float32)
+        )
+        with (self._partial / "proposals.npz").open("wb") as stream:
+            np.savez_compressed(
+                stream,
+                actions=proposal_actions,
+                created_step=np.asarray(
+                    [item["created_step"] for item in self._proposals], np.int32
+                ),
+                primitive_id=np.asarray(
+                    [item["primitive_id"] for item in self._proposals], np.int32
+                ),
+                instruction=np.asarray(
+                    [item["instruction"] for item in self._proposals], dtype=np.str_
+                ),
+            )
+
+        success_steps = np.flatnonzero(np.asarray(self._terminated, np.bool_))
+        success = bool(success_steps.size)
+        metadata = {
+            **self._metadata,
+            "is_success": success,
+            "stop_reason": (
+                "env_terminated"
+                if success
+                else "env_truncated"
+                if any(self._truncated)
+                else "agent_stopped"
+            ),
+            "step_count": self.step_count,
+            "training_step_count": int(success_steps[0] + 1) if success else 0,
+            "primitive_names": self._primitive_names,
+            "proposal_count": len(self._proposals),
+        }
+        (self._partial / "episode.json").write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        validate_episode(self._partial)
+        os.replace(self._partial, self.path)
+        self._closed = True
+        return self.path
+
+
+def validate_episode(path: Path | str) -> dict[str, Any]:
+    """Validate the alignment needed by the exporter and training loader."""
+    root = Path(path)
+    metadata = json.loads((root / "episode.json").read_text(encoding="utf-8"))
+    if metadata.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"unsupported episode schema in {root}")
+    with np.load(root / "transitions.npz", allow_pickle=False) as data:
+        count = int(metadata["step_count"])
+        if data["actions"].shape != (count, 7):
+            raise ValueError(f"invalid action shape in {root}")
+        for key in ("main_images", "wrist_images"):
+            if data[key].shape != (count + 1, 256, 256, 3):
+                raise ValueError(f"invalid {key} shape in {root}")
+        if data["states"].shape != (count + 1, 8):
+            raise ValueError(f"invalid state shape in {root}")
+        for key in (
+            "rewards",
+            "terminated",
+            "truncated",
+            "action_source",
+            "primitive_id",
+            "vla_chunk_id",
+            "proposal_index",
+        ):
+            if data[key].shape != (count,):
+                raise ValueError(f"invalid {key} shape in {root}")
+        terminated = data["terminated"]
+        expected = int(np.flatnonzero(terminated)[0] + 1) if terminated.any() else 0
+        if (
+            metadata["is_success"] != bool(terminated.any())
+            or metadata["training_step_count"] != expected
+        ):
+            raise ValueError(f"invalid training boundary in {root}")
+        if (
+            not np.isfinite(data["actions"]).all()
+            or not np.isfinite(data["states"]).all()
+        ):
+            raise ValueError(f"non-finite training data in {root}")
+    proposal_count = metadata["proposal_count"]
+    with np.load(root / "proposals.npz", allow_pickle=False) as proposals:
+        actions = proposals["actions"]
+        if (
+            actions.ndim != 3
+            or actions.shape[0] != proposal_count
+            or actions.shape[2] != 7
+        ):
+            raise ValueError(f"invalid proposal action shape in {root}")
+        for key in ("created_step", "primitive_id", "instruction"):
+            if proposals[key].shape != (proposal_count,):
+                raise ValueError(f"invalid proposal {key} shape in {root}")
+    return metadata

--- a/flywheel/export.py
+++ b/flywheel/export.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Export successful LIBERO episodes to the LeRobot format used by RLinf."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from flywheel.episode import validate_episode
+
+_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+
+def _features() -> dict[str, dict[str, Any]]:
+    return {
+        "image": {
+            "dtype": "image",
+            "shape": (256, 256, 3),
+            "names": ["height", "width", "channel"],
+        },
+        "wrist_image": {
+            "dtype": "image",
+            "shape": (256, 256, 3),
+            "names": ["height", "width", "channel"],
+        },
+        "state": {"dtype": "float32", "shape": (8,), "names": ["state"]},
+        "actions": {
+            "dtype": "float32",
+            "shape": (7,),
+            "names": ["actions"],
+        },
+    }
+
+
+def _successful_episodes(
+    data_root: Path, suite: str, task_id: int
+) -> list[tuple[Path, dict[str, Any]]]:
+    task_root = data_root / "raw" / "libero" / suite / f"task_{task_id:02d}"
+    episodes = []
+    for path in sorted(task_root.glob("seed_*/episode_*")):
+        if not path.is_dir() or path.name.endswith(".partial"):
+            continue
+        metadata = validate_episode(path)
+        if metadata["suite"] != suite or metadata["task_id"] != task_id:
+            raise ValueError(f"episode metadata does not match its directory: {path}")
+        if metadata["is_success"]:
+            episodes.append((path, metadata))
+    if not episodes:
+        raise ValueError(f"no successful episodes found under {task_root}")
+    return episodes
+
+
+def export_lerobot(
+    data_root: Path | str,
+    *,
+    suite: str,
+    task_id: int,
+    dataset_id: str | None = None,
+    output_root: Path | str | None = None,
+) -> dict[str, Any]:
+    """Export all finalized successful episodes for one LIBERO task."""
+    if not _NAME.fullmatch(suite):
+        raise ValueError(f"invalid LIBERO suite: {suite!r}")
+    dataset_id = dataset_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    if not _NAME.fullmatch(dataset_id):
+        raise ValueError(f"invalid dataset ID: {dataset_id!r}")
+
+    data_root = Path(data_root).expanduser().resolve()
+    episodes = _successful_episodes(data_root, suite, task_id)
+    languages = {metadata["task_language"] for _, metadata in episodes}
+    if len(languages) != 1:
+        raise ValueError("successful episodes have different task descriptions")
+    language = languages.pop()
+
+    parent = (
+        Path(output_root).expanduser().resolve()
+        if output_root is not None
+        else data_root / "datasets" / "lerobot" / suite / f"task_{task_id:02d}"
+    )
+    destination = parent / dataset_id
+    partial = parent / f"{dataset_id}.partial"
+    if destination.exists() or partial.exists():
+        raise FileExistsError(f"dataset already exists: {destination}")
+
+    try:
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    except ImportError as exc:
+        raise RuntimeError("install RPent with the 'flywheel' extra") from exc
+    parent.mkdir(parents=True, exist_ok=True)
+
+    repo_id = f"rpent/{suite}-task-{task_id:02d}-{dataset_id}"
+    dataset = LeRobotDataset.create(
+        repo_id=repo_id,
+        root=partial,
+        robot_type="panda",
+        fps=20,
+        features=_features(),
+        use_videos=False,
+        image_writer_threads=2,
+    )
+    frame_count = 0
+    source_ids = []
+    for path, metadata in episodes:
+        count = metadata["training_step_count"]
+        with np.load(path / "transitions.npz", allow_pickle=False) as data:
+            for index in range(count):
+                dataset.add_frame(
+                    {
+                        "image": data["main_images"][index],
+                        "wrist_image": data["wrist_images"][index],
+                        "state": data["states"][index],
+                        "actions": data["actions"][index],
+                    },
+                    task=language,
+                )
+        dataset.save_episode()
+        frame_count += count
+        source_ids.append(metadata["episode_id"])
+
+    reopened = LeRobotDataset(repo_id, root=partial)
+    if len(reopened) != frame_count:
+        raise RuntimeError("LeRobot frame count changed after reopening")
+    manifest = {
+        "schema_version": 1,
+        "repo_id": repo_id,
+        "suite": suite,
+        "task_id": task_id,
+        "task_language": language,
+        "source_episode_ids": source_ids,
+        "episode_count": len(source_ids),
+        "frame_count": frame_count,
+    }
+    (partial / "meta" / "rpent_flywheel.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(partial, destination)
+    return {"dataset_path": str(destination), **manifest}

--- a/flywheel/train.py
+++ b/flywheel/train.py
@@ -1,0 +1,115 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch Pi0.5 SFT through an official RLinf checkout."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def train_rlinf(
+    *,
+    dataset: Path | str,
+    checkpoint: Path | str,
+    rlinf_root: Path | str,
+    output_dir: Path | str,
+    max_steps: int,
+    save_interval: int = 100,
+    cuda_device: int = 0,
+) -> dict[str, Any]:
+    """Run RLinf's native VLA SFT entry point with the Flywheel config."""
+    dataset = Path(dataset).expanduser().resolve()
+    checkpoint = Path(checkpoint).expanduser().resolve()
+    rlinf_root = Path(rlinf_root).expanduser().resolve()
+    output_dir = Path(output_dir).expanduser().resolve()
+    python = rlinf_root / ".venv" / "bin" / "python"
+    trainer = rlinf_root / "examples" / "sft" / "train_vla_sft.py"
+    if not (dataset / "meta" / "info.json").is_file():
+        raise ValueError(f"not a LeRobot dataset: {dataset}")
+    if not checkpoint.is_dir():
+        raise FileNotFoundError(f"checkpoint not found: {checkpoint}")
+    if not trainer.is_file():
+        raise ValueError(f"not an RLinf source checkout: {rlinf_root}")
+    if not python.is_file():
+        raise FileNotFoundError(f"RLinf virtual environment not found: {python}")
+    if max_steps <= 0:
+        raise ValueError("max_steps must be positive")
+    if save_interval == 0 or save_interval < -1:
+        raise ValueError("save_interval must be positive or -1")
+    if output_dir.exists():
+        raise FileExistsError(f"training output already exists: {output_dir}")
+    rlinf_commit = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=rlinf_root, text=True
+    ).strip()
+    output_dir.mkdir(parents=True)
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CUDA_VISIBLE_DEVICES": str(cuda_device),
+            "PYTHONPATH": str(rlinf_root),
+            "RPENT_FLYWHEEL_DATASET": str(dataset),
+            "RPENT_FLYWHEEL_CHECKPOINT": str(checkpoint),
+            "RPENT_FLYWHEEL_OUTPUT": str(output_dir),
+            "RLINF_SFT_CONFIG": str(rlinf_root / "examples" / "sft" / "config"),
+        }
+    )
+    config_dir = Path(__file__).with_name("config")
+    command = [
+        str(python),
+        str(trainer),
+        "--config-path",
+        str(config_dir),
+        "--config-name",
+        "pi05_sft",
+        f"runner.max_steps={max_steps}",
+        f"runner.save_interval={save_interval}",
+        f"actor.optim.total_training_steps={max_steps}",
+    ]
+    log_path = output_dir / "rlinf.log"
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.run(
+            command,
+            cwd=rlinf_root,
+            env=environment,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+    report = {
+        "command": command,
+        "cuda_device": cuda_device,
+        "dataset": str(dataset),
+        "checkpoint": str(checkpoint),
+        "rlinf_commit": rlinf_commit,
+        "rlinf_root": str(rlinf_root),
+        "rlinf_log": str(log_path),
+        "max_steps": max_steps,
+        "save_interval": save_interval,
+        "return_code": process.returncode,
+        "passed": process.returncode == 0,
+    }
+    report_path = output_dir / "training_report.json"
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if not report["passed"]:
+        raise RuntimeError(f"RLinf training failed; inspect {report_path}")
+    return report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 [project.scripts]
 rpent = "rpent.cli.main:main"
 rpent-memory = "rpent.cli.memory:main"
+rpent-flywheel = "flywheel.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/RLinf/RPent"
@@ -94,6 +95,9 @@ robocasa = [
     "rlinf-rldx>=1.0.1.post10",
     "robosuite @ git+https://github.com/RLinf/robosuite.git@rpent",
 ]
+flywheel = [
+    "lerobot>=0.3.3,<0.4",
+]
 robotwin = [
     # TODO: replace fixed owner-controlled revisions with released versions.
     "rpent[rlinf]",
@@ -109,11 +113,12 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["rpent*"]
+include = ["rpent*", "flywheel*"]
 exclude = ["tests*", "docs*", "examples*", "docker*", "toolkits*"]
 
 [tool.setuptools.package-data]
 "rpent.dashboard" = ["*.html", "static/*.css", "static/*.js"]
+"flywheel" = ["config/*.yaml"]
 
 [tool.ruff]
 line-length = 88

--- a/robots/libero/robot_spec.py
+++ b/robots/libero/robot_spec.py
@@ -162,6 +162,16 @@ def _add_cli_args(parser: argparse.ArgumentParser, use_dashboard: bool) -> None:
     parser.add_argument("--task", type=int, default=None, required=required)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument(
+        "--collect-flywheel-data",
+        action="store_true",
+        help="record this evaluation episode for Flywheel training",
+    )
+    parser.add_argument(
+        "--flywheel-root",
+        default=None,
+        help="Flywheel data root (default: <repo>/datacollection)",
+    )
+    parser.add_argument(
         "--auto-merge-memory",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -227,6 +237,8 @@ def _parse_config(args: argparse.Namespace) -> RunConfig:
         raise ValueError("--explore cannot be used with --memory-profile hf")
     if explore and args.explore_sessions <= 0:
         raise ValueError("--explore-sessions must be greater than 0")
+    if explore and args.collect_flywheel_data:
+        raise ValueError("flywheel collection supports evaluation mode only")
     memory_profile = requested_profile or ("local" if explore else "hf")
     if memory_profile == "hf" and args.memory_dir is not None:
         raise ValueError("--memory-dir requires --memory-profile local or --explore")
@@ -447,5 +459,13 @@ def _init_runtime(
             post_fn=partial(connectors[component], rpc),
         )
         primitives_kwargs.update(component_kwargs)
+
+    if args.collect_flywheel_data:
+        primitives_kwargs["flywheel_config"] = {
+            "root": args.flywheel_root or str(get_repo_root() / "datacollection"),
+            "suite": args.suite,
+            "task_id": args.task,
+            "seed": args.seed,
+        }
 
     return list(owned_daemons.values()), primitives_kwargs

--- a/robots/libero/toolkit.py
+++ b/robots/libero/toolkit.py
@@ -97,6 +97,7 @@ class LiberoToolkit(Toolkit):
                 handler = getattr(self._primitives, name, None)
                 if handler is None:
                     continue  # spec without a backing primitive method
+                handler = partial(self._execute_primitive, name, handler)
             self.add_tool(name, spec, handler)
         if self._mode == "exploration":
             reset_spec = next(
@@ -107,6 +108,13 @@ class LiberoToolkit(Toolkit):
             self.add_tool(
                 "finish", finish_spec, partial(self._guarded_finish, finish_handler)
             )
+
+    def _execute_primitive(self, name: str, handler: Any, **kwargs: Any) -> Any:
+        self._primitives.begin_primitive(name)
+        try:
+            return handler(**kwargs)
+        finally:
+            self._primitives.end_primitive()
 
     @readonly
     def _guarded_finish(self, inner: Any, **kwargs: Any) -> dict[str, Any]:
@@ -206,13 +214,18 @@ class LiberoToolkit(Toolkit):
     def close(self) -> None:
         """Flush the agent-side video buffer through ``EnvState``."""
         try:
-            frames = self._primitives.stop_recording()
-            if frames:
-                self._state.save("episode.mp4", frames, step=None, fps=20)
-        except Exception as e:
-            # The runner is in the cleanup path; never let a video save
-            # abort it.
-            logger.warning(f"failed to save episode video: {e}")
+            episode = self._primitives.finalize_flywheel()
+            if episode is not None:
+                logger.info("flywheel episode finalized: %s", episode)
+        finally:
+            try:
+                frames = self._primitives.stop_recording()
+                if frames:
+                    self._state.save("episode.mp4", frames, step=None, fps=20)
+            except Exception as e:
+                # The runner is in the cleanup path; never let a video save
+                # abort it.
+                logger.warning(f"failed to save episode video: {e}")
 
     def solved(self) -> bool:
         """Return whether this run has completed the task."""

--- a/robots/libero/tools.py
+++ b/robots/libero/tools.py
@@ -57,6 +57,7 @@ class LiberoPrimitives:
         model: Pi05VLAClient,
         sam3_client: Sam3Client,
         check_cancelled: Callable[[], None],
+        flywheel_config: dict[str, Any] | None = None,
     ):
         self.env = env
         self.model = model
@@ -70,6 +71,8 @@ class LiberoPrimitives:
         # Toggled via start_recording() / stop_recording().
         self._recording = False
         self._frames = []
+        self._flywheel_config = flywheel_config
+        self._flywheel = None
 
     def start_recording(self):
         self._recording = True
@@ -105,12 +108,32 @@ class LiberoPrimitives:
     def reset(self):
         obs, info = self.env.reset()
         self.set_obs(obs)
+        if self._flywheel_config is not None:
+            from flywheel.episode import EpisodeWriter
+
+            self._flywheel = EpisodeWriter(
+                **self._flywheel_config,
+                initial_observation=obs,
+            )
         return self._last_obs, info
+
+    def begin_primitive(self, name: str) -> None:
+        if self._flywheel is not None:
+            self._flywheel.begin_primitive(name)
+
+    def end_primitive(self) -> None:
+        if self._flywheel is not None:
+            self._flywheel.end_primitive()
+
+    def finalize_flywheel(self) -> Path | None:
+        return self._flywheel.finalize() if self._flywheel is not None else None
 
     def _step_env(self, action) -> None:
         """Execute one env action between cancellation checkpoints."""
         self._check_cancelled()
-        obs, _r, _t, _tr, _i = self.env.step(action)
+        obs, reward, terminated, truncated, _info = self.env.step(action)
+        if self._flywheel is not None:
+            self._flywheel.add_transition(action, obs, reward, terminated, truncated)
         self.set_obs(obs)
         if self._recording:
             self.record_frame(obs)
@@ -135,15 +158,32 @@ class LiberoPrimitives:
             actions, _ = self.model.predict_action_batch(self._last_obs, mode="eval")
             self._check_cancelled()
 
-            if not self._recording:
+            vla_id = (
+                self._flywheel.add_proposal(instruction, actions)
+                if self._flywheel is not None
+                else -1
+            )
+
+            if not self._recording and self._flywheel is None:
                 chunk_obs, _r, _t, _tr, _i = self.env.chunk_step(actions)
                 obs = chunk_obs[-1] if self.env.return_all_frames else chunk_obs
             else:
-                chunk_obs, _r, _t, _tr, _i = self.env.chunk_step(
+                chunk_obs, rewards, terminated, truncated, _info = self.env.chunk_step(
                     actions, return_all_frames=True
                 )
-                for obs in chunk_obs:
-                    self.record_frame(obs)
+                for index, obs in enumerate(chunk_obs):
+                    if self._recording:
+                        self.record_frame(obs)
+                    if self._flywheel is not None:
+                        self._flywheel.add_transition(
+                            actions[index],
+                            obs,
+                            rewards[index],
+                            terminated[index],
+                            truncated[index],
+                            vla_id=vla_id,
+                            proposal_index=index,
+                        )
                 obs = chunk_obs[-1]
             self.set_obs(obs)
             return self._last_obs

--- a/tests/flywheel/test_episode.py
+++ b/tests/flywheel/test_episode.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import numpy as np
+
+from flywheel.episode import EpisodeWriter, validate_episode
+from flywheel.export import export_lerobot
+
+
+def _obs(value: int) -> dict:
+    return {
+        "main_images": np.full((256, 256, 3), value, np.uint8),
+        "wrist_images": np.full((256, 256, 3), value + 1, np.uint8),
+        "states": np.full(8, value, np.float32),
+        "task_descriptions": "put the bowl on the plate",
+    }
+
+
+def test_success_episode_keeps_aligned_training_prefix(tmp_path):
+    initial = _obs(1)
+    writer = EpisodeWriter(
+        tmp_path,
+        suite="libero_object",
+        task_id=2,
+        seed=7,
+        initial_observation=initial,
+    )
+    initial["main_images"].fill(99)
+
+    writer.begin_primitive("move_to")
+    writer.add_transition(np.zeros(7), _obs(2), 0, False, False)
+    writer.end_primitive()
+
+    writer.begin_primitive("pi0_pick")
+    proposal = np.ones((2, 7), np.float32)
+    vla_id = writer.add_proposal("pick up the bowl", proposal)
+    proposal.fill(99)
+    writer.add_transition(
+        np.ones(7), _obs(3), 1, True, False, vla_id=vla_id, proposal_index=0
+    )
+    writer.add_transition(
+        np.full(7, 2),
+        _obs(4),
+        0,
+        False,
+        False,
+        vla_id=vla_id,
+        proposal_index=1,
+    )
+    writer.end_primitive()
+
+    path = writer.finalize()
+    metadata = validate_episode(path)
+    assert metadata["is_success"] is True
+    assert metadata["step_count"] == 3
+    assert metadata["training_step_count"] == 2
+    assert metadata["primitive_names"] == ["move_to", "pi0_pick"]
+
+    with np.load(path / "transitions.npz", allow_pickle=False) as data:
+        assert data["main_images"].shape[0] == 4
+        assert data["main_images"][0, 0, 0, 0] == 1
+        np.testing.assert_array_equal(data["action_source"], [0, 1, 1])
+        np.testing.assert_array_equal(data["primitive_id"], [0, 1, 1])
+        np.testing.assert_array_equal(data["proposal_index"], [-1, 0, 1])
+    with np.load(path / "proposals.npz", allow_pickle=False) as proposals:
+        assert proposals["actions"][0, 0, 0] == 1
+        assert proposals["created_step"].tolist() == [1]
+
+    assert json.loads((path / "episode.json").read_text())["stop_reason"] == (
+        "env_terminated"
+    )
+    assert not path.with_name(f"{path.name}.partial").exists()
+    assert writer.finalize() == path
+
+
+def test_failed_episode_has_no_training_prefix(tmp_path):
+    writer = EpisodeWriter(
+        tmp_path,
+        suite="libero_object",
+        task_id=2,
+        seed=8,
+        initial_observation=_obs(1),
+    )
+    writer.begin_primitive("move_to")
+    writer.add_transition(np.zeros(7), _obs(2), 0, False, True)
+
+    metadata = validate_episode(writer.finalize())
+    assert metadata["is_success"] is False
+    assert metadata["training_step_count"] == 0
+    assert metadata["stop_reason"] == "env_truncated"
+
+
+def test_export_uses_only_success_prefix(tmp_path):
+    success = EpisodeWriter(
+        tmp_path,
+        suite="libero_object",
+        task_id=2,
+        seed=1,
+        initial_observation=_obs(1),
+    )
+    success.begin_primitive("pi0_pick")
+    success.add_transition(np.ones(7), _obs(2), 1, True, False)
+    success.add_transition(np.full(7, 2), _obs(3), 0, False, False)
+    success.finalize()
+
+    failure = EpisodeWriter(
+        tmp_path,
+        suite="libero_object",
+        task_id=2,
+        seed=2,
+        initial_observation=_obs(4),
+    )
+    failure.begin_primitive("move_to")
+    failure.add_transition(np.zeros(7), _obs(5), 0, False, True)
+    failure.finalize()
+
+    report = export_lerobot(
+        tmp_path, suite="libero_object", task_id=2, dataset_id="test"
+    )
+    assert report["episode_count"] == 1
+    assert report["frame_count"] == 1
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    dataset = LeRobotDataset(report["repo_id"], root=report["dataset_path"])
+    assert len(dataset) == 1
+    assert tuple(dataset[0]["actions"].shape) == (7,)
+    assert dataset[0]["task"] == "put the bowl on the plate"

--- a/tests/flywheel/test_libero_integration.py
+++ b/tests/flywheel/test_libero_integration.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from flywheel.episode import validate_episode
+from robots.libero.tools import LiberoPrimitives
+
+
+def _obs(value: int) -> dict:
+    return {
+        "main_images": np.full((256, 256, 3), value, np.uint8),
+        "wrist_images": np.full((256, 256, 3), value + 1, np.uint8),
+        "states": np.full(8, value, np.float32),
+        "task_descriptions": "put the bowl on the plate",
+    }
+
+
+class _Env:
+    def __init__(self):
+        self.terminated = False
+        self.truncated = False
+        self.return_all_frames = False
+        self.chunk_return_all_frames = None
+
+    def reset(self):
+        return _obs(0), {}
+
+    def step(self, action):
+        del action
+        return _obs(1), 0, False, False, {}
+
+    def chunk_step(self, actions, *, return_all_frames=None):
+        self.chunk_return_all_frames = return_all_frames
+        observations = [_obs(index + 2) for index in range(len(actions))]
+        result = observations if return_all_frames else observations[-1]
+        terminated = np.zeros(len(actions), np.bool_)
+        terminated[-1] = True
+        self.terminated = True
+        return result, np.zeros(len(actions)), terminated, np.zeros(len(actions)), {}
+
+
+class _Model:
+    def predict_action_batch(self, observation, *, mode):
+        assert observation["task_descriptions"] == "pick up the bowl"
+        assert mode == "eval"
+        return np.ones((2, 7), np.float32), {}
+
+
+def _primitives(env, config=None):
+    return LiberoPrimitives(
+        env=env,
+        model=_Model(),
+        sam3_client=SimpleNamespace(),
+        check_cancelled=lambda: None,
+        flywheel_config=config,
+    )
+
+
+def test_collection_records_scripted_and_vla_actions(tmp_path):
+    env = _Env()
+    primitives = _primitives(
+        env,
+        {
+            "root": tmp_path,
+            "suite": "libero_object",
+            "task_id": 2,
+            "seed": 3,
+        },
+    )
+    primitives.reset()
+    primitives.begin_primitive("move_to")
+    primitives._step_env(np.zeros(7))
+    primitives.end_primitive()
+    primitives.begin_primitive("pi0_pick")
+    primitives._vlm_chunk("pick up the bowl")
+    primitives.end_primitive()
+
+    path = primitives.finalize_flywheel()
+    metadata = validate_episode(path)
+    assert metadata["step_count"] == 3
+    assert metadata["training_step_count"] == 3
+    assert env.chunk_return_all_frames is True
+    with np.load(path / "transitions.npz", allow_pickle=False) as data:
+        np.testing.assert_array_equal(data["action_source"], [0, 1, 1])
+        np.testing.assert_array_equal(data["primitive_id"], [0, 1, 1])
+
+
+def test_collection_disabled_keeps_fast_chunk_path():
+    env = _Env()
+    primitives = _primitives(env)
+    primitives.reset()
+    primitives._vlm_chunk("pick up the bowl")
+    assert env.chunk_return_all_frames is None
+    assert primitives.finalize_flywheel() is None

--- a/tests/flywheel/test_train.py
+++ b/tests/flywheel/test_train.py
@@ -1,0 +1,70 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from flywheel.train import train_rlinf
+
+
+def test_train_launcher_uses_official_rlinf_environment(tmp_path, monkeypatch):
+    dataset = tmp_path / "dataset"
+    (dataset / "meta").mkdir(parents=True)
+    (dataset / "meta/info.json").write_text("{}")
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    rlinf_root = tmp_path / "RLinf"
+    (rlinf_root / ".venv/bin").mkdir(parents=True)
+    (rlinf_root / ".venv/bin/python").write_text("")
+    (rlinf_root / "examples/sft").mkdir(parents=True)
+    (rlinf_root / "examples/sft/train_vla_sft.py").write_text("")
+    output = tmp_path / "output"
+
+    def fake_run(command, **kwargs):
+        assert command[0] == str(rlinf_root / ".venv/bin/python")
+        assert command[1] == str(rlinf_root / "examples/sft/train_vla_sft.py")
+        assert command[5] == "pi05_sft"
+        assert "runner.max_steps=20" in command
+        assert kwargs["env"]["RPENT_FLYWHEEL_DATASET"] == str(dataset)
+        assert kwargs["env"]["RPENT_FLYWHEEL_CHECKPOINT"] == str(checkpoint)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("flywheel.train.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "flywheel.train.subprocess.check_output", lambda *args, **kwargs: "abc123\n"
+    )
+    report = train_rlinf(
+        dataset=dataset,
+        checkpoint=checkpoint,
+        rlinf_root=rlinf_root,
+        output_dir=output,
+        max_steps=20,
+        save_interval=5,
+        cuda_device=2,
+    )
+    assert report["passed"] is True
+    assert report["cuda_device"] == 2
+    assert report["max_steps"] == 20
+    assert report["rlinf_commit"] == "abc123"
+    assert report["save_interval"] == 5
+
+
+def test_training_config_uses_pi05_full_sft():
+    config_path = Path(__file__).parents[2] / "flywheel/config/pi05_sft.yaml"
+    config = yaml.safe_load(config_path.read_text())
+    assert config["actor"]["model"]["is_lora"] is False
+    assert config["actor"]["model"]["openpi"]["train_expert_only"] is False
+    assert config["actor"]["fsdp_config"]["use_orig_params"] is False


### PR DESCRIPTION
## Summary

This PR adds a minimal, opt-in LIBERO data flywheel to RPent:

- record action-aligned policy observations, actions, rewards, termination flags,
  Primitive ownership, and VLA proposals during normal evaluation;
- keep finalized raw episodes immutable and retain both successful and failed runs;
- validate raw episodes and export successful training prefixes to LeRobot;
- launch native Pi0.5 SFT through an explicit official RLinf checkout.

Collection is disabled by default. The existing fast VLA chunk path remains
unchanged when Flywheel collection is not enabled.

## Usage

Enable collection on a normal LIBERO evaluation:

```bash
python -m rpent.cli.main \
  --robot libero \
  --suite libero_object_swap \
  --task 2 \
  --seed 1 \
  --collect-flywheel-data \
  --flywheel-root datacollection \
  ...
```

Validate and export successful episodes:

```bash
rpent-flywheel validate datacollection/raw/libero/<suite>/task_<id>/seed_<seed>/<episode>

rpent-flywheel export-lerobot \
  --data-root datacollection \
  --suite libero_object_swap \
  --task 2 \
  --output-root datasets
```

Run Pi0.5 SFT with official RLinf:

```bash
rpent-flywheel train-rlinf \
  --dataset datasets/<dataset-id> \
  --checkpoint /path/to/pi05 \
  --rlinf-root /path/to/RLinf \
  --output-dir /path/to/new-training-output \
  --max-steps 1000 \
  --save-interval 100 \
  --cuda-device 0
```

## Data contract

- An episode is first written to a `.partial` directory and atomically
  published only after validation.
- Each action is aligned with its policy input observation and resulting
  observation.
- Scripted actions retain their Primitive ID; VLA actions additionally retain
  the VLA chunk ID and proposal index.
- Environment termination is the success label. Failed episodes remain in raw
  storage, while the current SFT exporter selects successful training prefixes.
- Export and training create derived outputs and do not overwrite raw episodes
  or the input checkpoint.

## Validation

- Full test suite: `13 passed, 1 skipped`.
- Ruff, Python compilation, `git diff --check`, Hydra config composition, clean
  wheel build, and installed-wheel CLI checks passed.
- Current collection runs finalized five action-aligned episodes with no stale
  `.partial` directories, including VLA and scripted Primitive execution.
- A known successful 138-action LIBERO trajectory was replayed at the same
  deterministic reset state through the current environment and writer. The
  environment again returned `terminated=True` at step 138; the resulting raw
  episode contained five action-producing Primitive calls and ten VLA proposals
  and passed installed-wheel validation.
- The installed-wheel exporter produced and reopened a one-episode, 138-frame
  LeRobot dataset. Raw-file SHA-256 manifests were identical before and after
  export.
- Official `RLinf@dd92c62857da4c67aa5e7c36f731c0d6a121f6d7` consumed that dataset,
  completed exactly one Pi0.5 optimizer step, and saved a readable complete
  checkpoint. Loss (`0.00112`) and gradient norm (`0.433`) were finite; sampled
  vision, language, action-expert, and projection tensors changed, while the
  input checkpoint checksum remained unchanged.

This validation establishes the data and training integration, not model-quality
improvement or a success-rate claim.
