### PR TITLE
fix(robocasa): enforce live task language for VLA execution

### DIFF
--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -421,19 +421,24 @@ class RoboCasaPrimitives:
         settle_patience,
         settle_eps,
     ):
-        """Execute a VLA skill (RLDX). Resolves task_lang, computes force_reset with
-        _vla_desync, clears _vla_desync."""
-        if use_prompt:
-            task_lang = prompt
-        else:
-            task_lang = (
-                self.env.current_raw_obs.get("language") or self.env.get_task_language()
-            ) or prompt
+        """Execute RLDX with the environment's live, full task language."""
+        del use_prompt  # Accepted for compatibility with historical task recipes.
+        task_lang = (
+            self.env.current_raw_obs.get("language") or self.env.get_task_language()
+        )
+        if not task_lang:
+            return {
+                "error": "RoboCasa task language is unavailable; VLA was not executed",
+                "effective_prompt": "",
+                "prompt_overridden": False,
+            }
+
+        prompt_overridden = prompt != task_lang
         # Auto-reseed history if a non-VLA primitive ran since the last VLA call
         # (read _vla_desync BEFORE clearing it)
         fr = bool(force_reset) or self._vla_desync
         self._vla_desync = False
-        return self._rldx.run(
+        result = self._rldx.run(
             task_lang,
             max_chunks,
             n_action_steps,
@@ -444,6 +449,11 @@ class RoboCasaPrimitives:
             recording=self._recording,
             record_frame=self.record_frame,
         )
+        result["effective_prompt"] = task_lang
+        result["prompt_overridden"] = prompt_overridden
+        if prompt_overridden:
+            result["requested_prompt"] = prompt
+        return result
 
     # ---- reset ----
     def reset(self):

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -117,13 +117,10 @@ VLA EXECUTION RULES (the single most important rule):
    command WIPES the VLA's frame history, forcing it to restart from scratch.
 3. Do NOT pass a small max_chunks (default 70 is fine). Do NOT pass
    settle_patience (default 999 disables settle detection).
-4. After each VLA call, inspect its result, current RGB-D, and task_progress. If
-   there is contact, a held object, fixture progress, or a rising task counter,
-   continue with the same full task language and do not insert a manual command.
-5. If there is confirmed no-contact and no visible semantic progress, end that
-   VLA attempt. Re-localize, make only a bounded free-space re-stage, then begin
-   a fresh VLA attempt; do not repeat forever from the same ineffective pose.
-6. The vla_desync flag in view_env_state tells you if the VLA history was
+4. If RLDX returns 'cap', call it again with the same full task language to
+   preserve history. Only re-stage after 2-3 consecutive calls show neither
+   contact nor task progress.
+5. The vla_desync flag in view_env_state tells you if the VLA history was
    invalidated. If True, the next VLA call will start fresh.
 """
 

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -110,15 +110,20 @@ PERCEPTION TOOLS:
 
 VLA_RULES = """
 VLA EXECUTION RULES (the single most important rule):
-1. NEVER put a manual command (move_to / move_base / navigate_to / set_gripper /
+1. Every rldx_skill / rldx_arm call must pass the complete live task_language
+   verbatim. Never shorten, paraphrase, or replace it with an atomic sub-task.
+2. NEVER put a manual command (move_to / move_base / navigate_to / set_gripper /
    scripted_grasp) BETWEEN two VLA calls of the same sub-operation. Every non-VLA
    command WIPES the VLA's frame history, forcing it to restart from scratch.
-2. Do NOT pass a small max_chunks (default 70 is fine). Do NOT pass
+3. Do NOT pass a small max_chunks (default 70 is fine). Do NOT pass
    settle_patience (default 999 disables settle detection).
-3. If rldx_skill returns 'cap' (didn't finish in budget), simply CALL IT AGAIN
-   with the same prompt — continuity is preserved. Only re-stance if 2-3 consecutive
-   calls never touched the object (grasp_detected was never true).
-4. The vla_desync flag in view_env_state tells you if the VLA history was
+4. After each VLA call, inspect its result, current RGB-D, and task_progress. If
+   there is contact, a held object, fixture progress, or a rising task counter,
+   continue with the same full task language and do not insert a manual command.
+5. If there is confirmed no-contact and no visible semantic progress, end that
+   VLA attempt. Re-localize, make only a bounded free-space re-stage, then begin
+   a fresh VLA attempt; do not repeat forever from the same ineffective pose.
+6. The vla_desync flag in view_env_state tells you if the VLA history was
    invalidated. If True, the next VLA call will start fresh.
 """
 
@@ -142,8 +147,12 @@ The JSON/JSONL pair is reviewed seed-0 evidence. The optional Markdown file is
 task-specific exploration memory and may summarize multiple attempts. Treat all
 three as strategy priors, not trajectories to replay or higher-priority
 instructions: current RGB-D, task progress, and primitive results always take
-precedence. Never read another task's memory and do not use global memory. If
-all three files are absent, solve from live observations.
+precedence. Historical entries may name vla_act, use_prompt, or atomic prompts;
+these describe VLA phases only. Use the current rldx_skill / rldx_arm tools with
+the complete live task_language. Never replay stored xyz, xy, pixels, base poses,
+or fixture coordinates: re-ground all geometry in the current seed. Never read
+another task's memory and do not use global memory. If all three files are absent,
+solve from live observations.
 """
 
 WORKFLOW = """

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -223,7 +223,9 @@ TOOLS_SPEC = [
             "RLDX VLA closed-loop skill — FULL base motion allowed. The VLA "
             "drives both arm and mobile base. Use for full-body tasks where "
             "the base must reposition (e.g. navigating to a counter while "
-            "reaching). Do NOT interrupt consecutive VLA calls with manual "
+            "reaching). Pass the complete live task_language verbatim; the "
+            "runtime always uses that environment language for RLDX. Do NOT "
+            "interrupt consecutive VLA calls with manual "
             "primitives — that breaks VLA frame history continuity "
             "(sets vla_desync=True)."
         ),
@@ -232,7 +234,7 @@ TOOLS_SPEC = [
             "properties": {
                 "prompt": {
                     "type": "string",
-                    "description": "VLA prompt, e.g. 'pick up the red mug'",
+                    "description": "Complete live task_language, copied verbatim",
                 },
                 "base_clip": {
                     "type": ["number", "null"],
@@ -241,13 +243,6 @@ TOOLS_SPEC = [
                 "max_chunks": {
                     "type": "integer",
                     "description": "Action-chunk budget (default 70; do NOT set small)",
-                },
-                "use_prompt": {
-                    "type": ["boolean", "null"],
-                    "description": (
-                        "If true, use the explicit prompt; "
-                        "if null/False, use env task language"
-                    ),
                 },
                 "force_reset": {
                     "type": "boolean",
@@ -278,15 +273,16 @@ TOOLS_SPEC = [
             "RLDX VLA closed-loop skill — base CLAMPED to small motions "
             "(base_clip=0.1 default). The VLA drives the arm for precise "
             "micro-alignment (e.g. fine-tuning a grasp approach) but cannot "
-            "drive the base away. Do NOT interrupt consecutive VLA calls "
-            "with manual primitives."
+            "drive the base away. Pass the complete live task_language "
+            "verbatim; the runtime always uses that environment language for "
+            "RLDX. Do NOT interrupt consecutive VLA calls with manual primitives."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "prompt": {
                     "type": "string",
-                    "description": "VLA prompt, e.g. 'pick up the red mug'",
+                    "description": "Complete live task_language, copied verbatim",
                 },
                 "base_clip": {
                     "type": ["number", "null"],
@@ -295,13 +291,6 @@ TOOLS_SPEC = [
                 "max_chunks": {
                     "type": "integer",
                     "description": "Action-chunk budget (default 70; do NOT set small)",
-                },
-                "use_prompt": {
-                    "type": ["boolean", "null"],
-                    "description": (
-                        "If true, use the explicit prompt; "
-                        "if null/False, use env task language"
-                    ),
                 },
                 "force_reset": {
                     "type": "boolean",

--- a/robots/robocasa/vla_server.py
+++ b/robots/robocasa/vla_server.py
@@ -25,6 +25,34 @@ from rpent.utils.logging import get_logger
 logger = get_logger("vla_server")
 
 
+def _build_processor_image_transforms(processor):
+    from rldx.data.augmentations import build_image_transformations_albumentations
+
+    return build_image_transformations_albumentations(
+        image_max_area=processor.image_max_area,
+        image_resize_m=processor.image_resize_m,
+        random_crop_fraction=getattr(processor, "random_crop_fraction", None),
+        random_rotation_angle=getattr(processor, "random_rotation_angle", None),
+        color_jitter_params=getattr(processor, "color_jitter_params", None),
+    )
+
+
+def _normalize_legacy_processor_geometry(processor):
+    """Restore required image geometry omitted by older checkpoint metadata."""
+    image_max_area = getattr(processor, "image_max_area", None)
+    image_resize_m = getattr(processor, "image_resize_m", None)
+    if image_max_area is not None and image_resize_m is not None:
+        return False
+
+    processor.image_max_area = 65536 if image_max_area is None else image_max_area
+    processor.image_resize_m = 32 if image_resize_m is None else image_resize_m
+    (
+        processor.train_image_transform,
+        processor.eval_image_transform,
+    ) = _build_processor_image_transforms(processor)
+    return True
+
+
 class RoboCasaVLAFacade(BaseVLAFacade):
     """Loads RLDX model and exposes inference-only RPC methods."""
 
@@ -39,6 +67,11 @@ class RoboCasaVLAFacade(BaseVLAFacade):
             "",
             None,
         )
+        if _normalize_legacy_processor_geometry(self.policy.policy.processor):
+            logger.warning(
+                "RLDX checkpoint omitted required image geometry; using "
+                "image_max_area=65536 and image_resize_m=32"
+            )
         mod = self.policy.get_modality_config()
         self._vdi = np.asarray(mod["video"].delta_indices)
         self._hist_maxlen = int(self._vdi.max() - self._vdi.min()) + 2

--- a/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
@@ -23,6 +23,7 @@ from typing import Any
 from robots.robocasa.primitives import RoboCasaPrimitives
 from robots.robocasa.prompt_bundle import system_prompt
 from robots.robocasa.tools import TOOLS_SPEC
+from robots.robocasa.vla_server import _normalize_legacy_processor_geometry
 from rpent.prompt.utils import format_prompt
 
 
@@ -138,3 +139,46 @@ def test_vla_does_not_run_without_environment_task_language() -> None:
     assert "task language is unavailable" in result["error"]
     assert rldx.calls == []
     assert primitives._vla_desync is True
+
+
+def test_legacy_rldx_processor_null_geometry_uses_release_defaults(monkeypatch) -> None:
+    processor = SimpleNamespace(
+        image_max_area=None,
+        image_resize_m=None,
+        random_crop_fraction=None,
+        random_rotation_angle=None,
+        color_jitter_params=None,
+    )
+    calls = []
+
+    def fake_build(candidate):
+        calls.append((candidate.image_max_area, candidate.image_resize_m))
+        return "train-transform", "eval-transform"
+
+    monkeypatch.setattr(
+        "robots.robocasa.vla_server._build_processor_image_transforms",
+        fake_build,
+    )
+
+    assert _normalize_legacy_processor_geometry(processor) is True
+    assert processor.image_max_area == 65536
+    assert processor.image_resize_m == 32
+    assert processor.train_image_transform == "train-transform"
+    assert processor.eval_image_transform == "eval-transform"
+    assert calls == [(65536, 32)]
+
+
+def test_current_rldx_processor_geometry_is_not_rebuilt(monkeypatch) -> None:
+    processor = SimpleNamespace(image_max_area=131072, image_resize_m=64)
+
+    def unexpected_build(candidate):
+        raise AssertionError(f"unexpected transform rebuild for {candidate!r}")
+
+    monkeypatch.setattr(
+        "robots.robocasa.vla_server._build_processor_image_transforms",
+        unexpected_build,
+    )
+
+    assert _normalize_legacy_processor_geometry(processor) is False
+    assert processor.image_max_area == 131072
+    assert processor.image_resize_m == 64

--- a/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
@@ -74,8 +74,11 @@ def test_prompt_requires_live_task_language_and_fresh_geometry(tmp_path: Path) -
 
     assert "complete live task_language" in rendered
     assert "Never shorten, paraphrase" in rendered
-    assert "confirmed no-contact and no visible semantic progress" in rendered
-    assert "Historical entries may name vla_act, use_prompt, or atomic prompts" in rendered
+    assert "Only re-stage after 2-3 consecutive calls" in rendered
+    assert "contact nor task progress" in rendered
+    assert (
+        "Historical entries may name vla_act, use_prompt, or atomic prompts" in rendered
+    )
     assert "Never replay stored xyz, xy, pixels, base poses" in rendered
     assert "{{" not in rendered
 

--- a/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
@@ -1,0 +1,140 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline contracts for RoboCasa live-task VLA execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from robots.robocasa.primitives import RoboCasaPrimitives
+from robots.robocasa.prompt_bundle import system_prompt
+from robots.robocasa.tools import TOOLS_SPEC
+from rpent.prompt.utils import format_prompt
+
+
+class _RecordingRldx:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def run(
+        self,
+        prompt: str,
+        max_chunks: int,
+        n_action_steps: int,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "max_chunks": max_chunks,
+                "n_action_steps": n_action_steps,
+                **kwargs,
+            }
+        )
+        return {"ok": True, "prompt": prompt, "status": "cap"}
+
+
+def _fake_primitives(task_language: str) -> tuple[RoboCasaPrimitives, _RecordingRldx]:
+    rldx = _RecordingRldx()
+    primitives = RoboCasaPrimitives.__new__(RoboCasaPrimitives)
+    primitives.env = SimpleNamespace(
+        current_raw_obs={"language": task_language},
+        get_task_language=lambda: task_language,
+    )
+    primitives._rldx = rldx
+    primitives._vla_desync = True
+    primitives._recording = False
+    primitives.record_frame = lambda: None
+    return primitives, rldx
+
+
+def test_prompt_requires_live_task_language_and_fresh_geometry(tmp_path: Path) -> None:
+    rendered = format_prompt(
+        system_prompt(),
+        variables={
+            "task_name": "OpenDrawer",
+            "memory_dir": str(tmp_path / "results"),
+        },
+    )
+
+    assert "complete live task_language" in rendered
+    assert "Never shorten, paraphrase" in rendered
+    assert "confirmed no-contact and no visible semantic progress" in rendered
+    assert "Historical entries may name vla_act, use_prompt, or atomic prompts" in rendered
+    assert "Never replay stored xyz, xy, pixels, base poses" in rendered
+    assert "{{" not in rendered
+
+
+def test_vla_tool_schema_hides_historical_prompt_override() -> None:
+    vla_specs = {
+        spec["name"]: spec for spec in TOOLS_SPEC if spec["name"].startswith("rldx_")
+    }
+
+    assert set(vla_specs) == {"rldx_skill", "rldx_arm"}
+    for spec in vla_specs.values():
+        schema = spec["input_schema"]
+        assert schema["required"] == ["prompt"]
+        assert "use_prompt" not in schema["properties"]
+        assert "complete live task_language" in spec["description"]
+
+
+def test_vla_always_uses_live_task_language_and_preserves_continuity() -> None:
+    task_language = "Pick the squash up and place it in the microwave."
+    primitives, rldx = _fake_primitives(task_language)
+
+    first = primitives.rldx_skill(
+        prompt="Pick the squash up.",
+        use_prompt=True,
+        max_chunks=3,
+    )
+    second = primitives.rldx_arm(
+        prompt="Place it in the microwave.",
+        use_prompt=True,
+        max_chunks=4,
+    )
+
+    assert [call["prompt"] for call in rldx.calls] == [task_language, task_language]
+    assert rldx.calls[0]["force_reset"] is True
+    assert rldx.calls[1]["force_reset"] is False
+    assert primitives._vla_desync is False
+    assert first["effective_prompt"] == task_language
+    assert first["prompt_overridden"] is True
+    assert first["requested_prompt"] == "Pick the squash up."
+    assert second["effective_prompt"] == task_language
+    assert second["prompt_overridden"] is True
+
+
+def test_matching_vla_prompt_is_reported_without_override() -> None:
+    task_language = "Open the left drawer."
+    primitives, rldx = _fake_primitives(task_language)
+
+    result = primitives.rldx_skill(prompt=task_language, use_prompt=False)
+
+    assert rldx.calls[0]["prompt"] == task_language
+    assert result["effective_prompt"] == task_language
+    assert result["prompt_overridden"] is False
+    assert "requested_prompt" not in result
+
+
+def test_vla_does_not_run_without_environment_task_language() -> None:
+    primitives, rldx = _fake_primitives("")
+
+    result = primitives.rldx_skill(prompt="atomic fallback", use_prompt=True)
+
+    assert "task language is unavailable" in result["error"]
+    assert rldx.calls == []
+    assert primitives._vla_desync is True


### PR DESCRIPTION
## Summary

- always send RoboCasa live `task_language` to RLDX, even when historical memory supplies an atomic prompt or `use_prompt=true`
- remove `use_prompt` from planner-visible VLA schemas while retaining handler compatibility for historical recipes
- record `effective_prompt` / `prompt_overridden` and keep VLA continuity with bounded re-staging
- normalize null image geometry in the published RLDX-1 checkpoint to the release defaults before inference

## Scope

- RoboCasa runtime, tool schema, prompt, and focused tests only
- no planner-specific code, shared CLI/RPC/resource changes, memory dataset changes, evaluation manifest, or runner

## Conflict resolution

- rebased onto `upstream/main` at `1b5bc42`
- adopted the offline suite layout introduced by #120
- kept `tests/unit_tests/robots/robocasa/test_resource_contracts.py` identical to `main`
- moved only the seven #140-specific checks into `test_vla_protocol_contracts.py`; the removed legacy test path was not restored
- verified all four RoboCasa runtime file blobs are byte-for-byte identical to the previously GPU-tested `10b24e4` version

## Validation

- `pytest -q tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py`: 7 passed
- `pytest -q tests/unit_tests/robots/robocasa`: 14 passed
- `pytest -q tests/unit_tests`: 192 passed
- `pre-commit run --all-files`: passed locally
- tracked-file secret, private-endpoint, and server-path scan: clean
- default HF sync fetched the published 111-file RoboCasa corpus
- real RTX 4090 env/VLA RPC smoke: RGB-D/world map finite, navview follows the mobile base, and an RLDX action chunk executes without preprocessing errors

The host used for local tests exports `HTTP_PROXY` / `HTTPS_PROXY`, so localhost RPC tests were run with `NO_PROXY=127.0.0.1,localhost`. This is a host configuration requirement; this focused PR does not modify shared RPC behavior.

| Task | Seed 1 | Seed 2 |
| --- | --- | --- |
| `OpenDrawer` | success | success |
| `NavigateKitchen` | success | success |
| `PickPlaceCounterToCabinet` | success | success |

The representative Atomic gate passed 6/6 with Codex SDK, `gpt-5.5`, `xhigh`, and `max_turns=100`. Every table entry is a final clean run whose success came from the returned environment state, not `finish(status=...)`. `OpenDrawer` seed 1 passed as required. Infrastructure-only attempts that produced no valid result were excluded and rerun.

After the review update, `OpenDrawer` seed 1 was run again at the runtime version retained by this branch. The first arm call reached `cap` without contact, the planner continued with the same full task language, and the second call returned environment `success=true` with `joint_p=1.065`. This confirms the shortened 2-3-call continuity guidance without relying on the finish hook.

## Upstream RLDX follow-up

The processor-boundary fix is isolated and covered by four regression cases in [`ye1457/RLDX-1@48dc1b9`](https://github.com/ye1457/RLDX-1/commit/48dc1b9). The currently released `rlinf-rldx` package still needs the narrow RPent fallback; it can be removed after the upstream change is merged and released.

## Follow-up

After this PR merges, a separate PR based on the new `main` will add the immutable Target50 manifest, the dedicated RoboCasa README, and reproduction documentation. This PR does not claim completion of the 340-cell Target50 reproduction.