### PR TITLE
feat(robocasa): define and document the target50 evaluation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ RPent is built for four kinds of users:
 - [2026/08] 🔥 RPent supports the non-reasoning mode, which reduces average execution time by ~40%.
 - [2026/08] 🔥 RPent supports exploration mode for LIBERO. Doc: [LIBERO exploration mode](https://rpent.readthedocs.io/en/latest/rst_source/usage/libero.html#exploration-and-local-memory-evaluation).
 - [2026/08] 🔥 RPent supports RoboTwin with LingBot-VLA for dual-arm manipulation tasks. Doc: [RoboTwin](https://rpent.readthedocs.io/en/latest/rst_source/usage/robotwin.html).
-- [2026/08] 🔥 RPent supports RoboCasa with RLDX-1 as manipulation model. Doc: [RoboCasa](https://rpent.readthedocs.io/en/latest/rst_source/usage/robocasa.html).
+- [2026/08] 🔥 RPent supports RoboCasa with RLDX-1 as manipulation model. See the [RoboCasa setup and Target50 guide](robots/robocasa/README.md) and [full documentation](https://rpent.readthedocs.io/en/latest/rst_source/usage/robocasa.html).
 - [2026/07] 🔥 Our first RPent publication, [Harness VLA: Steering Frozen VLAs into Reliable Manipulation Primitives via Memory-Guided Agents](https://arxiv.org/abs/2607.08448), is released.
 
 ## Feature Matrix
@@ -109,6 +109,9 @@ pip install -e ".[robotwin]"    # RoboTwin
 ```
 
 `.[libero-pro]` is the recommended default. See the [installation docs](https://rpent.readthedocs.io/en/latest/rst_source/installation.html) for other environments.
+
+For RoboCasa setup, task memory, and the Target50 protocol, see the
+[RoboCasa guide](robots/robocasa/README.md).
 
 The example below continues with LIBERO-PRO.
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ RPent is built for four kinds of users:
 
 ## What's NEW!
 
+- [2026/08] 🔥 RPent supports RoboCasa with RLDX-1 as manipulation model. See the [RoboCasa setup and Target50 guide](robots/robocasa/README.md) and [full documentation](https://rpent.readthedocs.io/en/latest/rst_source/usage/robocasa.html).
 - [2026/08] 🔥 RPent supports the non-reasoning mode, which reduces average execution time by ~40%.
 - [2026/08] 🔥 RPent supports exploration mode for LIBERO. Doc: [LIBERO exploration mode](https://rpent.readthedocs.io/en/latest/rst_source/usage/libero.html#exploration-and-local-memory-evaluation).
 - [2026/08] 🔥 RPent supports RoboTwin with LingBot-VLA for dual-arm manipulation tasks. Doc: [RoboTwin](https://rpent.readthedocs.io/en/latest/rst_source/usage/robotwin.html).
-- [2026/08] 🔥 RPent supports RoboCasa with RLDX-1 as manipulation model. See the [RoboCasa setup and Target50 guide](robots/robocasa/README.md) and [full documentation](https://rpent.readthedocs.io/en/latest/rst_source/usage/robocasa.html).
 - [2026/07] 🔥 Our first RPent publication, [Harness VLA: Steering Frozen VLAs into Reliable Manipulation Primitives via Memory-Guided Agents](https://arxiv.org/abs/2607.08448), is released.
 
 ## Feature Matrix

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ RPent 面向以下四类用户：
 - [2026/08] 🔥 新增非推理（non-reasoning）模式，平均执行时间降低约 40%。
 - [2026/08] 🔥 支持 LIBERO 探索模式。文档：[LIBERO 探索模式](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/libero.html#memory)。
 - [2026/08] 🔥 支持 RoboTwin，使用 LingBot-VLA 处理双臂操作任务。文档：[RoboTwin](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robotwin.html)。
-- [2026/08] 🔥 支持 RoboCasa，使用 RLDX-1 作为操作模型。参见 [RoboCasa 安装与 Target50 指南](robots/robocasa/README.md)和[完整中文文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robocasa.html)。
+- [2026/08] 🔥 支持 RoboCasa，使用 RLDX-1 作为操作模型。参见 [RoboCasa 安装与 Target50 指南](robots/robocasa/README.md)和 [完整中文文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robocasa.html)。
 - [2026/07] 🔥 RPent 首篇论文 [Harness VLA: Steering Frozen VLAs into Reliable Manipulation Primitives via Memory-Guided Agents](https://arxiv.org/abs/2607.08448) 发布。
 
 ## 功能矩阵

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ RPent 面向以下四类用户：
 - [2026/08] 🔥 新增非推理（non-reasoning）模式，平均执行时间降低约 40%。
 - [2026/08] 🔥 支持 LIBERO 探索模式。文档：[LIBERO 探索模式](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/libero.html#memory)。
 - [2026/08] 🔥 支持 RoboTwin，使用 LingBot-VLA 处理双臂操作任务。文档：[RoboTwin](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robotwin.html)。
-- [2026/08] 🔥 支持 RoboCasa，使用 RLDX-1 作为操作模型。文档：[RoboCasa](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robocasa.html)。
+- [2026/08] 🔥 支持 RoboCasa，使用 RLDX-1 作为操作模型。参见 [RoboCasa 安装与 Target50 指南](robots/robocasa/README.md)和[完整中文文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robocasa.html)。
 - [2026/07] 🔥 RPent 首篇论文 [Harness VLA: Steering Frozen VLAs into Reliable Manipulation Primitives via Memory-Guided Agents](https://arxiv.org/abs/2607.08448) 发布。
 
 ## 功能矩阵
@@ -111,6 +111,9 @@ pip install -e ".[robotwin]"    # RoboTwin
 
 `.[libero-pro]` 是默认推荐配置。其他环境见
 [安装文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/installation.html)。
+
+RoboCasa 安装、任务 memory 与 Target50 协议参见
+[RoboCasa 指南](robots/robocasa/README.md)。
 
 下面的示例继续使用 LIBERO-PRO。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,10 +38,10 @@ RPent 面向以下四类用户：
 
 ## 最新动态
 
+- [2026/08] 🔥 支持 RoboCasa，使用 RLDX-1 作为操作模型。参见 [RoboCasa 安装与 Target50 指南](robots/robocasa/README.md)和 [完整中文文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robocasa.html)。
 - [2026/08] 🔥 新增非推理（non-reasoning）模式，平均执行时间降低约 40%。
 - [2026/08] 🔥 支持 LIBERO 探索模式。文档：[LIBERO 探索模式](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/libero.html#memory)。
 - [2026/08] 🔥 支持 RoboTwin，使用 LingBot-VLA 处理双臂操作任务。文档：[RoboTwin](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robotwin.html)。
-- [2026/08] 🔥 支持 RoboCasa，使用 RLDX-1 作为操作模型。参见 [RoboCasa 安装与 Target50 指南](robots/robocasa/README.md)和 [完整中文文档](https://rpent.readthedocs.io/zh-cn/latest/rst_source/usage/robocasa.html)。
 - [2026/07] 🔥 RPent 首篇论文 [Harness VLA: Steering Frozen VLAs into Reliable Manipulation Primitives via Memory-Guided Agents](https://arxiv.org/abs/2607.08448) 发布。
 
 ## 功能矩阵

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -24,12 +24,20 @@ the complete RoboCasa365 stack with ``.[robocasa]``:
 .. code-block:: bash
 
    uv venv --python 3.10
+   source .venv/bin/activate
    uv pip install -e ".[robocasa]" \
-      "torch==2.7.0" "torchvision==0.22.0" \
+      --constraint robots/robocasa/eval/target50-constraints.txt \
+      --override robots/robocasa/eval/target50-overrides.txt \
       --torch-backend=cu126
+   uv pip check
 
-This pins the Torch pair used by RLDX-1 and lets uv select the official CUDA
-wheel without treating the PyTorch wheel index as a general package index.
+The RoboCasa-specific constraints file pins the compatibility-sensitive
+package versions validated for Target50 reproduction without narrowing
+RPent's shared LIBERO or RoboTwin dependencies. The companion override file
+resolves the formal environment directly to the immutable Robosuite revision
+while the ordinary ``robocasa`` extra tracks its maintained ``rpent`` branch.
+The command also lets uv select the official CUDA wheel without treating the
+PyTorch wheel index as a general package index.
 Passing that index through ``--index`` can make uv select stale, unrelated
 packages under its default first-index strategy. The ``cu126`` command above
 is the validated CUDA installation; use another supported Torch backend only
@@ -40,7 +48,8 @@ For networks closer to Chinese mirrors:
 .. code-block:: bash
 
    uv pip install -e ".[robocasa]" \
-      "torch==2.7.0" "torchvision==0.22.0" \
+      --constraint robots/robocasa/eval/target50-constraints.txt \
+      --override robots/robocasa/eval/target50-overrides.txt \
       --default-index https://mirrors.aliyun.com/pypi/simple \
       --torch-backend=cu126
 
@@ -60,20 +69,19 @@ For networks closer to Chinese mirrors:
 
 **Post-install setup**
 
-One command writes ``macros_private.py`` and downloads the kitchen assets
-(~10 GB). Point it outside ``site-packages`` so the assets survive
-reinstalls:
+Download the kitchen assets (~10 GB) outside ``site-packages`` so they survive
+reinstalls. Target50 does not use RoboCasa dataset or teleop macros, so skip
+the optional private-macros setup:
 
 .. code-block:: bash
 
-   robocasa-download-assets --assets-path ~/.robocasa/assets -y
+   robocasa-download-assets --assets-path ~/.robocasa/assets --no-macros -y
 
-It prints the environment variables to export afterwards; add them to the
-shell that launches ``rpent``:
+It prints the environment variable to export afterwards; add it to the shell
+that launches ``rpent``:
 
 .. code-block:: bash
 
-   export ROBOCASA_MACROS_PATH=~/.robocasa/macros_private.py
    export ROBOCASA_ASSETS_PATH=~/.robocasa/assets
 
 Re-run with ``--skip-existing`` to leave downloaded folders alone.
@@ -86,13 +94,8 @@ name is ``mobilebase0_navview``. RPent does not run a separate reset-time
 camera preflight; a missing camera fails when navigation RGB-D or world-map
 rendering first requests it. No manual ``site-packages`` XML patch is required.
 Target50 freezes the resolved Robosuite revision at
-``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``. Install that exact revision for
-a formal reproduction:
-
-.. code-block:: bash
-
-   uv pip install --reinstall \
-      "robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
+``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``. The Target50 override in the
+installation command above selects that exact revision.
 
 **RLDX-1 checkpoint**
 
@@ -110,7 +113,9 @@ If the download is slow, use the HF mirror:
 
 .. code-block:: bash
 
-   HF_ENDPOINT=https://hf-mirror.com hf download RLWRLD/RLDX-1-FT-RC365 --local-dir ./checkpoints/rldx-1-ft-rc365
+   HF_ENDPOINT=https://hf-mirror.com hf download RLWRLD/RLDX-1-FT-RC365 \
+      --revision 587e9ecdcc5e7184fcc17f58713908edff5af041 \
+      --local-dir ./checkpoints/rldx-1-ft-rc365
 
 **Task memory**
 
@@ -258,7 +263,17 @@ RPent can run this robot. See :doc:`configure_planner` for configuration.
 For Target50, first download the fixed resources above, then invoke one ordinary
 command for each manifest cell. The Codex reference profile is ``gpt-5.5``,
 ``xhigh``, and ``max_turns=100``; RoboCasa itself remains planner-agnostic. For
-example, the first ``OpenDrawer`` Atomic cell is:
+the scene identity, use the ordinary ``--seed`` argument and do not set
+``RLDX_RESET_SEED``. Freeze the RLDX execution values first:
+
+.. code-block:: bash
+
+   export RLDX_MAX_CHUNKS=40
+   export RLDX_SETTLE_PATIENCE=999
+   export RLDX_ACTION_STEPS_PER_CHUNK=8
+   unset RLDX_RESET_SEED
+
+The first ``OpenDrawer`` Atomic cell is:
 
 .. code-block:: bash
 
@@ -277,6 +292,16 @@ the final recorded environment state has ``state.success=true``; the planner's
 ``finish(status=...)`` argument is not an evaluation label. Valid task failures
 and planner timeouts are not retried. Retry an infrastructure failure only when
 no valid environment result was produced for that cell.
+
+Every completed command atomically writes ``<output-dir>/result.json`` using
+the final environment ``state.success``. The record includes the effective
+protocol values but omits provider errors and credentials. Once all cells are
+present under ``<results-root>/<manifest-split>/<Task>_s<seed>/result.json``,
+validate the fixed denominator and print the task-weighted score with:
+
+.. code-block:: bash
+
+   python -m robots.robocasa.eval.validate_target50 ./runs/target50
 
 .. note::
 
@@ -312,7 +337,7 @@ following task-level aggregates:
      - 15.00%
      - 11/80 (13.75%)
    * - Overall (task-weighted)
-     - 224/340 cells
+     - N/A
      - 57.00%
      - 55.40%
 
@@ -334,6 +359,9 @@ Troubleshooting
   RPent does not fall back to another task's memory.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
+- Local ``127.0.0.1`` and ``localhost`` RPC endpoints must bypass
+  ``HTTP_PROXY`` and ``HTTPS_PROXY``. Update RPent if a local endpoint is still
+  sent through a configured proxy.
 
 Toolkit design vs. LIBERO
 -------------------------

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -245,17 +245,17 @@ larger; see the `RoboCasa <https://robocasa.ai>`_ upstream.
 Running a task
 --------------
 
-RPent-owned environment and VLA workers use request-local direct HTTP clients.
-Codex likewise adds loopback exclusions only to its child process for the local
-MCP connection. Leave ``HTTP_PROXY`` and ``HTTPS_PROXY`` unchanged when remote
-services require them; the default runtime does not require a shell-wide
-``NO_PROXY`` setup.
+HTTP RPC endpoints whose hostname is ``127.0.0.1`` or ``localhost`` are reached
+directly, whether RPent starts the worker or the user supplies the endpoint.
+Every other hostname and IP uses the standard proxy environment. Codex applies
+the same two-host exception only to its child process for the local MCP
+connection. Leave ``HTTP_PROXY`` and ``HTTPS_PROXY`` unchanged when Hugging
+Face, a remote planner, or another remote service requires them; the default
+runtime does not require a shell-wide ``NO_PROXY`` setup.
 
-User-supplied ``--env-endpoint`` and ``--vla-endpoint`` values deliberately
-honor the standard proxy environment. If such an endpoint is local and should
-be reached directly, add its exact hostname or IP to the user's existing
-``NO_PROXY`` and ``no_proxy`` configuration. This choice does not affect
-Hugging Face, a remote planner, or other remote endpoints.
+If a user-supplied local service uses another hostname or IP and should be
+reached directly, add that exact value to the user's existing ``NO_PROXY`` and
+``no_proxy`` configuration.
 
 The RoboCasa CLI flags are registered by ``robots/robocasa/__init__`` and
 are visible under ``rpent --robot robocasa --help``:
@@ -372,10 +372,10 @@ Troubleshooting
   RPent does not fall back to another task's memory.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
-- A user-supplied local ``--env-endpoint`` or ``--vla-endpoint`` follows the
-  standard proxy environment. Add that host to the user's ``NO_PROXY`` and
-  ``no_proxy`` configuration only when it should be reached directly.
-  RPent-owned workers need no proxy setup.
+- Only the exact ``127.0.0.1`` and ``localhost`` hostnames bypass HTTP proxies
+  automatically. Other hostnames and IPs use the standard proxy environment;
+  add the exact host to ``NO_PROXY`` and ``no_proxy`` only when it should be
+  reached directly.
 
 Toolkit design vs. LIBERO
 -------------------------

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -10,9 +10,10 @@ for the wire/transport selection.
 
 .. note::
 
-   This page documents ordinary single-task ``rpent --robot robocasa`` runs.
-   It does not define the full Atomic/Seen/Unseen benchmark reproduction
-   protocol.
+   The public Target50 protocol is frozen in
+   ``robots/robocasa/eval/target50.json``. RPent uses ordinary single-task
+   ``rpent --robot robocasa`` commands for its 340 cells and does not ship a
+   benchmark batch launcher.
 
 Installation
 ------------
@@ -83,10 +84,15 @@ The ``robocasa`` extra installs the ``rpent`` branch of ``RLinf/robosuite``,
 which provides the Omron base's fixed ``navview`` camera. Its composed MuJoCo
 name is ``mobilebase0_navview``. RPent does not run a separate reset-time
 camera preflight; a missing camera fails when navigation RGB-D or world-map
-rendering first requests it. Reinstall ``.[robocasa]`` to refresh that branch;
-no manual ``site-packages`` XML patch is required. During this PR's validation,
-the branch resolved to commit ``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``;
-record the resolved commit when reporting experiments.
+rendering first requests it. No manual ``site-packages`` XML patch is required.
+Target50 freezes the resolved Robosuite revision at
+``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``. Install that exact revision for
+a formal reproduction:
+
+.. code-block:: bash
+
+   uv pip install --reinstall \
+      "robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
 
 **RLDX-1 checkpoint**
 
@@ -96,7 +102,9 @@ fine-tune). Download it from HuggingFace:
 
 .. code-block:: bash
 
-   hf download RLWRLD/RLDX-1-FT-RC365 --local-dir ./checkpoints/rldx-1-ft-rc365
+   hf download RLWRLD/RLDX-1-FT-RC365 \
+      --revision 587e9ecdcc5e7184fcc17f58713908edff5af041 \
+      --local-dir ./checkpoints/rldx-1-ft-rc365
 
 If the download is slow, use the HF mirror:
 
@@ -106,9 +114,13 @@ If the download is slow, use the HF mirror:
 
 **Task memory**
 
-Default evaluation syncs the ``robocasa/**`` subtree from the
-``RLinf/RPent-memory`` Hugging Face dataset into ``memory/robocasa``. The
-current task may use only these task-matched files under ``task_only/``:
+Before every ordinary run with the default ``hf`` profile, RPent's shared
+memory manager synchronizes the ``robocasa/**`` subtree from the
+`RLinf/RPent-memory dataset
+<https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/task_only>`_
+into ``memory/robocasa``. An online ordinary run therefore requires no separate
+memory download. The current task may use only these task-matched files under
+``task_only/``:
 
 .. code-block:: text
 
@@ -116,29 +128,85 @@ current task may use only these task-matched files under ``task_only/``:
    memory/robocasa/task_only/<Task>_s0_recipe.jsonl
    memory/robocasa/task_only/<Task>.md  # optional
 
-The JSON/JSONL pair contains reviewed seed-0 evidence. The optional Markdown
-file contains task-specific exploration memory and may summarize multiple
-attempts; 16 Composite-Seen and 9 Composite-Unseen tasks currently provide one.
-The prompt requires the planner to read every current-task file that exists
-before acting. RPent makes those files available through ``read_text_file``
-but does not inject their contents into the prompt.
+The final published corpus contains 43 audit JSON files, 43 recipe JSONL files,
+and 25 task Markdown files, for 111 files in total and no global memory. The
+JSON/JSONL pair contains reviewed seed-0 evidence. The optional Markdown file
+contains task-specific exploration memory and may summarize multiple attempts;
+all 16 Composite-Seen and 9 Composite-Unseen tasks provide one. The prompt
+requires the planner to read every current-task file that exists before acting.
+RPent makes those files available through ``read_text_file`` but does not inject
+their contents into the prompt.
 
 RoboCasa never asks the planner to use global memory or another task's memory.
-If a current-task file is absent, ``read_text_file`` reports it as missing and
-the planner continues with the available task files and live observations.
-To use reviewed local files instead, select the local profile and pass the
-memory directory:
+Seven Composite-Unseen tasks have no task memory and remain in the evaluation:
+``HeatKebabSandwich``, ``PanTransfer``, ``PortionHotDogs``,
+``SeparateFreezerRack``, ``WaffleReheat``, ``WashFruitColander``, and
+``WeighIngredients``. They continue from live observations. Memory is strategy
+evidence; historical coordinates, poses, pixels, and subtask prompts must not
+replace current localization or the live task language.
+
+Ordinary runs synchronize Hugging Face ``main``. Formal Target50 runs use the
+immutable memory snapshot
+``551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b``:
+
+.. code-block:: bash
+
+   hf download RLinf/RPent-memory \
+      --repo-type dataset \
+      --revision 551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b \
+      --include "robocasa/**" \
+      --local-dir ./target50-memory
+
+Select the local profile and pass the directory containing the frozen results
+corpus:
 
 .. code-block:: bash
 
    rpent --robot robocasa --task-name OpenDrawer --seed 1 \
-         --vla-model-path /path/to/rldx --planner claude_code \
-         --memory-profile local --memory-dir /path/to/robocasa-memory
+         --vla-model-path ./checkpoints/rldx-1-ft-rc365 \
+         --planner claude_code --model claude-opus-4-8 \
+         --memory-profile local \
+         --memory-dir ./target50-memory/robocasa
 
-Available task list
--------------------
+Target50 evaluation protocol
+----------------------------
 
-The 50 tasks used in RPent split into three groups:
+``robots/robocasa/eval/target50.json`` is the canonical manifest. It freezes the
+``target`` environment split, dependency revisions, memory scope, task and seed
+matrix, cell time limits, success source, and retry policy. Its protocol ID is
+``robocasa-harness-vla-v1``:
+
+.. list-table:: RoboCasa Target50 matrix
+   :header-rows: 1
+   :widths: 30 15 20 20 15
+
+   * - Split
+     - Tasks
+     - Seeds per task
+     - Cell timeout
+     - Cells
+   * - Atomic
+     - 18
+     - 1--10
+     - 1800 s
+     - 180
+   * - Composite-Seen
+     - 16
+     - 1--5
+     - 3600 s
+     - 80
+   * - Composite-Unseen
+     - 16
+     - 1--5
+     - 3600 s
+     - 80
+   * - **Total**
+     - **50**
+     -
+     -
+     - **340**
+
+The tasks split into three groups:
 
 - **Atomic (18)** — single-primitive articulation and pick-place
   tasks: ``CloseBlenderLid``, ``CloseFridge``,
@@ -179,7 +247,7 @@ are visible under ``rpent --robot robocasa --help``:
    rpent --robot robocasa \
          --task-name OpenDrawer \
          --split target \
-         --seed 0 \
+         --seed 1 \
          --vla-model-path /path/to/rldx \
          --planner claude_code \
          --model claude-opus-4-8
@@ -187,12 +255,72 @@ are visible under ``rpent --robot robocasa --help``:
 RoboCasa does not select a planner implementation; any planner supported by
 RPent can run this robot. See :doc:`configure_planner` for configuration.
 
+For Target50, first download the fixed resources above, then invoke one ordinary
+command for each manifest cell. The Codex reference profile is ``gpt-5.5``,
+``xhigh``, and ``max_turns=100``; RoboCasa itself remains planner-agnostic. For
+example, the first ``OpenDrawer`` Atomic cell is:
+
+.. code-block:: bash
+
+   rpent --robot robocasa \
+         --task-name OpenDrawer --split target --seed 1 \
+         --vla-model-path ./checkpoints/rldx-1-ft-rc365 --cuda-device 0 \
+         --planner codex --model gpt-5.5 --reasoning-effort xhigh \
+         --max-turns 100 --planner-timeout-s 1800 \
+         --memory-profile local \
+         --memory-dir ./target50-memory/robocasa/results \
+         --output-dir ./runs/target50/atomic/OpenDrawer_s1
+
+Use ``--planner-timeout-s 3600`` for either composite split. Execute Atomic,
+Composite-Seen, and Composite-Unseen in that order. A cell succeeds only when
+the final recorded environment state has ``state.success=true``; the planner's
+``finish(status=...)`` argument is not an evaluation label. Valid task failures
+and planner timeouts are not retried. Retry an infrastructure failure only when
+no valid environment result was produced for that cell.
+
 .. note::
 
    Use ``--env-endpoint`` / ``--vla-endpoint`` to point at already-running
    servers (``[protocol://]host:port``); when omitted, RPent spawns the env
    and VLA daemons in-process and writes their logs to
    ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
+
+Published Target50 results
+--------------------------
+
+The published Codex reproduction contains all 340 cells and reports the
+following task-level aggregates:
+
+.. list-table:: Codex Target50 reproduction
+   :header-rows: 1
+   :widths: 30 20 20 30
+
+   * - Split
+     - Successful cells
+     - Success rate
+     - Harness VLA reference
+   * - Atomic
+     - 163/180
+     - 90.56%
+     - 165/180 (91.67%)
+   * - Composite-Seen
+     - 49/80
+     - 61.25%
+     - 45/80 (56.25%)
+   * - Composite-Unseen
+     - 12/80
+     - 15.00%
+     - 11/80 (13.75%)
+   * - Overall (task-weighted)
+     - 224/340 cells
+     - 57.00%
+     - 55.40%
+
+The `complete per-task table
+<https://github.com/RLinf/RPent/blob/main/robots/robocasa/eval/target50_codex_results.md>`_
+contains the success count and accuracy for every task. The published record is
+task-level aggregate data; it does not include per-seed traces, raw trajectories,
+or failure classifications and therefore is not a per-cell audit artifact.
 
 Troubleshooting
 ---------------

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -12,8 +12,7 @@ for the wire/transport selection.
 
    The public Target50 protocol is frozen in
    ``robots/robocasa/eval/target50.json``. RPent uses ordinary single-task
-   ``rpent --robot robocasa`` commands for its 340 cells and does not ship a
-   benchmark batch launcher.
+   ``rpent --robot robocasa`` commands for its 340 cells.
 
 Installation
 ------------
@@ -119,8 +118,9 @@ If the download is slow, use the HF mirror:
 
 **Task memory**
 
-Before every ordinary run with the default ``hf`` profile, RPent's shared
-memory manager synchronizes the ``robocasa/**`` subtree from the
+Select automatic synchronization with ``--memory-profile hf`` (the default).
+Before every such ordinary run, RPent's shared memory manager synchronizes the
+``robocasa/**`` subtree from the
 `RLinf/RPent-memory dataset
 <https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/task_only>`_
 into ``memory/robocasa``. An online ordinary run therefore requires no separate
@@ -173,12 +173,13 @@ corpus:
          --memory-profile local \
          --memory-dir ./target50-memory/robocasa
 
-Target50 evaluation protocol
-----------------------------
+Harness VLA Target50 reproduction protocol
+-------------------------------------------
 
-``robots/robocasa/eval/target50.json`` is the canonical manifest. It freezes the
-``target`` environment split, dependency revisions, memory scope, task and seed
-matrix, cell time limits, success source, and retry policy. Its protocol ID is
+``robots/robocasa/eval/target50.json`` is the canonical manifest for reproducing
+Harness VLA on RoboCasa Target50. It freezes the ``target`` environment split,
+dependency revisions, memory scope, task and seed matrix, cell time limits,
+success source, and retry policy. Its protocol ID is
 ``robocasa-harness-vla-v1``:
 
 .. list-table:: RoboCasa Target50 matrix

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -89,9 +89,9 @@ Re-run with ``--skip-existing`` to leave downloaded folders alone.
 
 The ``robocasa`` extra installs the ``rpent`` branch of ``RLinf/robosuite``,
 which provides the Omron base's fixed ``navview`` camera. Its composed MuJoCo
-name is ``mobilebase0_navview``. RPent does not run a separate reset-time
-camera preflight; a missing camera fails when navigation RGB-D or world-map
-rendering first requests it. No manual ``site-packages`` XML patch is required.
+name is ``mobilebase0_navview``. Navigation RGB-D and world-map rendering
+validate the camera when they first request it, and report an error if it is
+missing. No manual ``site-packages`` XML patch is required.
 Target50 freezes the resolved Robosuite revision at
 ``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``. The Target50 override in the
 installation command above selects that exact revision.
@@ -122,16 +122,16 @@ Select automatic synchronization with ``--memory-profile hf`` (the default).
 Before every such ordinary run, RPent's shared memory manager synchronizes the
 ``robocasa/**`` subtree from the
 `RLinf/RPent-memory dataset
-<https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/task_only>`_
+<https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/results>`_
 into ``memory/robocasa``. An online ordinary run therefore requires no separate
 memory download. The current task may use only these task-matched files under
-``task_only/``:
+``results/``:
 
 .. code-block:: text
 
-   memory/robocasa/task_only/<Task>_s0.json
-   memory/robocasa/task_only/<Task>_s0_recipe.jsonl
-   memory/robocasa/task_only/<Task>.md  # optional
+   memory/robocasa/results/<Task>_s0.json
+   memory/robocasa/results/recipe_<Task>_s0.jsonl
+   memory/robocasa/results/<Task>.md  # optional
 
 The final published corpus contains 43 audit JSON files, 43 recipe JSONL files,
 and 25 task Markdown files, for 111 files in total and no global memory. The
@@ -277,7 +277,8 @@ For Target50, first download the fixed resources above, then invoke one ordinary
 command for each manifest cell. The Codex reference profile is ``gpt-5.5``,
 ``xhigh``, and ``max_turns=100``; RoboCasa itself remains planner-agnostic. For
 the scene identity, use the ordinary ``--seed`` argument and do not set
-``RLDX_RESET_SEED``. Freeze the RLDX execution values first:
+``RLDX_RESET_SEED``. Ordinary RoboCasa uses ``max_chunks=70``; Target50 alone
+overrides it to 40. Freeze the Target50 RLDX execution values first:
 
 .. code-block:: bash
 
@@ -296,7 +297,7 @@ The first ``OpenDrawer`` Atomic cell is:
          --planner codex --model gpt-5.5 --reasoning-effort xhigh \
          --max-turns 100 --planner-timeout-s 1800 \
          --memory-profile local \
-         --memory-dir ./target50-memory/robocasa/results \
+         --memory-dir ./target50-memory/robocasa \
          --output-dir ./runs/target50/atomic/OpenDrawer_s1
 
 Use ``--planner-timeout-s 3600`` for either composite split. Execute Atomic,
@@ -368,7 +369,7 @@ Troubleshooting
   ``RLinf/robosuite`` ``rpent`` branch. Do not patch installed XML files
   manually.
 - If ``read_text_file`` reports a missing current-task result, check the
-  ``memory/robocasa/task_only/`` corpus or the selected local directory.
+  ``memory/robocasa/results/`` corpus or the selected local directory.
   RPent does not fall back to another task's memory.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -245,19 +245,17 @@ larger; see the `RoboCasa <https://robocasa.ai>`_ upstream.
 Running a task
 --------------
 
-RPent starts its default environment and VLA workers on loopback addresses. If
-the launch shell defines ``HTTP_PROXY`` or ``HTTPS_PROXY``, keep that proxy for
-remote services while exempting local RPC in both commonly recognized forms:
+RPent-owned environment and VLA workers use request-local direct HTTP clients.
+Codex likewise adds loopback exclusions only to its child process for the local
+MCP connection. Leave ``HTTP_PROXY`` and ``HTTPS_PROXY`` unchanged when remote
+services require them; the default runtime does not require a shell-wide
+``NO_PROXY`` setup.
 
-.. code-block:: bash
-
-   export NO_PROXY="${NO_PROXY:+${NO_PROXY},}127.0.0.1,localhost,::1"
-   export no_proxy="${no_proxy:+${no_proxy},}127.0.0.1,localhost,::1"
-
-These assignments preserve existing exclusions. If ``--env-endpoint`` or
-``--vla-endpoint`` names another local host or IP, add that exact value to both
-variables. Hugging Face, remote planners, and other remote endpoints continue
-to use the configured proxy.
+User-supplied ``--env-endpoint`` and ``--vla-endpoint`` values deliberately
+honor the standard proxy environment. If such an endpoint is local and should
+be reached directly, add its exact hostname or IP to the user's existing
+``NO_PROXY`` and ``no_proxy`` configuration. This choice does not affect
+Hugging Face, a remote planner, or other remote endpoints.
 
 The RoboCasa CLI flags are registered by ``robots/robocasa/__init__`` and
 are visible under ``rpent --robot robocasa --help``:
@@ -279,8 +277,7 @@ For Target50, first download the fixed resources above, then invoke one ordinary
 command for each manifest cell. The Codex reference profile is ``gpt-5.5``,
 ``xhigh``, and ``max_turns=100``; RoboCasa itself remains planner-agnostic. For
 the scene identity, use the ordinary ``--seed`` argument and do not set
-``RLDX_RESET_SEED``. Keep the loopback ``NO_PROXY`` / ``no_proxy`` settings
-above and freeze the RLDX execution values first:
+``RLDX_RESET_SEED``. Freeze the RLDX execution values first:
 
 .. code-block:: bash
 
@@ -375,10 +372,10 @@ Troubleshooting
   RPent does not fall back to another task's memory.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
-- If local RPC is sent through an HTTP proxy, set both ``NO_PROXY`` and
-  ``no_proxy`` as shown under "Running a task". Keep ``HTTP_PROXY`` and
-  ``HTTPS_PROXY`` for remote traffic, and add any custom local endpoint host to
-  the exclusions.
+- A user-supplied local ``--env-endpoint`` or ``--vla-endpoint`` follows the
+  standard proxy environment. Add that host to the user's ``NO_PROXY`` and
+  ``no_proxy`` configuration only when it should be reached directly.
+  RPent-owned workers need no proxy setup.
 
 Toolkit design vs. LIBERO
 -------------------------

--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -244,6 +244,20 @@ larger; see the `RoboCasa <https://robocasa.ai>`_ upstream.
 Running a task
 --------------
 
+RPent starts its default environment and VLA workers on loopback addresses. If
+the launch shell defines ``HTTP_PROXY`` or ``HTTPS_PROXY``, keep that proxy for
+remote services while exempting local RPC in both commonly recognized forms:
+
+.. code-block:: bash
+
+   export NO_PROXY="${NO_PROXY:+${NO_PROXY},}127.0.0.1,localhost,::1"
+   export no_proxy="${no_proxy:+${no_proxy},}127.0.0.1,localhost,::1"
+
+These assignments preserve existing exclusions. If ``--env-endpoint`` or
+``--vla-endpoint`` names another local host or IP, add that exact value to both
+variables. Hugging Face, remote planners, and other remote endpoints continue
+to use the configured proxy.
+
 The RoboCasa CLI flags are registered by ``robots/robocasa/__init__`` and
 are visible under ``rpent --robot robocasa --help``:
 
@@ -264,7 +278,8 @@ For Target50, first download the fixed resources above, then invoke one ordinary
 command for each manifest cell. The Codex reference profile is ``gpt-5.5``,
 ``xhigh``, and ``max_turns=100``; RoboCasa itself remains planner-agnostic. For
 the scene identity, use the ordinary ``--seed`` argument and do not set
-``RLDX_RESET_SEED``. Freeze the RLDX execution values first:
+``RLDX_RESET_SEED``. Keep the loopback ``NO_PROXY`` / ``no_proxy`` settings
+above and freeze the RLDX execution values first:
 
 .. code-block:: bash
 
@@ -359,9 +374,10 @@ Troubleshooting
   RPent does not fall back to another task's memory.
 - Environment and VLA startup failures are recorded in
   ``<output_dir>/env_server.log`` and ``<output_dir>/vla_server.log``.
-- Local ``127.0.0.1`` and ``localhost`` RPC endpoints must bypass
-  ``HTTP_PROXY`` and ``HTTPS_PROXY``. Update RPent if a local endpoint is still
-  sent through a configured proxy.
+- If local RPC is sent through an HTTP proxy, set both ``NO_PROXY`` and
+  ``no_proxy`` as shown under "Running a task". Keep ``HTTP_PROXY`` and
+  ``HTTPS_PROXY`` for remote traffic, and add any custom local endpoint host to
+  the exclusions.
 
 Toolkit design vs. LIBERO
 -------------------------

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -226,15 +226,14 @@ task/seed 矩阵、cell 时限、成功来源与重试规则；协议 ID 为
 运行一个任务
 ------------
 
-RPent 自己启动的环境与 VLA worker 使用 request-local 的 HTTP 直连客户端。
-Codex 也只在其子进程环境中为本地 MCP 追加 loopback 排除项。如果远程服务需要
-``HTTP_PROXY`` 或 ``HTTPS_PROXY``，请保持原有代理；默认运行不再要求 shell 统一
-配置 ``NO_PROXY``。
+HTTP RPC endpoint 的主机名为 ``127.0.0.1`` 或 ``localhost`` 时一律直连，无论
+worker 由 RPent 启动还是由用户指定。其他主机名与 IP 均遵循标准代理环境。Codex
+只在其子进程环境中为本地 MCP 应用相同的两个主机名例外。如果 Hugging Face、
+远程 planner 或其他远程服务需要 ``HTTP_PROXY`` 或 ``HTTPS_PROXY``，请保持原有
+代理；默认运行不要求 shell 统一配置 ``NO_PROXY``。
 
-用户通过 ``--env-endpoint`` 或 ``--vla-endpoint`` 指定的服务会遵循标准代理环境。
-如果该 endpoint 位于本地且应当直连，请将准确的主机名或 IP 加入用户已有的
-``NO_PROXY`` 与 ``no_proxy`` 配置。该选择不会影响 Hugging Face、远程 planner
-或其他远程 endpoint。
+如果用户指定的本地服务使用其他主机名或 IP 且应当直连，请将该准确值加入用户
+已有的 ``NO_PROXY`` 与 ``no_proxy`` 配置。
 
 RoboCasa 的 CLI 参数由 ``robots/robocasa/__init__`` 注册，可通过
 ``rpent --robot robocasa --help`` 查看:
@@ -344,9 +343,9 @@ trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
   memory 作为替代。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
-- 用户指定的本地 ``--env-endpoint`` 或 ``--vla-endpoint`` 会遵循标准代理环境。
-  只有该服务应当直连时，才需要把主机名加入用户的 ``NO_PROXY`` 与
-  ``no_proxy`` 配置；RPent 自己启动的 worker 无需代理设置。
+- 只有准确的 ``127.0.0.1`` 与 ``localhost`` 主机名会自动绕过 HTTP 代理。其他
+  主机名与 IP 均遵循标准代理环境；只有该服务应当直连时，才需要把准确主机名
+  加入 ``NO_PROXY`` 与 ``no_proxy`` 配置。
 
 Toolkit 与 LIBERO 的差异
 ------------------------

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -10,8 +10,7 @@ RoboCasa
 .. note::
 
    公开的 Target50 协议固定在 ``robots/robocasa/eval/target50.json`` 中。
-   340 个 cell 均使用普通的单任务 ``rpent --robot robocasa`` 命令；RPent
-   不提供 benchmark 批量启动器。
+   340 个 cell 均使用普通的单任务 ``rpent --robot robocasa`` 命令。
 
 安装
 ----
@@ -109,7 +108,8 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 
 **任务 Memory**
 
-每次使用默认 ``hf`` profile 普通运行前，RPent 都会通过统一 memory manager，从
+通过 ``--memory-profile hf``（默认值）启用自动同步。每次以该 profile 普通
+运行前，RPent 都会通过统一 memory manager，从
 `RLinf/RPent-memory 数据集
 <https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/task_only>`_
 自动同步 ``robocasa/**`` 到 ``memory/robocasa``，因此在线普通运行无需单独下载
@@ -156,12 +156,13 @@ RoboCasa 不要求 planner 使用 global memory，也不会退回读取其他任
          --memory-profile local \
          --memory-dir ./target50-memory/robocasa
 
-Target50 评测协议
------------------
+Harness VLA Target50 复现协议
+-----------------------------
 
-``robots/robocasa/eval/target50.json`` 是唯一规范清单，固定 ``target`` 环境
-split、依赖 revision、memory 边界、task/seed 矩阵、cell 时限、成功来源与重试
-规则；协议 ID 为 ``robocasa-harness-vla-v1``：
+``robots/robocasa/eval/target50.json`` 是 Harness VLA 在 RoboCasa Target50
+上的规范复现清单。它固定 ``target`` 环境 split、依赖 revision、memory 边界、
+task/seed 矩阵、cell 时限、成功来源与重试规则；协议 ID 为
+``robocasa-harness-vla-v1``：
 
 .. list-table:: RoboCasa Target50 矩阵
    :header-rows: 1

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -81,8 +81,8 @@ macros 配置：
 
 ``robocasa`` extra 会安装 ``RLinf/robosuite`` 的 ``rpent`` 分支，该分支
 包含 Omron 底盘固定的 ``navview`` 相机，其组合后的 MuJoCo 相机名为
-``mobilebase0_navview``。RPent 不再执行单独的 reset-time 相机预检；如果相机
-缺失，首次请求导航 RGB-D 或 world map 渲染时会自然报错。无需手工修改
+``mobilebase0_navview``。导航 RGB-D 与 world map 渲染会在首次请求时验证该
+相机，并在缺失时明确报错。无需手工修改
 ``site-packages`` 中的 XML。Target50 将 Robosuite 固定为
 ``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``；上面安装命令中的 Target50
 override 会直接选中这一 revision。
@@ -111,15 +111,15 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 通过 ``--memory-profile hf``（默认值）启用自动同步。每次以该 profile 普通
 运行前，RPent 都会通过统一 memory manager，从
 `RLinf/RPent-memory 数据集
-<https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/task_only>`_
+<https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/results>`_
 自动同步 ``robocasa/**`` 到 ``memory/robocasa``，因此在线普通运行无需单独下载
-memory。当前任务只能读取 ``task_only/`` 下与该任务对应的 memory：
+memory。当前任务只能读取 ``results/`` 下与该任务对应的 memory：
 
 .. code-block:: text
 
-   memory/robocasa/task_only/<Task>_s0.json
-   memory/robocasa/task_only/<Task>_s0_recipe.jsonl
-   memory/robocasa/task_only/<Task>.md  # 可选
+   memory/robocasa/results/<Task>_s0.json
+   memory/robocasa/results/recipe_<Task>_s0.jsonl
+   memory/robocasa/results/<Task>.md  # 可选
 
 最终发布的 corpus 包含 43 个 audit JSON、43 个 recipe JSONL 和 25 个任务
 Markdown，共 111 个文件且不含 global memory。JSON/JSONL pair 保存经过审核的
@@ -146,7 +146,7 @@ RoboCasa 不要求 planner 使用 global memory，也不会退回读取其他任
       --include "robocasa/**" \
       --local-dir ./target50-memory
 
-随后选择 local profile，并传入固定的 results corpus 目录：
+随后选择 local profile，并传入固定的 RoboCasa memory 根目录：
 
 .. code-block:: bash
 
@@ -254,7 +254,8 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 正式 Target50 先按上文下载固定资源，再为 manifest 中每个 cell 调用一次普通
 命令。Codex 参考 profile 为 ``gpt-5.5``、``xhigh``、``max_turns=100``；
 RoboCasa 运行时本身仍与 planner 解耦。场景身份直接使用普通 ``--seed`` 参数，
-不要设置 ``RLDX_RESET_SEED``，并先固定 RLDX 执行参数：
+不要设置 ``RLDX_RESET_SEED``。普通 RoboCasa 使用 ``max_chunks=70``，只有
+Target50 将其覆盖为 40。运行前固定 Target50 的 RLDX 执行参数：
 
 .. code-block:: bash
 
@@ -273,7 +274,7 @@ RoboCasa 运行时本身仍与 planner 解耦。场景身份直接使用普通 `
          --planner codex --model gpt-5.5 --reasoning-effort xhigh \
          --max-turns 100 --planner-timeout-s 1800 \
          --memory-profile local \
-         --memory-dir ./target50-memory/robocasa/results \
+         --memory-dir ./target50-memory/robocasa \
          --output-dir ./runs/target50/atomic/OpenDrawer_s1
 
 Composite-Seen 与 Composite-Unseen 使用 ``--planner-timeout-s 3600``。执行顺序为
@@ -339,7 +340,7 @@ trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
   安装 ``.[robocasa]`` 以刷新 ``RLinf/robosuite`` 的 ``rpent`` 分支；不要手工
   修改已安装的 XML。
 - ``read_text_file`` 报告缺少当前任务结果时，请检查
-  ``memory/robocasa/task_only/`` 目录或所选本地目录。RPent 不会读取其他任务的
+  ``memory/robocasa/results/`` 目录或所选本地目录。RPent 不会读取其他任务的
   memory 作为替代。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -225,6 +225,19 @@ split、依赖 revision、memory 边界、task/seed 矩阵、cell 时限、成�
 运行一个任务
 ------------
 
+RPent 默认在 loopback 地址上启动环境与 VLA worker。如果启动 shell 配置了
+``HTTP_PROXY`` 或 ``HTTPS_PROXY``，请保留远程服务所需的代理，同时通过大小写
+两种常用环境变量排除本地 RPC：
+
+.. code-block:: bash
+
+   export NO_PROXY="${NO_PROXY:+${NO_PROXY},}127.0.0.1,localhost,::1"
+   export no_proxy="${no_proxy:+${no_proxy},}127.0.0.1,localhost,::1"
+
+上述写法会保留已有排除项。如果 ``--env-endpoint`` 或 ``--vla-endpoint`` 使用
+其他本地主机名或 IP，请把该值也加入两个变量。Hugging Face、远程 planner 及
+其他远程 endpoint 仍使用原有代理。
+
 RoboCasa 的 CLI 参数由 ``robots/robocasa/__init__`` 注册，可通过
 ``rpent --robot robocasa --help`` 查看:
 
@@ -244,7 +257,8 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 正式 Target50 先按上文下载固定资源，再为 manifest 中每个 cell 调用一次普通
 命令。Codex 参考 profile 为 ``gpt-5.5``、``xhigh``、``max_turns=100``；
 RoboCasa 运行时本身仍与 planner 解耦。场景身份直接使用普通 ``--seed`` 参数，
-不要设置 ``RLDX_RESET_SEED``。先固定 RLDX 执行参数：
+不要设置 ``RLDX_RESET_SEED``。保留上面的 loopback ``NO_PROXY`` / ``no_proxy``
+设置，并先固定 RLDX 执行参数：
 
 .. code-block:: bash
 
@@ -333,8 +347,9 @@ trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
   memory 作为替代。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
-- 本地 ``127.0.0.1`` 与 ``localhost`` RPC 必须绕过 ``HTTP_PROXY`` 和
-  ``HTTPS_PROXY``。如果本地 endpoint 仍被发往代理，请更新 RPent。
+- 如果本地 RPC 被发往 HTTP 代理，请按“运行一个任务”同时设置 ``NO_PROXY``
+  与 ``no_proxy``。保留远程流量所需的 ``HTTP_PROXY`` 和 ``HTTPS_PROXY``，并
+  将自定义本地 endpoint 的主机名加入排除列表。
 
 Toolkit 与 LIBERO 的差异
 ------------------------

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -22,21 +22,28 @@ RLDX-1 要求 Python ``3.10``。请创建独立环境，并通过 ``.[robocasa]`
 .. code-block:: bash
 
    uv venv --python 3.10
+   source .venv/bin/activate
    uv pip install -e ".[robocasa]" \
-      "torch==2.7.0" "torchvision==0.22.0" \
+      --constraint robots/robocasa/eval/target50-constraints.txt \
+      --override robots/robocasa/eval/target50-overrides.txt \
       --torch-backend=cu126
+   uv pip check
 
-该命令固定 RLDX-1 使用的 Torch 版本组合，并让 uv 只为 Torch 选择官方 CUDA
-wheel，避免把 PyTorch wheel 源作为通用 ``--index`` 后，在默认 first-index
-策略下误选其中的旧版无关依赖。上面的 ``cu126`` 是已验证的 CUDA 安装方式；
-仅当宿主机确有需要时才切换到其他受支持的 Torch backend。
+RoboCasa 专用 constraints 文件固定经 Target50 复现验证的兼容性敏感包版本，
+同时不会收窄 RPent 中 LIBERO 或 RoboTwin 的共享依赖。配套 override 文件让
+正式环境直接解析到不可变的 Robosuite revision，而普通 ``robocasa`` extra
+仍跟随维护中的 ``rpent`` 分支。该命令让 uv 只为 Torch 选择官方 CUDA wheel，
+避免把 PyTorch wheel 源作为通用 ``--index`` 后，在默认 first-index 策略下误选
+其中的旧版无关依赖。上面的 ``cu126`` 是已验证的 CUDA 安装方式；仅当宿主机
+确有需要时才切换到其他受支持的 Torch backend。
 
 国内网络可使用 PyPI 镜像加速：\
 
 .. code-block:: bash
 
    uv pip install -e ".[robocasa]" \
-      "torch==2.7.0" "torchvision==0.22.0" \
+      --constraint robots/robocasa/eval/target50-constraints.txt \
+      --override robots/robocasa/eval/target50-overrides.txt \
       --default-index https://mirrors.aliyun.com/pypi/simple \
       --torch-backend=cu126
 
@@ -55,18 +62,18 @@ wheel，避免把 PyTorch wheel 源作为通用 ``--index`` 后，在默认 firs
 
 **安装后处理**
 
-一条命令即可生成 ``macros_private.py`` 并下载厨房 assets（约 10 GB）。建议
-放在 ``site-packages`` 之外，重装不会丢：
+将厨房 assets（约 10 GB）下载到 ``site-packages`` 之外，重装不会丢。
+Target50 不使用 RoboCasa dataset 或 teleop macros，因此跳过可选的 private
+macros 配置：
 
 .. code-block:: bash
 
-   robocasa-download-assets --assets-path ~/.robocasa/assets -y
+   robocasa-download-assets --assets-path ~/.robocasa/assets --no-macros -y
 
-命令结束时会打印需要导出的环境变量，把它们加到启动 ``rpent`` 的 shell 里：
+命令结束时会打印需要导出的环境变量，把它加到启动 ``rpent`` 的 shell 里：
 
 .. code-block:: bash
 
-   export ROBOCASA_MACROS_PATH=~/.robocasa/macros_private.py
    export ROBOCASA_ASSETS_PATH=~/.robocasa/assets
 
 加 ``--skip-existing`` 重跑会跳过已下载的目录。
@@ -78,12 +85,8 @@ wheel，避免把 PyTorch wheel 源作为通用 ``--index`` 后，在默认 firs
 ``mobilebase0_navview``。RPent 不再执行单独的 reset-time 相机预检；如果相机
 缺失，首次请求导航 RGB-D 或 world map 渲染时会自然报错。无需手工修改
 ``site-packages`` 中的 XML。Target50 将 Robosuite 固定为
-``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``；正式复现时安装该 revision：
-
-.. code-block:: bash
-
-   uv pip install --reinstall \
-      "robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
+``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``；上面安装命令中的 Target50
+override 会直接选中这一 revision。
 
 **RLDX-1 checkpoint**
 
@@ -100,7 +103,9 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 
 .. code-block:: bash
 
-   HF_ENDPOINT=https://hf-mirror.com hf download RLWRLD/RLDX-1-FT-RC365 --local-dir ./checkpoints/rldx-1-ft-rc365
+   HF_ENDPOINT=https://hf-mirror.com hf download RLWRLD/RLDX-1-FT-RC365 \
+      --revision 587e9ecdcc5e7184fcc17f58713908edff5af041 \
+      --local-dir ./checkpoints/rldx-1-ft-rc365
 
 **任务 Memory**
 
@@ -238,7 +243,17 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 
 正式 Target50 先按上文下载固定资源，再为 manifest 中每个 cell 调用一次普通
 命令。Codex 参考 profile 为 ``gpt-5.5``、``xhigh``、``max_turns=100``；
-RoboCasa 运行时本身仍与 planner 解耦。第一个 ``OpenDrawer`` Atomic cell 示例：
+RoboCasa 运行时本身仍与 planner 解耦。场景身份直接使用普通 ``--seed`` 参数，
+不要设置 ``RLDX_RESET_SEED``。先固定 RLDX 执行参数：
+
+.. code-block:: bash
+
+   export RLDX_MAX_CHUNKS=40
+   export RLDX_SETTLE_PATIENCE=999
+   export RLDX_ACTION_STEPS_PER_CHUNK=8
+   unset RLDX_RESET_SEED
+
+第一个 ``OpenDrawer`` Atomic cell 示例：
 
 .. code-block:: bash
 
@@ -255,6 +270,15 @@ Composite-Seen 与 Composite-Unseen 使用 ``--planner-timeout-s 3600``。执行
 Atomic、Composite-Seen、Composite-Unseen。成功只认最终环境记录中的
 ``state.success=true``，planner 的 ``finish(status=...)`` 不是评测标签。有效任务
 失败与 planner timeout 不重跑；只有没有产生有效环境结果的基础设施失败允许重跑。
+
+每条完成的命令都会原子写入 ``<output-dir>/result.json``，成功值只来自最终环境
+``state.success``。文件记录有效协议参数，但不保存 provider 错误原文或凭据。全部
+cell 按 ``<results-root>/<manifest-split>/<Task>_s<seed>/result.json`` 落盘后，
+用下面命令校验固定分母并输出任务加权指标：
+
+.. code-block:: bash
+
+   python -m robots.robocasa.eval.validate_target50 ./runs/target50
 
 .. note::
 
@@ -289,7 +313,7 @@ Atomic、Composite-Seen、Composite-Unseen。成功只认最终环境记录中�
      - 15.00%
      - 11/80 (13.75%)
    * - 总体（任务加权）
-     - 224/340 cells
+     - 不适用
      - 57.00%
      - 55.40%
 
@@ -309,6 +333,8 @@ trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
   memory 作为替代。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
+- 本地 ``127.0.0.1`` 与 ``localhost`` RPC 必须绕过 ``HTTP_PROXY`` 和
+  ``HTTPS_PROXY``。如果本地 endpoint 仍被发往代理，请更新 RPent。
 
 Toolkit 与 LIBERO 的差异
 ------------------------

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -226,18 +226,15 @@ task/seed 矩阵、cell 时限、成功来源与重试规则；协议 ID 为
 运行一个任务
 ------------
 
-RPent 默认在 loopback 地址上启动环境与 VLA worker。如果启动 shell 配置了
-``HTTP_PROXY`` 或 ``HTTPS_PROXY``，请保留远程服务所需的代理，同时通过大小写
-两种常用环境变量排除本地 RPC：
+RPent 自己启动的环境与 VLA worker 使用 request-local 的 HTTP 直连客户端。
+Codex 也只在其子进程环境中为本地 MCP 追加 loopback 排除项。如果远程服务需要
+``HTTP_PROXY`` 或 ``HTTPS_PROXY``，请保持原有代理；默认运行不再要求 shell 统一
+配置 ``NO_PROXY``。
 
-.. code-block:: bash
-
-   export NO_PROXY="${NO_PROXY:+${NO_PROXY},}127.0.0.1,localhost,::1"
-   export no_proxy="${no_proxy:+${no_proxy},}127.0.0.1,localhost,::1"
-
-上述写法会保留已有排除项。如果 ``--env-endpoint`` 或 ``--vla-endpoint`` 使用
-其他本地主机名或 IP，请把该值也加入两个变量。Hugging Face、远程 planner 及
-其他远程 endpoint 仍使用原有代理。
+用户通过 ``--env-endpoint`` 或 ``--vla-endpoint`` 指定的服务会遵循标准代理环境。
+如果该 endpoint 位于本地且应当直连，请将准确的主机名或 IP 加入用户已有的
+``NO_PROXY`` 与 ``no_proxy`` 配置。该选择不会影响 Hugging Face、远程 planner
+或其他远程 endpoint。
 
 RoboCasa 的 CLI 参数由 ``robots/robocasa/__init__`` 注册，可通过
 ``rpent --robot robocasa --help`` 查看:
@@ -258,8 +255,7 @@ RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该
 正式 Target50 先按上文下载固定资源，再为 manifest 中每个 cell 调用一次普通
 命令。Codex 参考 profile 为 ``gpt-5.5``、``xhigh``、``max_turns=100``；
 RoboCasa 运行时本身仍与 planner 解耦。场景身份直接使用普通 ``--seed`` 参数，
-不要设置 ``RLDX_RESET_SEED``。保留上面的 loopback ``NO_PROXY`` / ``no_proxy``
-设置，并先固定 RLDX 执行参数：
+不要设置 ``RLDX_RESET_SEED``，并先固定 RLDX 执行参数：
 
 .. code-block:: bash
 
@@ -348,9 +344,9 @@ trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
   memory 作为替代。
 - 环境与 VLA 启动错误会分别记录在 ``<output_dir>/env_server.log`` 和
   ``<output_dir>/vla_server.log``。
-- 如果本地 RPC 被发往 HTTP 代理，请按“运行一个任务”同时设置 ``NO_PROXY``
-  与 ``no_proxy``。保留远程流量所需的 ``HTTP_PROXY`` 和 ``HTTPS_PROXY``，并
-  将自定义本地 endpoint 的主机名加入排除列表。
+- 用户指定的本地 ``--env-endpoint`` 或 ``--vla-endpoint`` 会遵循标准代理环境。
+  只有该服务应当直连时，才需要把主机名加入用户的 ``NO_PROXY`` 与
+  ``no_proxy`` 配置；RPent 自己启动的 worker 无需代理设置。
 
 Toolkit 与 LIBERO 的差异
 ------------------------

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -9,8 +9,9 @@ RoboCasa
 
 .. note::
 
-   本页只说明普通的单任务 ``rpent --robot robocasa`` 运行方式，不定义
-   Atomic/Seen/Unseen 全量 benchmark 的正式复现协议。
+   公开的 Target50 协议固定在 ``robots/robocasa/eval/target50.json`` 中。
+   340 个 cell 均使用普通的单任务 ``rpent --robot robocasa`` 命令；RPent
+   不提供 benchmark 批量启动器。
 
 安装
 ----
@@ -75,11 +76,14 @@ wheel，避免把 PyTorch wheel 源作为通用 ``--index`` 后，在默认 firs
 ``robocasa`` extra 会安装 ``RLinf/robosuite`` 的 ``rpent`` 分支，该分支
 包含 Omron 底盘固定的 ``navview`` 相机，其组合后的 MuJoCo 相机名为
 ``mobilebase0_navview``。RPent 不再执行单独的 reset-time 相机预检；如果相机
-缺失，首次请求导航 RGB-D 或 world map 渲染时会自然报错。此时重新安装
-``.[robocasa]`` 以刷新该分支即可，无需手工修改 ``site-packages`` 中的 XML。
-本 PR 验证时该分支解析为 commit
-``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``；发布实验结果时应记录实际解析
-到的 commit。
+缺失，首次请求导航 RGB-D 或 world map 渲染时会自然报错。无需手工修改
+``site-packages`` 中的 XML。Target50 将 Robosuite 固定为
+``97cfbde4b68d8ec43dad20cf4747297866a6ca2e``；正式复现时安装该 revision：
+
+.. code-block:: bash
+
+   uv pip install --reinstall \
+      "robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
 
 **RLDX-1 checkpoint**
 
@@ -88,7 +92,9 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 
 .. code-block:: bash
 
-   hf download RLWRLD/RLDX-1-FT-RC365 --local-dir ./checkpoints/rldx-1-ft-rc365
+   hf download RLWRLD/RLDX-1-FT-RC365 \
+      --revision 587e9ecdcc5e7184fcc17f58713908edff5af041 \
+      --local-dir ./checkpoints/rldx-1-ft-rc365
 
 下载慢的话用 HF 镜像:
 
@@ -98,8 +104,11 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
 
 **任务 Memory**
 
-默认评测会从 Hugging Face 数据集 ``RLinf/RPent-memory`` 同步 ``robocasa/**``
-到 ``memory/robocasa``。当前任务只能读取 ``task_only/`` 下与该任务对应的 memory：
+每次使用默认 ``hf`` profile 普通运行前，RPent 都会通过统一 memory manager，从
+`RLinf/RPent-memory 数据集
+<https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/task_only>`_
+自动同步 ``robocasa/**`` 到 ``memory/robocasa``，因此在线普通运行无需单独下载
+memory。当前任务只能读取 ``task_only/`` 下与该任务对应的 memory：
 
 .. code-block:: text
 
@@ -107,27 +116,79 @@ checkpoint 路径（RoboCasa365 微调版）。从 HuggingFace 下载:
    memory/robocasa/task_only/<Task>_s0_recipe.jsonl
    memory/robocasa/task_only/<Task>.md  # 可选
 
-JSON/JSONL pair 保存经过审核的 seed-0 证据。可选的 Markdown 文件保存同任务
-探索 memory，可能汇总多次尝试；当前 16 个 Composite-Seen 和 9 个
-Composite-Unseen 任务包含此文件。Prompt 要求 planner 在开始动作前主动通过
-``read_text_file`` 读取当前任务所有存在的文件；RPent 不会把 Markdown 内容
-强制注入 prompt。
+最终发布的 corpus 包含 43 个 audit JSON、43 个 recipe JSONL 和 25 个任务
+Markdown，共 111 个文件且不含 global memory。JSON/JSONL pair 保存经过审核的
+seed-0 证据。可选 Markdown 保存同任务探索 memory，可能汇总多次尝试；全部
+16 个 Composite-Seen 和 9 个 Composite-Unseen 任务包含该文件。Prompt 要求
+planner 在开始动作前主动通过 ``read_text_file`` 读取当前任务所有存在的文件；
+RPent 不会把 Markdown 内容强制注入 prompt。
 
-RoboCasa 不要求 planner 使用 global memory，也不会读取其他任务的 memory 作为
-替代。当前任务文件缺失时，``read_text_file`` 会报告该文件不存在，planner 使用
-其余可用的同任务文件和实时观测继续。如需使用经过审核的本地 memory，请使用
-``--memory-profile local`` 并通过 ``--memory-dir`` 指定 memory 目录：
+RoboCasa 不要求 planner 使用 global memory，也不会退回读取其他任务的 memory。
+7 个 Composite-Unseen 任务完全没有 task memory，但仍计入评测：
+``HeatKebabSandwich``、``PanTransfer``、``PortionHotDogs``、
+``SeparateFreezerRack``、``WaffleReheat``、``WashFruitColander`` 和
+``WeighIngredients``；这些任务基于实时观测继续。Memory 仅是策略证据，历史
+坐标、位姿、像素和子任务 prompt 不能替代当前定位与完整实时任务语言。
+
+普通运行同步 Hugging Face ``main``；正式 Target50 使用固定 memory snapshot
+``551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b``：
+
+.. code-block:: bash
+
+   hf download RLinf/RPent-memory \
+      --repo-type dataset \
+      --revision 551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b \
+      --include "robocasa/**" \
+      --local-dir ./target50-memory
+
+随后选择 local profile，并传入固定的 results corpus 目录：
 
 .. code-block:: bash
 
    rpent --robot robocasa --task-name OpenDrawer --seed 1 \
-         --vla-model-path /path/to/rldx --planner claude_code \
-         --memory-profile local --memory-dir /path/to/robocasa-memory
+         --vla-model-path ./checkpoints/rldx-1-ft-rc365 \
+         --planner claude_code --model claude-opus-4-8 \
+         --memory-profile local \
+         --memory-dir ./target50-memory/robocasa
 
-可用任务列表
-------------
+Target50 评测协议
+-----------------
 
-RPent 用的 50 个任务分三组:
+``robots/robocasa/eval/target50.json`` 是唯一规范清单，固定 ``target`` 环境
+split、依赖 revision、memory 边界、task/seed 矩阵、cell 时限、成功来源与重试
+规则；协议 ID 为 ``robocasa-harness-vla-v1``：
+
+.. list-table:: RoboCasa Target50 矩阵
+   :header-rows: 1
+   :widths: 30 15 20 20 15
+
+   * - Split
+     - 任务数
+     - 每任务 seed
+     - Cell 时限
+     - Cells
+   * - Atomic
+     - 18
+     - 1--10
+     - 1800 秒
+     - 180
+   * - Composite-Seen
+     - 16
+     - 1--5
+     - 3600 秒
+     - 80
+   * - Composite-Unseen
+     - 16
+     - 1--5
+     - 3600 秒
+     - 80
+   * - **总计**
+     - **50**
+     -
+     -
+     - **340**
+
+50 个任务分三组:
 
 - **Atomic (18)** —— 单步原语的开合与搬运任务: ``CloseBlenderLid``、
   ``CloseFridge``、``CloseToasterOvenDoor``、``CoffeeSetupMug``、
@@ -167,7 +228,7 @@ RoboCasa 的 CLI 参数由 ``robots/robocasa/__init__`` 注册，可通过
    rpent --robot robocasa \
          --task-name OpenDrawer \
          --split target \
-         --seed 0 \
+         --seed 1 \
          --vla-model-path /path/to/rldx \
          --planner claude_code \
          --model claude-opus-4-8
@@ -175,12 +236,67 @@ RoboCasa 的 CLI 参数由 ``robots/robocasa/__init__`` 注册，可通过
 RoboCasa 不绑定具体 planner；RPent 支持的任意 planner 都可用于该机器人。
 配置方式参见 :doc:`configure_planner`。
 
+正式 Target50 先按上文下载固定资源，再为 manifest 中每个 cell 调用一次普通
+命令。Codex 参考 profile 为 ``gpt-5.5``、``xhigh``、``max_turns=100``；
+RoboCasa 运行时本身仍与 planner 解耦。第一个 ``OpenDrawer`` Atomic cell 示例：
+
+.. code-block:: bash
+
+   rpent --robot robocasa \
+         --task-name OpenDrawer --split target --seed 1 \
+         --vla-model-path ./checkpoints/rldx-1-ft-rc365 --cuda-device 0 \
+         --planner codex --model gpt-5.5 --reasoning-effort xhigh \
+         --max-turns 100 --planner-timeout-s 1800 \
+         --memory-profile local \
+         --memory-dir ./target50-memory/robocasa/results \
+         --output-dir ./runs/target50/atomic/OpenDrawer_s1
+
+Composite-Seen 与 Composite-Unseen 使用 ``--planner-timeout-s 3600``。执行顺序为
+Atomic、Composite-Seen、Composite-Unseen。成功只认最终环境记录中的
+``state.success=true``，planner 的 ``finish(status=...)`` 不是评测标签。有效任务
+失败与 planner timeout 不重跑；只有没有产生有效环境结果的基础设施失败允许重跑。
+
 .. note::
 
    使用 ``--env-endpoint`` / ``--vla-endpoint`` 指向已运行的服务器
    (``[protocol://]host:port``)；不指定时，RPent 会就地启动 env 和 VLA
    子进程，日志分别写到 ``<output_dir>/env_server.log`` 和
    ``<output_dir>/vla_server.log``。
+
+已发布的 Target50 结果
+-----------------------
+
+已发布 Codex 复现覆盖全部 340 cells，任务级汇总如下：
+
+.. list-table:: Codex Target50 复现结果
+   :header-rows: 1
+   :widths: 30 20 20 30
+
+   * - Split
+     - 成功 cells
+     - 成功率
+     - Harness VLA 参考值
+   * - Atomic
+     - 163/180
+     - 90.56%
+     - 165/180 (91.67%)
+   * - Composite-Seen
+     - 49/80
+     - 61.25%
+     - 45/80 (56.25%)
+   * - Composite-Unseen
+     - 12/80
+     - 15.00%
+     - 11/80 (13.75%)
+   * - 总体（任务加权）
+     - 224/340 cells
+     - 57.00%
+     - 55.40%
+
+`完整逐任务结果表
+<https://github.com/RLinf/RPent/blob/main/robots/robocasa/eval/target50_codex_results.md>`_
+给出每个任务的成功次数和准确率。当前发布内容是任务级聚合数据，不包含 seed 级
+trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
 
 常见错误
 --------

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -1,0 +1,236 @@
+# RoboCasa in RPent
+
+## Overview
+
+RPent runs the RoboCasa365 kitchen benchmark with a PandaOmron mobile
+manipulator and the frozen RLDX-1 policy. An agentic planner selects RPent
+primitives, while RLDX-1 executes the manipulation skills. The integration is
+planner-agnostic: API planners, Claude Code, Codex, and future RPent planners
+all use the same RoboCasa toolkit.
+
+The public Target50 protocol covers 50 tasks from the RoboCasa365 `target`
+environment split. It is intentionally expressed as an immutable manifest and
+ordinary single-task `rpent` commands; RPent does not include a benchmark batch
+launcher.
+
+## Runtime Flow
+
+```text
+rpent CLI -> task-memory sync -> environment and VLA servers
+          -> planner toolkit -> RoboCasa state.success
+```
+
+Unless external endpoints are supplied, RPent starts one RoboCasa environment
+server and one RLDX-1 VLA server for the run. The planner receives the current
+task language and observations through the RoboCasa toolkit. The environment's
+own `_check_success()` result is surfaced as `state.success` and is the only
+evaluation success signal.
+
+## Installation
+
+RLDX-1 requires Python 3.10. From the RPent repository root, create a dedicated
+environment and install the RoboCasa extra with the validated Torch pair:
+
+```bash
+uv venv --python 3.10
+source .venv/bin/activate
+uv pip install -e ".[robocasa]" \
+  "torch==2.7.0" "torchvision==0.22.0" \
+  --torch-backend=cu126
+```
+
+Download the RoboCasa kitchen assets outside `site-packages`, then export the
+paths printed by the command:
+
+```bash
+robocasa-download-assets --assets-path ~/.robocasa/assets -y
+export ROBOCASA_MACROS_PATH=~/.robocasa/macros_private.py
+export ROBOCASA_ASSETS_PATH=~/.robocasa/assets
+```
+
+The RPent Robosuite fork provides the Omron base-mounted `navview` camera,
+composed by MuJoCo as `mobilebase0_navview`. Target50 freezes Robosuite at
+`97cfbde4b68d8ec43dad20cf4747297866a6ca2e`. Install that exact revision for a
+formal reproduction:
+
+```bash
+uv pip install --reinstall \
+  "robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
+```
+
+No installed XML file needs to be patched manually.
+
+## RLDX-1 Checkpoint
+
+Download the RoboCasa365-finetuned checkpoint at the revision frozen by the
+Target50 manifest:
+
+```bash
+hf download RLWRLD/RLDX-1-FT-RC365 \
+  --revision 587e9ecdcc5e7184fcc17f58713908edff5af041 \
+  --local-dir ./checkpoints/rldx-1-ft-rc365
+```
+
+Pass that directory to `--vla-model-path`. The checkpoint is not distributed
+inside RPent.
+
+## Task Memory
+
+Before every ordinary run using the default `hf` memory profile, RPent calls
+the shared `ensure_resources()` helper to synchronize the `robocasa/**` subtree
+from the public
+[`RLinf/RPent-memory`](https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/results)
+dataset. Files land under `resources/robocasa/results`, so an online ordinary
+run does not require a separate memory download command.
+
+The published RoboCasa corpus contains 111 files: 43 audit JSON files, 43
+recipe JSONL files, and 25 task Markdown files. There is no global memory. For
+the current task, the planner may read only:
+
+```text
+resources/robocasa/results/<Task>_s0.json
+resources/robocasa/results/recipe_<Task>_s0.jsonl
+resources/robocasa/results/<Task>.md  # optional
+```
+
+The Markdown files cover all 16 Composite-Seen tasks and 9 Composite-Unseen
+tasks. Seven Composite-Unseen tasks have no published memory and still run from
+live observations:
+
+```text
+HeatKebabSandwich, PanTransfer, PortionHotDogs, SeparateFreezerRack,
+WaffleReheat, WashFruitColander, WeighIngredients
+```
+
+Memory is strategy evidence, not a trajectory to replay. The planner must not
+read another task's files or reuse historical coordinates, poses, pixels, or
+subtask prompts in place of the current task language and observations.
+
+Ordinary runs synchronize the dataset's current `main`. Formal Target50 runs
+instead use the immutable memory snapshot
+`551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b`:
+
+```bash
+hf download RLinf/RPent-memory \
+  --repo-type dataset \
+  --revision 551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b \
+  --include "robocasa/**" \
+  --local-dir ./target50-memory
+```
+
+## Run One Task
+
+The default HF profile synchronizes memory automatically:
+
+```bash
+rpent --robot robocasa \
+  --task-name OpenDrawer \
+  --split target \
+  --seed 1 \
+  --vla-model-path ./checkpoints/rldx-1-ft-rc365 \
+  --cuda-device 0 \
+  --planner claude_code \
+  --model claude-opus-4-8 \
+  --memory-profile hf
+```
+
+To use a reviewed local corpus, point `--memory-dir` directly at its `results`
+directory:
+
+```bash
+rpent --robot robocasa \
+  --task-name OpenDrawer \
+  --split target \
+  --seed 1 \
+  --vla-model-path ./checkpoints/rldx-1-ft-rc365 \
+  --cuda-device 0 \
+  --planner claude_code \
+  --model claude-opus-4-8 \
+  --memory-profile local \
+  --memory-dir ./target50-memory/robocasa/results
+```
+
+Planner credentials are supplied by the user outside the repository. See the
+[planner configuration guide](../../docs/source-en/rst_source/usage/configure_planner.rst)
+for all supported backends.
+
+## Target50 Reproduction
+
+[`eval/target50.json`](eval/target50.json) is the canonical evaluation
+manifest. It freezes task membership, seeds, time limits, dependency revisions,
+memory scope, the success source, and retry policy. Its protocol ID is
+`robocasa-harness-vla-v1`.
+
+| Split | Tasks | Seeds per task | Cell timeout | Cells |
+|---|---:|---:|---:|---:|
+| Atomic | 18 | 1-10 | 1800 s | 180 |
+| Composite-Seen | 16 | 1-5 | 3600 s | 80 |
+| Composite-Unseen | 16 | 1-5 | 3600 s | 80 |
+| **Total** | **50** | | | **340** |
+
+Run each manifest cell with the ordinary CLI. The reference Codex profile is
+`gpt-5.5`, `xhigh`, and `max_turns=100`; this profile does not restrict the
+RoboCasa runtime to Codex. An Atomic cell is:
+
+```bash
+rpent --robot robocasa \
+  --task-name OpenDrawer \
+  --split target \
+  --seed 1 \
+  --vla-model-path ./checkpoints/rldx-1-ft-rc365 \
+  --cuda-device 0 \
+  --planner codex \
+  --model gpt-5.5 \
+  --reasoning-effort xhigh \
+  --max-turns 100 \
+  --planner-timeout-s 1800 \
+  --memory-profile local \
+  --memory-dir ./target50-memory/robocasa/results \
+  --output-dir ./runs/target50/atomic/OpenDrawer_s1
+```
+
+Use `--planner-timeout-s 3600` for Composite-Seen and Composite-Unseen cells.
+Execute Atomic 180, Composite-Seen 80, then Composite-Unseen 80. Each cell must
+own its environment and VLA worker; GPU concurrency is an execution setting and
+does not change the manifest.
+
+## Success and Retry Policy
+
+- A cell succeeds only when its final recorded environment state has
+  `state.success=true`. A planner-provided `finish(status=...)` value is not an
+  evaluation label.
+- A valid task failure and a planner timeout remain in the fixed denominator
+  and are not retried.
+- An infrastructure failure may be retried only when it produced no valid
+  environment result for the cell.
+- All 340 cells remain in the denominator, including the seven Unseen tasks
+  without task memory.
+
+## Published Results
+
+The published Codex reproduction reports `163/180` Atomic, `49/80`
+Composite-Seen, and `12/80` Composite-Unseen successes, for a task-weighted
+RoboCasa365 score of `57.00%`. See the
+[complete per-task table](eval/target50_codex_results.md) for comparison with
+the Harness VLA reference results and for the aggregation boundary.
+
+## Troubleshooting
+
+- **Assets or macros are missing:** rerun `robocasa-download-assets` and export
+  `ROBOCASA_MACROS_PATH` and `ROBOCASA_ASSETS_PATH` in the launch shell.
+- **`mobilebase0_navview` is missing:** reinstall the frozen Robosuite revision
+  above. Do not edit files under `site-packages`.
+- **The RLDX server cannot load:** verify `--vla-model-path`, CUDA visibility,
+  and `vla_server.log`. FlashAttention is optional; RLDX-1 can use PyTorch SDPA.
+- **Task memory is missing:** check `resources/robocasa/results` for HF mode or
+  the exact directory passed to `--memory-dir`. Do not substitute another
+  task's files. Missing memory is expected for the seven tasks listed above.
+- **A server fails to start:** inspect `env_server.log`, `vla_server.log`, and
+  `run.log` inside the cell's output directory.
+
+## Further Documentation
+
+- [English RoboCasa usage guide](../../docs/source-en/rst_source/usage/robocasa.rst)
+- [Chinese RoboCasa usage guide](../../docs/source-zh/rst_source/usage/robocasa.rst)
+- [Planner configuration](../../docs/source-en/rst_source/usage/configure_planner.rst)
+- [Harness VLA overview](../../docs/source-en/rst_source/awesome_works/harnessvla.rst)

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -35,30 +35,33 @@ environment and install the RoboCasa extra with the validated Torch pair:
 uv venv --python 3.10
 source .venv/bin/activate
 uv pip install -e ".[robocasa]" \
-  "torch==2.7.0" "torchvision==0.22.0" \
+  --constraint robots/robocasa/eval/target50-constraints.txt \
+  --override robots/robocasa/eval/target50-overrides.txt \
   --torch-backend=cu126
+uv pip check
 ```
 
+The Target50-specific [constraints file](eval/target50-constraints.txt) pins
+the compatibility-sensitive package versions validated for reproduction
+without narrowing the shared RPent dependency ranges for LIBERO or RoboTwin.
+The accompanying [override file](eval/target50-overrides.txt) resolves the
+formal environment directly to the immutable Robosuite revision while the
+ordinary `robocasa` extra continues to track its maintained `rpent` branch.
+
 Download the RoboCasa kitchen assets outside `site-packages`, then export the
-paths printed by the command:
+path printed by the command. Target50 does not use RoboCasa dataset or teleop
+macros, so skip the optional private-macros setup:
 
 ```bash
-robocasa-download-assets --assets-path ~/.robocasa/assets -y
-export ROBOCASA_MACROS_PATH=~/.robocasa/macros_private.py
+robocasa-download-assets --assets-path ~/.robocasa/assets --no-macros -y
 export ROBOCASA_ASSETS_PATH=~/.robocasa/assets
 ```
 
 The RPent Robosuite fork provides the Omron base-mounted `navview` camera,
 composed by MuJoCo as `mobilebase0_navview`. Target50 freezes Robosuite at
-`97cfbde4b68d8ec43dad20cf4747297866a6ca2e`. Install that exact revision for a
-formal reproduction:
-
-```bash
-uv pip install --reinstall \
-  "robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
-```
-
-No installed XML file needs to be patched manually.
+`97cfbde4b68d8ec43dad20cf4747297866a6ca2e`; the Target50 override in the
+installation command above selects that exact revision. No installed XML file
+needs to be patched manually.
 
 ## RLDX-1 Checkpoint
 
@@ -170,7 +173,18 @@ memory scope, the success source, and retry policy. Its protocol ID is
 
 Run each manifest cell with the ordinary CLI. The reference Codex profile is
 `gpt-5.5`, `xhigh`, and `max_turns=100`; this profile does not restrict the
-RoboCasa runtime to Codex. An Atomic cell is:
+RoboCasa runtime to Codex. The scene identity is the ordinary `--seed` value;
+do not set `RLDX_RESET_SEED`. Freeze the RLDX execution values before running
+the cells:
+
+```bash
+export RLDX_MAX_CHUNKS=40
+export RLDX_SETTLE_PATIENCE=999
+export RLDX_ACTION_STEPS_PER_CHUNK=8
+unset RLDX_RESET_SEED
+```
+
+An Atomic cell is:
 
 ```bash
 rpent --robot robocasa \
@@ -194,6 +208,19 @@ Execute Atomic 180, Composite-Seen 80, then Composite-Unseen 80. Each cell must
 own its environment and VLA worker; GPU concurrency is an execution setting and
 does not change the manifest.
 
+Each completed command atomically writes `<output-dir>/result.json`. This file
+uses the final environment `state.success`, records the effective protocol
+settings, and deliberately omits provider errors and credentials. After all
+cells finish, validate the fixed denominator and print the task-weighted score:
+
+```bash
+python -m robots.robocasa.eval.validate_target50 ./runs/target50
+```
+
+The expected layout is
+`<results-root>/<manifest-split>/<Task>_s<seed>/result.json`. A valid planner
+timeout remains a failed cell; an infrastructure error is rejected for rerun.
+
 ## Success and Retry Policy
 
 - A cell succeeds only when its final recorded environment state has
@@ -216,8 +243,9 @@ the Harness VLA reference results and for the aggregation boundary.
 
 ## Troubleshooting
 
-- **Assets or macros are missing:** rerun `robocasa-download-assets` and export
-  `ROBOCASA_MACROS_PATH` and `ROBOCASA_ASSETS_PATH` in the launch shell.
+- **Assets are missing:** rerun `robocasa-download-assets` and export
+  `ROBOCASA_ASSETS_PATH` in the launch shell. Private dataset and teleop macros
+  are not required by Target50.
 - **`mobilebase0_navview` is missing:** reinstall the frozen Robosuite revision
   above. Do not edit files under `site-packages`.
 - **The RLDX server cannot load:** verify `--vla-model-path`, CUDA visibility,
@@ -227,6 +255,9 @@ the Harness VLA reference results and for the aggregation boundary.
   task's files. Missing memory is expected for the seven tasks listed above.
 - **A server fails to start:** inspect `env_server.log`, `vla_server.log`, and
   `run.log` inside the cell's output directory.
+- **Local RPC follows an HTTP proxy:** update to an RPent revision containing
+  the loopback proxy bypass. Local `127.0.0.1` and `localhost` RPC must not use
+  `HTTP_PROXY` or `HTTPS_PROXY`.
 
 ## Further Documentation
 

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -80,10 +80,10 @@ inside RPent.
 ## Task Memory
 
 Select automatic synchronization with `--memory-profile hf` (the default).
-Before every such ordinary run, RPent calls the shared `ensure_resources()`
-helper to synchronize the `robocasa/**` subtree from the public
+Before every such ordinary run, RPent's shared memory manager synchronizes the
+`robocasa/**` subtree from the public
 [`RLinf/RPent-memory`](https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/results)
-dataset. Files land under `resources/robocasa/results`, so an online ordinary
+dataset. Files land under `memory/robocasa/results`, so an online ordinary
 run does not require a separate memory download command.
 
 The published RoboCasa corpus contains 111 files: 43 audit JSON files, 43
@@ -91,9 +91,9 @@ recipe JSONL files, and 25 task Markdown files. There is no global memory. For
 the current task, the planner may read only:
 
 ```text
-resources/robocasa/results/<Task>_s0.json
-resources/robocasa/results/recipe_<Task>_s0.jsonl
-resources/robocasa/results/<Task>.md  # optional
+memory/robocasa/results/<Task>_s0.json
+memory/robocasa/results/recipe_<Task>_s0.jsonl
+memory/robocasa/results/<Task>.md  # optional
 ```
 
 The Markdown files cover all 16 Composite-Seen tasks and 9 Composite-Unseen
@@ -149,8 +149,8 @@ rpent --robot robocasa \
   --memory-profile hf
 ```
 
-To use a reviewed local corpus, point `--memory-dir` directly at its `results`
-directory:
+To use a reviewed local corpus, point `--memory-dir` at its RoboCasa memory
+root (the directory that contains `results/`):
 
 ```bash
 rpent --robot robocasa \
@@ -162,7 +162,7 @@ rpent --robot robocasa \
   --planner claude_code \
   --model claude-opus-4-8 \
   --memory-profile local \
-  --memory-dir ./target50-memory/robocasa/results
+  --memory-dir ./target50-memory/robocasa
 ```
 
 Planner credentials are supplied by the user outside the repository. See the
@@ -187,8 +187,9 @@ and retry policy. Its protocol ID is
 Run each manifest cell with the ordinary CLI. The reference Codex profile is
 `gpt-5.5`, `xhigh`, and `max_turns=100`; this profile does not restrict the
 RoboCasa runtime to Codex. The scene identity is the ordinary `--seed` value;
-do not set `RLDX_RESET_SEED`. Freeze the RLDX execution values before running
-the cells:
+do not set `RLDX_RESET_SEED`. Ordinary RoboCasa uses `max_chunks=70`; Target50
+alone overrides it to 40. Freeze the Target50 RLDX execution values before
+running the cells:
 
 ```bash
 export RLDX_MAX_CHUNKS=40
@@ -212,7 +213,7 @@ rpent --robot robocasa \
   --max-turns 100 \
   --planner-timeout-s 1800 \
   --memory-profile local \
-  --memory-dir ./target50-memory/robocasa/results \
+  --memory-dir ./target50-memory/robocasa \
   --output-dir ./runs/target50/atomic/OpenDrawer_s1
 ```
 
@@ -263,7 +264,7 @@ the Harness VLA reference results and for the aggregation boundary.
   above. Do not edit files under `site-packages`.
 - **The RLDX server cannot load:** verify `--vla-model-path`, CUDA visibility,
   and `vla_server.log`. FlashAttention is optional; RLDX-1 can use PyTorch SDPA.
-- **Task memory is missing:** check `resources/robocasa/results` for HF mode or
+- **Task memory is missing:** check `memory/robocasa/results` for HF mode or
   the exact directory passed to `--memory-dir`. Do not substitute another
   task's files. Missing memory is expected for the seven tasks listed above.
 - **A server fails to start:** inspect `env_server.log`, `vla_server.log`, and

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -123,18 +123,17 @@ hf download RLinf/RPent-memory \
 
 ## Run One Task
 
-RPent starts its default environment and VLA workers on loopback addresses. If
-the launch shell defines `HTTP_PROXY` or `HTTPS_PROXY`, preserve that proxy for
-remote services while exempting local RPC in both commonly recognized forms:
+RPent-owned environment and VLA workers use request-local direct HTTP clients.
+Codex likewise adds loopback exclusions only to its child process for the local
+MCP connection. Leave `HTTP_PROXY` and `HTTPS_PROXY` unchanged when remote
+services require them; the default runtime does not require a shell-wide
+`NO_PROXY` setup.
 
-```bash
-export NO_PROXY="${NO_PROXY:+${NO_PROXY},}127.0.0.1,localhost,::1"
-export no_proxy="${no_proxy:+${no_proxy},}127.0.0.1,localhost,::1"
-```
-
-These assignments keep existing exclusions. Add the exact hostname or IP when
-`--env-endpoint` or `--vla-endpoint` uses a different local address. They do not
-bypass the proxy for Hugging Face, a remote planner, or other remote endpoints.
+User-supplied `--env-endpoint` and `--vla-endpoint` values deliberately honor
+the standard proxy environment. If such an endpoint is local and should be
+reached directly, add its exact hostname or IP to the user's existing
+`NO_PROXY` and `no_proxy` configuration. This choice does not affect Hugging
+Face, a remote planner, or other remote endpoints.
 
 The default HF profile synchronizes memory automatically:
 
@@ -189,7 +188,7 @@ Run each manifest cell with the ordinary CLI. The reference Codex profile is
 `gpt-5.5`, `xhigh`, and `max_turns=100`; this profile does not restrict the
 RoboCasa runtime to Codex. The scene identity is the ordinary `--seed` value;
 do not set `RLDX_RESET_SEED`. Freeze the RLDX execution values before running
-the cells, keeping the loopback `NO_PROXY` / `no_proxy` settings above:
+the cells:
 
 ```bash
 export RLDX_MAX_CHUNKS=40
@@ -269,9 +268,10 @@ the Harness VLA reference results and for the aggregation boundary.
   task's files. Missing memory is expected for the seven tasks listed above.
 - **A server fails to start:** inspect `env_server.log`, `vla_server.log`, and
   `run.log` inside the cell's output directory.
-- **Local RPC follows an HTTP proxy:** set both `NO_PROXY` and `no_proxy` as
-  shown under "Run One Task". Keep `HTTP_PROXY` and `HTTPS_PROXY` enabled for
-  remote traffic, and add any custom local endpoint hostname to the exclusions.
+- **A user-supplied local endpoint follows an HTTP proxy:** this is the expected
+  behavior for `--env-endpoint` and `--vla-endpoint`. Add that host to the
+  user's `NO_PROXY` and `no_proxy` configuration only when it should be reached
+  directly. RPent-owned workers need no proxy setup.
 
 ## Further Documentation
 

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -123,17 +123,17 @@ hf download RLinf/RPent-memory \
 
 ## Run One Task
 
-RPent-owned environment and VLA workers use request-local direct HTTP clients.
-Codex likewise adds loopback exclusions only to its child process for the local
-MCP connection. Leave `HTTP_PROXY` and `HTTPS_PROXY` unchanged when remote
-services require them; the default runtime does not require a shell-wide
-`NO_PROXY` setup.
+HTTP RPC endpoints whose hostname is `127.0.0.1` or `localhost` are reached
+directly, whether RPent starts the worker or the user supplies the endpoint.
+Every other hostname and IP uses the standard proxy environment. Codex applies
+the same two-host exception only to its child process for the local MCP
+connection. Leave `HTTP_PROXY` and `HTTPS_PROXY` unchanged when Hugging Face,
+a remote planner, or another remote service requires them; the default runtime
+does not require a shell-wide `NO_PROXY` setup.
 
-User-supplied `--env-endpoint` and `--vla-endpoint` values deliberately honor
-the standard proxy environment. If such an endpoint is local and should be
-reached directly, add its exact hostname or IP to the user's existing
-`NO_PROXY` and `no_proxy` configuration. This choice does not affect Hugging
-Face, a remote planner, or other remote endpoints.
+If a user-supplied local service uses another hostname or IP and should be
+reached directly, add that exact value to the user's existing `NO_PROXY` and
+`no_proxy` configuration.
 
 The default HF profile synchronizes memory automatically:
 
@@ -268,10 +268,10 @@ the Harness VLA reference results and for the aggregation boundary.
   task's files. Missing memory is expected for the seven tasks listed above.
 - **A server fails to start:** inspect `env_server.log`, `vla_server.log`, and
   `run.log` inside the cell's output directory.
-- **A user-supplied local endpoint follows an HTTP proxy:** this is the expected
-  behavior for `--env-endpoint` and `--vla-endpoint`. Add that host to the
-  user's `NO_PROXY` and `no_proxy` configuration only when it should be reached
-  directly. RPent-owned workers need no proxy setup.
+- **A custom endpoint unexpectedly follows an HTTP proxy:** only the exact
+  `127.0.0.1` and `localhost` hostnames bypass proxies automatically. Other
+  hostnames and IPs use the standard proxy environment; add the exact host to
+  `NO_PROXY` and `no_proxy` only when it should be reached directly.
 
 ## Further Documentation
 

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -79,9 +79,9 @@ inside RPent.
 
 ## Task Memory
 
-Before every ordinary run using the default `hf` memory profile, RPent calls
-the shared `ensure_resources()` helper to synchronize the `robocasa/**` subtree
-from the public
+Select automatic synchronization with `--memory-profile hf` (the default).
+Before every such ordinary run, RPent calls the shared `ensure_resources()`
+helper to synchronize the `robocasa/**` subtree from the public
 [`RLinf/RPent-memory`](https://huggingface.co/datasets/RLinf/RPent-memory/tree/main/robocasa/results)
 dataset. Files land under `resources/robocasa/results`, so an online ordinary
 run does not require a separate memory download command.
@@ -170,11 +170,12 @@ Planner credentials are supplied by the user outside the repository. See the
 [planner configuration guide](../../docs/source-en/rst_source/usage/configure_planner.rst)
 for all supported backends.
 
-## Target50 Reproduction
+## Harness VLA Target50 Reproduction
 
-[`eval/target50.json`](eval/target50.json) is the canonical evaluation
-manifest. It freezes task membership, seeds, time limits, dependency revisions,
-memory scope, the success source, and retry policy. Its protocol ID is
+[`eval/target50.json`](eval/target50.json) is the canonical manifest for the
+Harness VLA reproduction on RoboCasa Target50. It freezes task membership,
+seeds, time limits, dependency revisions, memory scope, the success source,
+and retry policy. Its protocol ID is
 `robocasa-harness-vla-v1`.
 
 | Split | Tasks | Seeds per task | Cell timeout | Cells |

--- a/robots/robocasa/README.md
+++ b/robots/robocasa/README.md
@@ -123,6 +123,19 @@ hf download RLinf/RPent-memory \
 
 ## Run One Task
 
+RPent starts its default environment and VLA workers on loopback addresses. If
+the launch shell defines `HTTP_PROXY` or `HTTPS_PROXY`, preserve that proxy for
+remote services while exempting local RPC in both commonly recognized forms:
+
+```bash
+export NO_PROXY="${NO_PROXY:+${NO_PROXY},}127.0.0.1,localhost,::1"
+export no_proxy="${no_proxy:+${no_proxy},}127.0.0.1,localhost,::1"
+```
+
+These assignments keep existing exclusions. Add the exact hostname or IP when
+`--env-endpoint` or `--vla-endpoint` uses a different local address. They do not
+bypass the proxy for Hugging Face, a remote planner, or other remote endpoints.
+
 The default HF profile synchronizes memory automatically:
 
 ```bash
@@ -175,7 +188,7 @@ Run each manifest cell with the ordinary CLI. The reference Codex profile is
 `gpt-5.5`, `xhigh`, and `max_turns=100`; this profile does not restrict the
 RoboCasa runtime to Codex. The scene identity is the ordinary `--seed` value;
 do not set `RLDX_RESET_SEED`. Freeze the RLDX execution values before running
-the cells:
+the cells, keeping the loopback `NO_PROXY` / `no_proxy` settings above:
 
 ```bash
 export RLDX_MAX_CHUNKS=40
@@ -255,9 +268,9 @@ the Harness VLA reference results and for the aggregation boundary.
   task's files. Missing memory is expected for the seven tasks listed above.
 - **A server fails to start:** inspect `env_server.log`, `vla_server.log`, and
   `run.log` inside the cell's output directory.
-- **Local RPC follows an HTTP proxy:** update to an RPent revision containing
-  the loopback proxy bypass. Local `127.0.0.1` and `localhost` RPC must not use
-  `HTTP_PROXY` or `HTTPS_PROXY`.
+- **Local RPC follows an HTTP proxy:** set both `NO_PROXY` and `no_proxy` as
+  shown under "Run One Task". Keep `HTTP_PROXY` and `HTTPS_PROXY` enabled for
+  remote traffic, and add any custom local endpoint hostname to the exclusions.
 
 ## Further Documentation
 

--- a/robots/robocasa/eval/__init__.py
+++ b/robots/robocasa/eval/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RoboCasa evaluation manifests and result contracts."""

--- a/robots/robocasa/eval/result.py
+++ b/robots/robocasa/eval/result.py
@@ -1,0 +1,115 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Machine-readable result records for RoboCasa evaluation cells."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+RESULT_SCHEMA_VERSION = "1.0"
+TARGET50_MANIFEST = Path(__file__).with_name("target50.json")
+
+
+def _target50_identity(
+    task_name: str, environment_split: str, seed: int
+) -> tuple[str | None, str | None]:
+    """Return ``(protocol_id, evaluation_split)`` for a Target50 cell."""
+    if environment_split != "target":
+        return None, None
+    manifest = json.loads(TARGET50_MANIFEST.read_text(encoding="utf-8"))
+    for split_name, split in manifest["splits"].items():
+        if task_name in split["tasks"] and seed in split["seeds"]:
+            return manifest["protocol_id"], split_name
+    return None, None
+
+
+def _termination_reason(agent_error: str | None, success: bool) -> str:
+    """Classify completion without persisting provider error details."""
+    if success or not agent_error:
+        return "completed"
+    lowered = agent_error.lower()
+    if "timed out" in lowered and (
+        "planner" in lowered or "agent sdk" in lowered or "codex sdk" in lowered
+    ):
+        return "planner_timeout"
+    return "infrastructure_error"
+
+
+def build_cell_result(
+    *,
+    task_name: str,
+    environment_split: str,
+    seed: int,
+    success: bool,
+    environment_result_available: bool,
+    agent_error: str | None,
+    elapsed_s: float,
+    planner: str,
+    model: str | None,
+    reasoning_effort: str,
+    max_turns: int,
+    cell_timeout_seconds: int | None,
+) -> dict[str, Any]:
+    """Build one sanitized, environment-authoritative cell result."""
+    protocol_id, evaluation_split = _target50_identity(
+        task_name, environment_split, seed
+    )
+    reason = _termination_reason(agent_error, success)
+    max_chunks = int(os.environ.get("RLDX_MAX_CHUNKS", "40"))
+    settle_patience = int(os.environ.get("RLDX_SETTLE_PATIENCE", "999"))
+    action_steps = int(os.environ.get("RLDX_ACTION_STEPS_PER_CHUNK", "8"))
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "protocol_id": protocol_id,
+        "evaluation_split": evaluation_split,
+        "task_name": task_name,
+        "environment_split": environment_split,
+        "seed": seed,
+        "valid": environment_result_available and reason != "infrastructure_error",
+        "success": bool(success),
+        "success_source": "state.success",
+        "termination_reason": reason,
+        "elapsed_s": round(elapsed_s, 1),
+        "planner": {
+            "backend": planner,
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+            "max_turns": max_turns,
+        },
+        "runtime": {
+            "cell_timeout_seconds": cell_timeout_seconds,
+            "rldx_max_chunks": max_chunks,
+            "rldx_settle_patience": settle_patience,
+            "rldx_action_steps_per_chunk": action_steps,
+        },
+    }
+
+
+def write_cell_result(output_dir: Path | str, **kwargs: Any) -> Path:
+    """Atomically write ``result.json`` and return its path."""
+    destination = Path(output_dir) / "result.json"
+    temporary = destination.with_name(".result.json.tmp")
+    record = build_cell_result(**kwargs)
+    try:
+        with temporary.open("w", encoding="utf-8") as file:
+            json.dump(record, file, indent=2)
+            file.write("\n")
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return destination

--- a/robots/robocasa/eval/result.py
+++ b/robots/robocasa/eval/result.py
@@ -72,7 +72,7 @@ def build_cell_result(
         task_name, environment_split, seed
     )
     reason = _termination_reason(agent_error, success)
-    max_chunks = int(os.environ.get("RLDX_MAX_CHUNKS", "40"))
+    max_chunks = int(os.environ.get("RLDX_MAX_CHUNKS", "70"))
     settle_patience = int(os.environ.get("RLDX_SETTLE_PATIENCE", "999"))
     action_steps = int(os.environ.get("RLDX_ACTION_STEPS_PER_CHUNK", "8"))
     return {

--- a/robots/robocasa/eval/result.py
+++ b/robots/robocasa/eval/result.py
@@ -21,6 +21,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from rpent.evaluation import RunFinalizationContext, write_json_atomic
+
 RESULT_SCHEMA_VERSION = "1.0"
 TARGET50_MANIFEST = Path(__file__).with_name("target50.json")
 
@@ -100,16 +102,21 @@ def build_cell_result(
     }
 
 
-def write_cell_result(output_dir: Path | str, **kwargs: Any) -> Path:
-    """Atomically write ``result.json`` and return its path."""
-    destination = Path(output_dir) / "result.json"
-    temporary = destination.with_name(".result.json.tmp")
-    record = build_cell_result(**kwargs)
-    try:
-        with temporary.open("w", encoding="utf-8") as file:
-            json.dump(record, file, indent=2)
-            file.write("\n")
-        os.replace(temporary, destination)
-    finally:
-        temporary.unlink(missing_ok=True)
-    return destination
+def finalize_cell_result(context: RunFinalizationContext) -> Path:
+    """Adapt shared run state to the RoboCasa Target50 result schema."""
+    task = context.task_desc
+    record = build_cell_result(
+        task_name=str(task["task_name"]),
+        environment_split=str(task["split"]),
+        seed=int(task["seed"]),
+        success=bool(context.environment_success),
+        environment_result_available=context.environment_success is not None,
+        agent_error=context.agent_error,
+        elapsed_s=context.elapsed_s,
+        planner=context.planner,
+        model=context.model,
+        reasoning_effort=context.reasoning_effort,
+        max_turns=context.max_turns,
+        cell_timeout_seconds=context.planner_timeout_s,
+    )
+    return write_json_atomic(context.output_dir / "result.json", record)

--- a/robots/robocasa/eval/target50-constraints.txt
+++ b/robots/robocasa/eval/target50-constraints.txt
@@ -1,0 +1,12 @@
+# Compatibility-sensitive package versions validated for Target50 reproduction.
+# The companion override file freezes the exact Robosuite Git revision.
+mujoco==3.3.1
+numpy==1.26.4
+pydantic==2.13.5
+# RPent's API planner contract targets the instruction semantics introduced at 2.1.
+pydantic-ai-slim==2.1.0
+rlinf-rldx==1.0.1.post10
+rlinf-robocasa365==1.0.1
+torch==2.7.0
+torchvision==0.22.0
+transformers==4.57.6

--- a/robots/robocasa/eval/target50-overrides.txt
+++ b/robots/robocasa/eval/target50-overrides.txt
@@ -1,0 +1,2 @@
+# Freeze direct-source dependencies for the formal Target50 environment.
+robosuite @ git+https://github.com/RLinf/robosuite.git@97cfbde4b68d8ec43dad20cf4747297866a6ca2e

--- a/robots/robocasa/eval/target50.json
+++ b/robots/robocasa/eval/target50.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": "1.0",
+  "protocol_id": "robocasa-harness-vla-v1",
+  "benchmark": "RoboCasa365",
+  "environment_split": "target",
+  "success_source": "state.success",
+  "total_tasks": 50,
+  "total_cells": 340,
+  "dependencies": {
+    "robosuite": {
+      "repository": "https://github.com/RLinf/robosuite",
+      "commit": "97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
+    },
+    "rldx_checkpoint": {
+      "repository": "RLWRLD/RLDX-1-FT-RC365",
+      "revision": "587e9ecdcc5e7184fcc17f58713908edff5af041"
+    },
+    "task_memory": {
+      "repository": "RLinf/RPent-memory",
+      "repository_type": "dataset",
+      "revision": "551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b",
+      "include_pattern": "robocasa/**"
+    }
+  },
+  "planner_reference": {
+    "planner": "codex",
+    "model": "gpt-5.5",
+    "reasoning_effort": "xhigh",
+    "max_turns": 100,
+    "runtime_is_planner_agnostic": true
+  },
+  "memory_policy": {
+    "scope": "same_task_seed_0",
+    "results_directory": "robocasa/results",
+    "required_files": [
+      "<Task>_s0.json",
+      "recipe_<Task>_s0.jsonl"
+    ],
+    "optional_files": [
+      "<Task>.md"
+    ],
+    "use_global_memory": false,
+    "use_cross_task_memory": false,
+    "tasks_with_memory": 43,
+    "tasks_without_memory": [
+      "HeatKebabSandwich",
+      "PanTransfer",
+      "PortionHotDogs",
+      "SeparateFreezerRack",
+      "WaffleReheat",
+      "WashFruitColander",
+      "WeighIngredients"
+    ]
+  },
+  "retry_policy": {
+    "retry_infrastructure_failure_without_valid_environment_result": true,
+    "retry_valid_task_failure": false,
+    "retry_planner_timeout": false
+  },
+  "splits": {
+    "atomic": {
+      "task_count": 18,
+      "seeds": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      "timeout_seconds": 1800,
+      "cell_count": 180,
+      "tasks": [
+        "CloseBlenderLid",
+        "CloseFridge",
+        "CloseToasterOvenDoor",
+        "CoffeeSetupMug",
+        "NavigateKitchen",
+        "OpenCabinet",
+        "OpenDrawer",
+        "OpenStandMixerHead",
+        "PickPlaceCounterToCabinet",
+        "PickPlaceCounterToStove",
+        "PickPlaceDrawerToCounter",
+        "PickPlaceSinkToCounter",
+        "PickPlaceToasterToCounter",
+        "SlideDishwasherRack",
+        "TurnOffStove",
+        "TurnOnElectricKettle",
+        "TurnOnMicrowave",
+        "TurnOnSinkFaucet"
+      ]
+    },
+    "composite_seen": {
+      "task_count": 16,
+      "seeds": [1, 2, 3, 4, 5],
+      "timeout_seconds": 3600,
+      "cell_count": 80,
+      "tasks": [
+        "ScrubCuttingBoard",
+        "StackBowlsCabinet",
+        "WashLettuce",
+        "RinseSinkBasin",
+        "PreSoakPan",
+        "StirVegetables",
+        "LoadDishwasher",
+        "SteamInMicrowave",
+        "SetUpCuttingStation",
+        "GetToastedBread",
+        "DeliverStraw",
+        "KettleBoiling",
+        "PrepareCoffee",
+        "StoreLeftoversInBowl",
+        "SearingMeat",
+        "PackIdenticalLunches"
+      ]
+    },
+    "composite_unseen": {
+      "task_count": 16,
+      "seeds": [1, 2, 3, 4, 5],
+      "timeout_seconds": 3600,
+      "cell_count": 80,
+      "tasks": [
+        "ArrangeBreadBasket",
+        "ArrangeTea",
+        "BreadSelection",
+        "CategorizeCondiments",
+        "CuttingToolSelection",
+        "GarnishPancake",
+        "GatherTableware",
+        "HeatKebabSandwich",
+        "MakeIceLemonade",
+        "PanTransfer",
+        "PortionHotDogs",
+        "RecycleBottlesByType",
+        "SeparateFreezerRack",
+        "WaffleReheat",
+        "WashFruitColander",
+        "WeighIngredients"
+      ]
+    }
+  }
+}

--- a/robots/robocasa/eval/target50.json
+++ b/robots/robocasa/eval/target50.json
@@ -7,6 +7,23 @@
   "total_tasks": 50,
   "total_cells": 340,
   "dependencies": {
+    "runtime": {
+      "python": "3.10",
+      "cuda": "12.6",
+      "constraints_file": "robots/robocasa/eval/target50-constraints.txt",
+      "overrides_file": "robots/robocasa/eval/target50-overrides.txt",
+      "packages": {
+        "mujoco": "3.3.1",
+        "numpy": "1.26.4",
+        "pydantic": "2.13.5",
+        "pydantic-ai-slim": "2.1.0",
+        "rlinf-rldx": "1.0.1.post10",
+        "rlinf-robocasa365": "1.0.1",
+        "torch": "2.7.0",
+        "torchvision": "0.22.0",
+        "transformers": "4.57.6"
+      }
+    },
     "robosuite": {
       "repository": "https://github.com/RLinf/robosuite",
       "commit": "97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
@@ -28,6 +45,15 @@
     "reasoning_effort": "xhigh",
     "max_turns": 100,
     "runtime_is_planner_agnostic": true
+  },
+  "runtime_protocol": {
+    "scene_seed_source": "cli_seed_identity",
+    "use_reset_seed_override": false,
+    "result_schema_version": "1.0",
+    "result_filename": "result.json",
+    "rldx_max_chunks": 40,
+    "rldx_settle_patience": 999,
+    "rldx_action_steps_per_chunk": 8
   },
   "memory_policy": {
     "scope": "same_task_seed_0",

--- a/robots/robocasa/eval/target50_codex_results.md
+++ b/robots/robocasa/eval/target50_codex_results.md
@@ -1,0 +1,89 @@
+# Codex Target50 Results
+
+This page reports the task-level aggregate results for the 340-cell RoboCasa
+Target50 evaluation defined by [`target50.json`](target50.json). The reference
+planner profile is Codex SDK with `gpt-5.5`, `xhigh` reasoning effort, and
+`max_turns=100`. Success is determined only by the environment's
+`state.success` value.
+
+The published record contains aggregate success counts for each task. It does
+not include per-seed traces, raw trajectories, failure classifications, or
+planner credentials, so it supports task-level comparison rather than
+independent per-cell auditing.
+
+## Split Summary
+
+| Split | Tasks | Reproduction | Success rate | Harness VLA reference | Difference |
+|---|---:|---:|---:|---:|---:|
+| Atomic | 18 | 163/180 | 90.56% | 165/180 (91.67%) | -1.11 pp |
+| Composite-Seen | 16 | 49/80 | 61.25% | 45/80 (56.25%) | +5.00 pp |
+| Composite-Unseen | 16 | 12/80 | 15.00% | 11/80 (13.75%) | +1.25 pp |
+| **Overall (task-weighted)** | **50** | **224/340 cells** | **57.00%** | **55.40%** | **+1.60 pp** |
+
+Split rates use `successful cells / evaluated cells`. The overall result uses
+the task-weighted RoboCasa365 convention, under which every task contributes
+equally despite Atomic having ten seeds per task and the composite splits
+having five:
+
+```text
+(18 * 90.555556% + 16 * 61.25% + 16 * 15.00%) / 50 = 57.00%
+```
+
+The reference values are the corresponding Harness VLA Codex counts reported
+for RoboCasa365. See the [Harness VLA paper](https://arxiv.org/abs/2607.08448)
+and the [RPent overview](../../../docs/source-en/rst_source/awesome_works/harnessvla.rst).
+
+## Per-Task Results
+
+| # | Split | Task | Successful cells | Success rate |
+|---:|---|---|---:|---:|
+| 1 | Atomic | CloseBlenderLid | 5/10 | 50% |
+| 2 | Atomic | CloseFridge | 8/10 | 80% |
+| 3 | Atomic | CloseToasterOvenDoor | 9/10 | 90% |
+| 4 | Atomic | CoffeeSetupMug | 9/10 | 90% |
+| 5 | Atomic | NavigateKitchen | 9/10 | 90% |
+| 6 | Atomic | OpenCabinet | 10/10 | 100% |
+| 7 | Atomic | OpenDrawer | 9/10 | 90% |
+| 8 | Atomic | OpenStandMixerHead | 10/10 | 100% |
+| 9 | Atomic | PickPlaceCounterToCabinet | 9/10 | 90% |
+| 10 | Atomic | PickPlaceCounterToStove | 10/10 | 100% |
+| 11 | Atomic | PickPlaceDrawerToCounter | 9/10 | 90% |
+| 12 | Atomic | PickPlaceSinkToCounter | 10/10 | 100% |
+| 13 | Atomic | PickPlaceToasterToCounter | 8/10 | 80% |
+| 14 | Atomic | SlideDishwasherRack | 9/10 | 90% |
+| 15 | Atomic | TurnOffStove | 10/10 | 100% |
+| 16 | Atomic | TurnOnElectricKettle | 10/10 | 100% |
+| 17 | Atomic | TurnOnMicrowave | 9/10 | 90% |
+| 18 | Atomic | TurnOnSinkFaucet | 10/10 | 100% |
+| 19 | Composite-Seen | ScrubCuttingBoard | 5/5 | 100% |
+| 20 | Composite-Seen | StackBowlsCabinet | 5/5 | 100% |
+| 21 | Composite-Seen | WashLettuce | 4/5 | 80% |
+| 22 | Composite-Seen | RinseSinkBasin | 5/5 | 100% |
+| 23 | Composite-Seen | PreSoakPan | 2/5 | 40% |
+| 24 | Composite-Seen | StirVegetables | 2/5 | 40% |
+| 25 | Composite-Seen | LoadDishwasher | 2/5 | 40% |
+| 26 | Composite-Seen | SteamInMicrowave | 3/5 | 60% |
+| 27 | Composite-Seen | SetUpCuttingStation | 1/5 | 20% |
+| 28 | Composite-Seen | GetToastedBread | 1/5 | 20% |
+| 29 | Composite-Seen | DeliverStraw | 0/5 | 0% |
+| 30 | Composite-Seen | KettleBoiling | 3/5 | 60% |
+| 31 | Composite-Seen | PrepareCoffee | 5/5 | 100% |
+| 32 | Composite-Seen | StoreLeftoversInBowl | 4/5 | 80% |
+| 33 | Composite-Seen | SearingMeat | 4/5 | 80% |
+| 34 | Composite-Seen | PackIdenticalLunches | 3/5 | 60% |
+| 35 | Composite-Unseen | ArrangeBreadBasket | 1/5 | 20% |
+| 36 | Composite-Unseen | ArrangeTea | 1/5 | 20% |
+| 37 | Composite-Unseen | BreadSelection | 1/5 | 20% |
+| 38 | Composite-Unseen | CategorizeCondiments | 2/5 | 40% |
+| 39 | Composite-Unseen | CuttingToolSelection | 1/5 | 20% |
+| 40 | Composite-Unseen | GarnishPancake | 0/5 | 0% |
+| 41 | Composite-Unseen | GatherTableware | 1/5 | 20% |
+| 42 | Composite-Unseen | HeatKebabSandwich | 0/5 | 0% |
+| 43 | Composite-Unseen | MakeIceLemonade | 1/5 | 20% |
+| 44 | Composite-Unseen | PanTransfer | 0/5 | 0% |
+| 45 | Composite-Unseen | PortionHotDogs | 1/5 | 20% |
+| 46 | Composite-Unseen | RecycleBottlesByType | 1/5 | 20% |
+| 47 | Composite-Unseen | SeparateFreezerRack | 0/5 | 0% |
+| 48 | Composite-Unseen | WaffleReheat | 1/5 | 20% |
+| 49 | Composite-Unseen | WashFruitColander | 1/5 | 20% |
+| 50 | Composite-Unseen | WeighIngredients | 0/5 | 0% |

--- a/robots/robocasa/eval/target50_codex_results.md
+++ b/robots/robocasa/eval/target50_codex_results.md
@@ -18,7 +18,7 @@ independent per-cell auditing.
 | Atomic | 18 | 163/180 | 90.56% | 165/180 (91.67%) | -1.11 pp |
 | Composite-Seen | 16 | 49/80 | 61.25% | 45/80 (56.25%) | +5.00 pp |
 | Composite-Unseen | 16 | 12/80 | 15.00% | 11/80 (13.75%) | +1.25 pp |
-| **Overall (task-weighted)** | **50** | **224/340 cells** | **57.00%** | **55.40%** | **+1.60 pp** |
+| **Overall (task-weighted)** | **50** | **N/A** | **57.00%** | **55.40%** | **+1.60 pp** |
 
 Split rates use `successful cells / evaluated cells`. The overall result uses
 the task-weighted RoboCasa365 convention, under which every task contributes

--- a/robots/robocasa/eval/validate_target50.py
+++ b/robots/robocasa/eval/validate_target50.py
@@ -1,0 +1,195 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate and summarize a complete RoboCasa Target50 result directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MANIFEST = Path(__file__).with_name("target50.json")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("top-level JSON value must be an object")
+    return value
+
+
+def validate_results(
+    results_root: Path | str,
+    *,
+    manifest_path: Path | str = DEFAULT_MANIFEST,
+) -> tuple[dict[str, Any], list[str]]:
+    """Validate expected result files and return ``(summary, errors)``."""
+    root = Path(results_root)
+    manifest = _load_json(Path(manifest_path))
+    errors: list[str] = []
+    task_rates: list[float] = []
+    valid_cells = 0
+    split_summaries: dict[str, dict[str, Any]] = {}
+
+    reference = manifest["planner_reference"]
+    runtime_protocol = manifest["runtime_protocol"]
+    for split_name, split in manifest["splits"].items():
+        split_successes = 0
+        split_valid = 0
+        for task_name in split["tasks"]:
+            task_successes = 0
+            for seed in split["seeds"]:
+                relative = Path(split_name) / f"{task_name}_s{seed}" / "result.json"
+                path = root / relative
+                if not path.is_file():
+                    errors.append(f"{relative}: missing result.json")
+                    continue
+                try:
+                    result = _load_json(path)
+                except (OSError, ValueError, json.JSONDecodeError) as exc:
+                    errors.append(f"{relative}: invalid JSON: {exc}")
+                    continue
+
+                expected = {
+                    "schema_version": "1.0",
+                    "protocol_id": manifest["protocol_id"],
+                    "evaluation_split": split_name,
+                    "task_name": task_name,
+                    "environment_split": manifest["environment_split"],
+                    "seed": seed,
+                    "success_source": manifest["success_source"],
+                }
+                for key, expected_value in expected.items():
+                    if result.get(key) != expected_value:
+                        errors.append(
+                            f"{relative}: {key}={result.get(key)!r}, "
+                            f"expected {expected_value!r}"
+                        )
+
+                success = result.get("success")
+                if not isinstance(success, bool):
+                    errors.append(f"{relative}: success must be a boolean")
+                if result.get("valid") is not True:
+                    errors.append(f"{relative}: result is not valid")
+                if result.get("termination_reason") not in {
+                    "completed",
+                    "planner_timeout",
+                }:
+                    errors.append(f"{relative}: invalid termination_reason")
+
+                planner = result.get("planner", {})
+                expected_planner = {
+                    "backend": reference["planner"],
+                    "model": reference["model"],
+                    "reasoning_effort": reference["reasoning_effort"],
+                    "max_turns": reference["max_turns"],
+                }
+                if planner != expected_planner:
+                    errors.append(
+                        f"{relative}: planner profile does not match the manifest"
+                    )
+
+                runtime = result.get("runtime", {})
+                if runtime.get("cell_timeout_seconds") != split["timeout_seconds"]:
+                    errors.append(
+                        f"{relative}: cell timeout does not match the manifest"
+                    )
+                if (
+                    runtime.get("rldx_max_chunks")
+                    != runtime_protocol["rldx_max_chunks"]
+                ):
+                    errors.append(
+                        f"{relative}: RLDX max_chunks does not match the manifest"
+                    )
+                if (
+                    runtime.get("rldx_settle_patience")
+                    != runtime_protocol["rldx_settle_patience"]
+                ):
+                    errors.append(
+                        f"{relative}: RLDX settle_patience does not match the manifest"
+                    )
+                if (
+                    runtime.get("rldx_action_steps_per_chunk")
+                    != runtime_protocol["rldx_action_steps_per_chunk"]
+                ):
+                    errors.append(
+                        f"{relative}: RLDX action steps do not match the manifest"
+                    )
+
+                if result.get("valid") is True and isinstance(success, bool):
+                    valid_cells += 1
+                    split_valid += 1
+                    task_successes += int(success)
+                    split_successes += int(success)
+
+            task_rates.append(task_successes / len(split["seeds"]))
+
+        split_summaries[split_name] = {
+            "successes": split_successes,
+            "valid_cells": split_valid,
+            "expected_cells": split["cell_count"],
+            "success_rate": round(split_successes / split["cell_count"], 6),
+        }
+
+    summary = {
+        "protocol_id": manifest["protocol_id"],
+        "valid_cells": valid_cells,
+        "expected_cells": manifest["total_cells"],
+        "splits": split_summaries,
+        "overall": {
+            "metric": "task_weighted_success_rate",
+            "tasks": manifest["total_tasks"],
+            "success_rate": round(sum(task_rates) / len(task_rates), 6),
+        },
+    }
+    return summary, errors
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "results_root",
+        type=Path,
+        help="Directory containing <split>/<Task>_s<seed>/result.json files.",
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the Target50 result validator."""
+    args = _build_parser().parse_args(argv)
+    try:
+        summary, errors = validate_results(
+            args.results_root,
+            manifest_path=args.manifest,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"manifest error: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(summary, indent=2))
+    if errors:
+        print(f"validation failed with {len(errors)} error(s):", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -498,7 +498,7 @@ class RoboCasaPrimitives:
     def rldx_skill(
         self,
         base_clip=None,
-        max_chunks=40,
+        max_chunks=70,
         use_prompt=None,
         prompt="",
         force_reset=False,
@@ -521,7 +521,7 @@ class RoboCasaPrimitives:
     def rldx_arm(
         self,
         base_clip=0.1,
-        max_chunks=40,
+        max_chunks=70,
         use_prompt=None,
         prompt="",
         force_reset=False,

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -423,6 +423,21 @@ class RoboCasaPrimitives:
     ):
         """Execute RLDX with the environment's live, full task language."""
         del use_prompt  # Accepted for compatibility with historical task recipes.
+        configured_max_chunks = os.environ.get("RLDX_MAX_CHUNKS")
+        if configured_max_chunks is not None:
+            max_chunks = int(configured_max_chunks)
+        configured_action_steps = os.environ.get("RLDX_ACTION_STEPS_PER_CHUNK")
+        if configured_action_steps is not None:
+            n_action_steps = int(configured_action_steps)
+        configured_settle_patience = os.environ.get("RLDX_SETTLE_PATIENCE")
+        if configured_settle_patience is not None:
+            settle_patience = int(configured_settle_patience)
+        if max_chunks < 1:
+            raise ValueError("max_chunks must be positive")
+        if n_action_steps < 1:
+            raise ValueError("n_action_steps must be positive")
+        if settle_patience < 1:
+            raise ValueError("settle_patience must be positive")
         task_lang = (
             self.env.current_raw_obs.get("language") or self.env.get_task_language()
         )
@@ -450,6 +465,9 @@ class RoboCasaPrimitives:
             record_frame=self.record_frame,
         )
         result["effective_prompt"] = task_lang
+        result["effective_max_chunks"] = max_chunks
+        result["effective_n_action_steps"] = n_action_steps
+        result["effective_settle_patience"] = settle_patience
         result["prompt_overridden"] = prompt_overridden
         if prompt_overridden:
             result["requested_prompt"] = prompt
@@ -479,7 +497,7 @@ class RoboCasaPrimitives:
     def rldx_skill(
         self,
         base_clip=None,
-        max_chunks=int(os.environ.get("RLDX_MAX_CHUNKS", 70)),
+        max_chunks=40,
         use_prompt=None,
         prompt="",
         force_reset=False,
@@ -502,7 +520,7 @@ class RoboCasaPrimitives:
     def rldx_arm(
         self,
         base_clip=0.1,
-        max_chunks=int(os.environ.get("RLDX_MAX_CHUNKS", 70)),
+        max_chunks=40,
         use_prompt=None,
         prompt="",
         force_reset=False,

--- a/robots/robocasa/primitives.py
+++ b/robots/robocasa/primitives.py
@@ -432,12 +432,13 @@ class RoboCasaPrimitives:
         configured_settle_patience = os.environ.get("RLDX_SETTLE_PATIENCE")
         if configured_settle_patience is not None:
             settle_patience = int(configured_settle_patience)
-        if max_chunks < 1:
-            raise ValueError("max_chunks must be positive")
-        if n_action_steps < 1:
-            raise ValueError("n_action_steps must be positive")
-        if settle_patience < 1:
-            raise ValueError("settle_patience must be positive")
+        for name, value in (
+            ("max_chunks", max_chunks),
+            ("n_action_steps", n_action_steps),
+            ("settle_patience", settle_patience),
+        ):
+            if value < 1:
+                return {"error": f"{name} must be positive; VLA was not executed"}
         task_lang = (
             self.env.current_raw_obs.get("language") or self.env.get_task_language()
         )

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -115,7 +115,7 @@ VLA EXECUTION RULES (the single most important rule):
 2. NEVER put a manual command (move_to / move_base / navigate_to / set_gripper /
    scripted_grasp) BETWEEN two VLA calls of the same sub-operation. Every non-VLA
    command WIPES the VLA's frame history, forcing it to restart from scratch.
-3. Do NOT pass a small max_chunks (default 70 is fine). Do NOT pass
+3. Omit max_chunks and use the protocol default of 40. Do NOT pass
    settle_patience (default 999 disables settle detection).
 4. If RLDX returns 'cap', call it again with the same full task language to
    preserve history. Only re-stage after 2-3 consecutive calls show neither

--- a/robots/robocasa/prompts/system.py
+++ b/robots/robocasa/prompts/system.py
@@ -115,8 +115,9 @@ VLA EXECUTION RULES (the single most important rule):
 2. NEVER put a manual command (move_to / move_base / navigate_to / set_gripper /
    scripted_grasp) BETWEEN two VLA calls of the same sub-operation. Every non-VLA
    command WIPES the VLA's frame history, forcing it to restart from scratch.
-3. Omit max_chunks and use the protocol default of 40. Do NOT pass
-   settle_patience (default 999 disables settle detection).
+3. Omit max_chunks. Ordinary RoboCasa defaults to 70; Target50 exports
+   RLDX_MAX_CHUNKS=40 to lock its protocol. Do NOT pass settle_patience
+   (default 999 disables settle detection).
 4. If RLDX returns 'cap', call it again with the same full task language to
    preserve history. Only re-stage after 2-3 consecutive calls show neither
    contact nor task progress.
@@ -137,9 +138,9 @@ GRIPPER RULES:
 
 MEMORY = """
 Before the first action, use read_text_file to read every existing file below:
-- {{memory_dir}}/task_only/{{task_name}}_s0.json
-- {{memory_dir}}/task_only/{{task_name}}_s0_recipe.jsonl
-- {{memory_dir}}/task_only/{{task_name}}.md
+- {{memory_dir}}/results/{{task_name}}_s0.json
+- {{memory_dir}}/results/recipe_{{task_name}}_s0.jsonl
+- {{memory_dir}}/results/{{task_name}}.md
 The JSON/JSONL pair is reviewed seed-0 evidence. The optional Markdown file is
 task-specific exploration memory and may summarize multiple attempts. Treat all
 three as strategy priors, not trajectories to replay or higher-priority

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -23,6 +23,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from robots.robocasa.eval.result import finalize_cell_result
 from robots.robocasa.prompt_bundle import (
     system_prompt,
     user_prompt,
@@ -87,6 +88,7 @@ def get_robot_spec() -> RobotSpec:
         parse_config=_parse_config,
         init_runtime=_init_runtime,
         dashboard=ROBOCASA_DASHBOARD_SPEC,
+        finalize_run=finalize_cell_result,
     )
 
 

--- a/robots/robocasa/robot_spec.py
+++ b/robots/robocasa/robot_spec.py
@@ -228,6 +228,9 @@ def _spawn_env_server(
             env_overrides={
                 "MUJOCO_GL": "egl",
                 "ROBOT_PLATFORM": "ROBOCASA",
+                # Standard RPent evaluation uses --seed directly. Do not let a
+                # stale variable from legacy paired-scene runs change the reset.
+                "RLDX_RESET_SEED": "",
             },
             log_path=str(Path(output_dir) / "env_server.log"),
         )

--- a/robots/robocasa/toolkit.py
+++ b/robots/robocasa/toolkit.py
@@ -163,6 +163,11 @@ class RoboCasaToolkit(Toolkit):
         except Exception as e:
             logger.warning("failed to save episode video: %s", e)
 
+    def solved(self) -> bool:
+        """Return the success value from the final recorded environment state."""
+        record = self._state.latest_record()
+        return bool(record is not None and record.extras.get("success", False))
+
     def write_recipe(self, recipe_tag: str) -> str:
         """Write the RoboCasa recipe JSONL from the dumped state trace."""
         return robocasa_tools.write_recipe_from_states(self._state, recipe_tag)

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -242,7 +242,7 @@ TOOLS_SPEC = [
                 },
                 "max_chunks": {
                     "type": "integer",
-                    "description": "Action-chunk budget (default 40)",
+                    "description": "Action-chunk budget (default 70)",
                 },
                 "force_reset": {
                     "type": "boolean",
@@ -290,7 +290,7 @@ TOOLS_SPEC = [
                 },
                 "max_chunks": {
                     "type": "integer",
-                    "description": "Action-chunk budget (default 40)",
+                    "description": "Action-chunk budget (default 70)",
                 },
                 "force_reset": {
                     "type": "boolean",

--- a/robots/robocasa/tools.py
+++ b/robots/robocasa/tools.py
@@ -242,7 +242,7 @@ TOOLS_SPEC = [
                 },
                 "max_chunks": {
                     "type": "integer",
-                    "description": "Action-chunk budget (default 70; do NOT set small)",
+                    "description": "Action-chunk budget (default 40)",
                 },
                 "force_reset": {
                     "type": "boolean",
@@ -290,7 +290,7 @@ TOOLS_SPEC = [
                 },
                 "max_chunks": {
                     "type": "integer",
-                    "description": "Action-chunk budget (default 70; do NOT set small)",
+                    "description": "Action-chunk budget (default 40)",
                 },
                 "force_reset": {
                     "type": "boolean",

--- a/rpent/memory/tools.py
+++ b/rpent/memory/tools.py
@@ -26,8 +26,9 @@ from pathlib import Path
 from rpent.tools.toolkit import readonly
 from rpent.utils.config import get_repo_root
 
-# Published memory subtrees an eval run may read.
-_READABLE_SCOPES = {"global", "suite", "task_only"}
+# Published memory subtrees an eval run may read. ``results`` retains
+# compatibility with the immutable RoboCasa task-only corpus.
+_READABLE_SCOPES = {"global", "suite", "task_only", "results"}
 
 # Suffix appended to shared file-tool descriptions when registered through
 # the memory access boundary.

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,3 +53,12 @@ Run the complete suite with:
 ```bash
 pytest tests/unit_tests -v
 ```
+
+Real simulator checks live under `integration_tests` and are always opt-in;
+they are not part of the offline CI suite. For example, after installing the
+RoboCasa extra and assets, run its Target50 environment contract with:
+
+```bash
+RPENT_RUN_ROBOCASA_INTEGRATION=1 \
+  pytest tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py -v
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -56,9 +56,13 @@ pytest tests/unit_tests -v
 
 Real simulator checks live under `integration_tests` and are always opt-in;
 they are not part of the offline CI suite. For example, after installing the
-RoboCasa extra and assets, run its Target50 environment contract with:
+RoboCasa extra and assets, run its 340-cell Target50 environment contract with:
 
 ```bash
 RPENT_RUN_ROBOCASA_INTEGRATION=1 \
   pytest tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py -v
 ```
+
+This opt-in test constructs and resets every manifest task/seed cell, verifies
+the 12D action interface, operation cameras, navigation RGB-D/world map,
+success predicate, and clean close. It does not invoke a planner or VLA model.

--- a/tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py
+++ b/tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in real-environment smoke coverage for every Target50 task."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MANIFEST_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50.json"
+
+
+def _target50_tasks() -> list[str]:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return [task for split in manifest["splits"].values() for task in split["tasks"]]
+
+
+class _DirectRpc:
+    def __init__(self, facade) -> None:
+        self.facade = facade
+
+    def call(
+        self,
+        method: str,
+        args: tuple = (),
+        kwargs: dict | None = None,
+        timeout_s: float | None = None,
+    ):
+        del timeout_s
+        handler = getattr(self.facade, method.removeprefix("env."))
+        return handler(*args, **(kwargs or {}))
+
+
+@pytest.mark.parametrize("task_name", _target50_tasks())
+def test_target50_environment_contract(task_name, monkeypatch):
+    if os.environ.get("RPENT_RUN_ROBOCASA_INTEGRATION") != "1":
+        pytest.skip("set RPENT_RUN_ROBOCASA_INTEGRATION=1 to run RoboCasa smoke tests")
+
+    pytest.importorskip("robocasa")
+    from robots.robocasa.env_client import RoboCasaEnvClient
+    from robots.robocasa.env_server import DEFAULT_CAMS, RoboCasaEnvFacade
+
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    monkeypatch.setenv("ROBOT_PLATFORM", "ROBOCASA")
+    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
+
+    facade = RoboCasaEnvFacade(
+        task_name=task_name,
+        split="target",
+        seed=1,
+        camera_h=64,
+        camera_w=64,
+    )
+    try:
+        assert facade.env.sim is None
+        client = RoboCasaEnvClient(
+            _DirectRpc(facade),
+            expected_meta=facade.get_env_meta(),
+        )
+
+        assert facade.env.action_dim == 12
+        task_language = client.get_task_language()
+        assert isinstance(task_language, str) and task_language.strip()
+
+        action = np.zeros(12, dtype=np.float64)
+        client.step(action)
+        assert isinstance(client.check_success(), bool)
+
+        for camera_name in DEFAULT_CAMS:
+            rgb = client.render_camera(camera_name)
+            assert rgb.shape == (64, 64, 3)
+            assert np.isfinite(rgb).all()
+
+        nav_rgb, nav_depth = client.render_camera("navview", depth=True)
+        nav_world = client.world_map("navview")
+        assert nav_rgb.shape == (64, 64, 3)
+        assert nav_depth.shape == (64, 64)
+        assert nav_world.shape == (64, 64, 3)
+        assert np.isfinite(nav_rgb).all()
+        assert np.isfinite(nav_depth).all()
+        assert np.isfinite(nav_world).all()
+    finally:
+        facade.close()

--- a/tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py
+++ b/tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py
@@ -27,9 +27,14 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 MANIFEST_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50.json"
 
 
-def _target50_tasks() -> list[str]:
+def _target50_cells() -> list[tuple[str, int]]:
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-    return [task for split in manifest["splits"].values() for task in split["tasks"]]
+    return [
+        (task, seed)
+        for split in manifest["splits"].values()
+        for task in split["tasks"]
+        for seed in split["seeds"]
+    ]
 
 
 class _DirectRpc:
@@ -48,8 +53,13 @@ class _DirectRpc:
         return handler(*args, **(kwargs or {}))
 
 
-@pytest.mark.parametrize("task_name", _target50_tasks())
-def test_target50_environment_contract(task_name, monkeypatch):
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    ("task_name", "seed"),
+    _target50_cells(),
+    ids=lambda value: str(value),
+)
+def test_target50_environment_contract(task_name, seed, monkeypatch):
     if os.environ.get("RPENT_RUN_ROBOCASA_INTEGRATION") != "1":
         pytest.skip("set RPENT_RUN_ROBOCASA_INTEGRATION=1 to run RoboCasa smoke tests")
 
@@ -64,7 +74,7 @@ def test_target50_environment_contract(task_name, monkeypatch):
     facade = RoboCasaEnvFacade(
         task_name=task_name,
         split="target",
-        seed=1,
+        seed=seed,
         camera_h=64,
         camera_w=64,
     )
@@ -96,5 +106,62 @@ def test_target50_environment_contract(task_name, monkeypatch):
         assert np.isfinite(nav_rgb).all()
         assert np.isfinite(nav_depth).all()
         assert np.isfinite(nav_world).all()
+    finally:
+        facade.close()
+
+
+@pytest.mark.timeout(180)
+def test_nav_camera_follows_mobile_base(monkeypatch):
+    if os.environ.get("RPENT_RUN_ROBOCASA_INTEGRATION") != "1":
+        pytest.skip("set RPENT_RUN_ROBOCASA_INTEGRATION=1 to run RoboCasa smoke tests")
+
+    pytest.importorskip("robocasa")
+    from robots.robocasa.env_client import RoboCasaEnvClient
+    from robots.robocasa.env_server import RoboCasaEnvFacade
+
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    monkeypatch.setenv("ROBOT_PLATFORM", "ROBOCASA")
+    monkeypatch.delenv("RLDX_RESET_SEED", raising=False)
+
+    facade = RoboCasaEnvFacade(
+        task_name="OpenDrawer",
+        split="target",
+        seed=1,
+        camera_h=64,
+        camera_w=64,
+    )
+    try:
+        client = RoboCasaEnvClient(
+            _DirectRpc(facade),
+            expected_meta=facade.get_env_meta(),
+        )
+        base_before = np.asarray(
+            client.current_raw_obs["robot0_base_pos"], dtype=np.float64
+        )
+        camera_before = np.asarray(
+            client.get_camera_meta("navview")["extrinsic_cam2world"],
+            dtype=np.float64,
+        )
+        image_before = client.render_camera("navview").astype(np.float64)
+
+        action = np.zeros(12, dtype=np.float64)
+        action[6] = 1.0
+        action[7] = 0.2
+        action[11] = 1.0
+        for _ in range(8):
+            client.step(action)
+
+        base_after = np.asarray(
+            client.current_raw_obs["robot0_base_pos"], dtype=np.float64
+        )
+        camera_after = np.asarray(
+            client.get_camera_meta("navview")["extrinsic_cam2world"],
+            dtype=np.float64,
+        )
+        image_after = client.render_camera("navview").astype(np.float64)
+
+        assert np.linalg.norm(base_after - base_before) > 1e-4
+        assert np.linalg.norm(camera_after - camera_before) > 1e-4
+        assert np.mean(np.abs(image_after - image_before)) > 0.1
     finally:
         facade.close()

--- a/tests/unit_tests/robots/robocasa/test_memory_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_memory_contracts.py
@@ -21,6 +21,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from robots.robocasa.prompt_bundle import system_prompt
 from robots.robocasa.robot_spec import _parse_config
 from rpent.memory import MemoryManager
@@ -79,18 +81,22 @@ def test_default_memory_sync_uses_robocasa_subtree(monkeypatch, tmp_path):
     }
 
 
-def test_task_only_corpus_is_readable_through_memory_tool(monkeypatch, tmp_path):
+def test_results_corpus_is_readable_through_memory_tool(monkeypatch, tmp_path):
     monkeypatch.setenv("RPENT_REPO_ROOT", str(tmp_path))
     memory_root = tmp_path / "memory" / "robocasa"
-    task_only = memory_root / "task_only"
-    task_only.mkdir(parents=True)
-    audit = task_only / "OpenDrawer_s0.json"
+    results = memory_root / "results"
+    results.mkdir(parents=True)
+    audit = results / "OpenDrawer_s0.json"
     audit.write_text('{"success": true}\n')
 
     manager = MemoryManager(root=memory_root)
-    read_text_file = manager.get_common_tool_bindings()["read_text_file"][1]
+    bindings = manager.get_common_tool_bindings()
+    read_text_file = bindings["read_text_file"][1]
+    write_text_file = bindings["write_text_file"][1]
 
     assert read_text_file(path=str(audit))["content"] == '{"success": true}\n'
+    with pytest.raises(PermissionError, match="writing to memory is denied"):
+        write_text_file(path=str(audit), content="{}\n")
 
 
 def test_parse_config_resolves_local_memory_dir(tmp_path):
@@ -113,9 +119,9 @@ def test_prompt_names_only_current_task_memory(tmp_path):
         },
     )
 
-    assert str(memory_dir / "task_only" / "OpenDrawer_s0.json") in rendered
-    assert str(memory_dir / "task_only" / "OpenDrawer_s0_recipe.jsonl") in rendered
-    assert str(memory_dir / "task_only" / "OpenDrawer.md") in rendered
+    assert str(memory_dir / "results" / "OpenDrawer_s0.json") in rendered
+    assert str(memory_dir / "results" / "recipe_OpenDrawer_s0.jsonl") in rendered
+    assert str(memory_dir / "results" / "OpenDrawer.md") in rendered
     assert "read every existing file" in rendered
     assert "ArrangeTea_s0" not in rendered
     assert "GLOBAL_MEMORY" not in rendered

--- a/tests/unit_tests/robots/robocasa/test_robocasa_toolkit_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_robocasa_toolkit_contracts.py
@@ -52,7 +52,7 @@ EXPECTED_TOOLS = COMMON_TOOLS | {
 
 
 def _record(step_idx: int = 0) -> SimpleNamespace:
-    return SimpleNamespace(step_idx=step_idx, terminated=False)
+    return SimpleNamespace(step_idx=step_idx, terminated=False, extras={})
 
 
 def _tool_names(robot_toolkit: Toolkit) -> set[str]:
@@ -139,3 +139,14 @@ def test_toolkit_constructs_and_classifies_tools_with_a_fake(
     assert primitive.recording_started is True
     assert callable(primitive.kwargs["check_cancelled"])
     assert (tmp_path / "success_criteria.md").read_text() == "offline success criteria"
+
+
+def test_solved_reads_only_the_final_environment_record() -> None:
+    records = [SimpleNamespace(extras={"success": True})]
+    robot_toolkit = toolkit.RoboCasaToolkit.__new__(toolkit.RoboCasaToolkit)
+    robot_toolkit._state = SimpleNamespace(latest_record=lambda: records[-1])
+
+    assert robot_toolkit.solved() is True
+
+    records.append(SimpleNamespace(extras={"success": False}))
+    assert robot_toolkit.solved() is False

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -22,8 +22,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from robots.robocasa import robot_spec
-from robots.robocasa.eval.result import build_cell_result, write_cell_result
+from robots.robocasa.eval.result import build_cell_result, finalize_cell_result
 from robots.robocasa.eval.validate_target50 import validate_results
+from rpent.evaluation import RunFinalizationContext, write_json_atomic
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 MANIFEST_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50.json"
@@ -350,30 +351,95 @@ def test_cell_result_counts_planner_timeout_but_not_missing_environment_result()
     assert missing["valid"] is False
 
 
-def test_cell_result_writer_is_atomic(tmp_path, monkeypatch):
+def test_robocasa_registers_and_adapts_shared_result_finalizer(tmp_path, monkeypatch):
     monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
 
-    path = write_cell_result(
-        tmp_path,
-        **{
-            "task_name": "OpenDrawer",
-            "environment_split": "target",
-            "seed": 1,
-            "success": True,
-            "environment_result_available": True,
-            "agent_error": None,
-            "elapsed_s": 12.34,
-            "planner": "codex",
-            "model": "gpt-5.5",
-            "reasoning_effort": "xhigh",
-            "max_turns": 100,
-            "cell_timeout_seconds": 1800,
-        },
+    spec = robot_spec.get_robot_spec()
+    assert spec.finalize_run is finalize_cell_result
+
+    path = finalize_cell_result(
+        RunFinalizationContext(
+            output_dir=tmp_path,
+            robot_name="robocasa",
+            task_desc={
+                "task_name": "OpenDrawer",
+                "split": "target",
+                "seed": 1,
+            },
+            environment_success=True,
+            agent_error=None,
+            elapsed_s=12.34,
+            planner="codex",
+            model="gpt-5.5",
+            reasoning_effort="xhigh",
+            max_turns=100,
+            planner_timeout_s=1800,
+            finish_result={"status": "failure", "summary": "ignored claim"},
+            stats={"tool_calls": 3},
+        )
     )
 
     assert path == tmp_path / "result.json"
-    assert json.loads(path.read_text(encoding="utf-8"))["success"] is True
-    assert not (tmp_path / ".result.json.tmp").exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == _cell_result(success=True)
+
+
+def test_robocasa_finalizer_marks_missing_environment_result_invalid(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+
+    path = finalize_cell_result(
+        RunFinalizationContext(
+            output_dir=tmp_path,
+            robot_name="robocasa",
+            task_desc={
+                "task_name": "OpenDrawer",
+                "split": "target",
+                "seed": 1,
+            },
+            environment_success=None,
+            agent_error="environment unavailable",
+            elapsed_s=12.34,
+            planner="codex",
+            model="gpt-5.5",
+            reasoning_effort="xhigh",
+            max_turns=100,
+            planner_timeout_s=1800,
+            finish_result=None,
+            stats={},
+        )
+    )
+
+    result = json.loads(path.read_text(encoding="utf-8"))
+    assert result["valid"] is False
+    assert result["success"] is False
+    assert result["termination_reason"] == "infrastructure_error"
+
+
+def _write_valid_cell_result(
+    output_dir: Path,
+    *,
+    task_name: str,
+    seed: int,
+    cell_timeout_seconds: int,
+) -> None:
+    write_json_atomic(
+        output_dir / "result.json",
+        build_cell_result(
+            task_name=task_name,
+            environment_split="target",
+            seed=seed,
+            success=True,
+            environment_result_available=True,
+            agent_error=None,
+            elapsed_s=1.0,
+            planner="codex",
+            model="gpt-5.5",
+            reasoning_effort="xhigh",
+            max_turns=100,
+            cell_timeout_seconds=cell_timeout_seconds,
+        ),
+    )
 
 
 def test_target50_validator_accepts_exactly_all_340_cells(tmp_path, monkeypatch):
@@ -385,19 +451,10 @@ def test_target50_validator_accepts_exactly_all_340_cells(tmp_path, monkeypatch)
             for seed in split["seeds"]:
                 output_dir = tmp_path / split_name / f"{task_name}_s{seed}"
                 output_dir.mkdir(parents=True)
-                write_cell_result(
+                _write_valid_cell_result(
                     output_dir,
                     task_name=task_name,
-                    environment_split="target",
                     seed=seed,
-                    success=True,
-                    environment_result_available=True,
-                    agent_error=None,
-                    elapsed_s=1.0,
-                    planner="codex",
-                    model="gpt-5.5",
-                    reasoning_effort="xhigh",
-                    max_turns=100,
                     cell_timeout_seconds=split["timeout_seconds"],
                 )
 

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -33,79 +33,25 @@ CONSTRAINTS_PATH = (
 )
 OVERRIDES_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50-overrides.txt"
 RESULTS_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50_codex_results.md"
-DOCUMENTATION_PATHS = [
-    REPO_ROOT / "robots" / "robocasa" / "README.md",
-    REPO_ROOT / "docs" / "source-en" / "rst_source" / "usage" / "robocasa.rst",
-    REPO_ROOT / "docs" / "source-zh" / "rst_source" / "usage" / "robocasa.rst",
-]
-
-EXPECTED_TASKS = {
+EXPECTED_SPLIT_SHAPES = {
     "atomic": {
-        "CloseBlenderLid",
-        "CloseFridge",
-        "CloseToasterOvenDoor",
-        "CoffeeSetupMug",
-        "NavigateKitchen",
-        "OpenCabinet",
-        "OpenDrawer",
-        "OpenStandMixerHead",
-        "PickPlaceCounterToCabinet",
-        "PickPlaceCounterToStove",
-        "PickPlaceDrawerToCounter",
-        "PickPlaceSinkToCounter",
-        "PickPlaceToasterToCounter",
-        "SlideDishwasherRack",
-        "TurnOffStove",
-        "TurnOnElectricKettle",
-        "TurnOnMicrowave",
-        "TurnOnSinkFaucet",
+        "task_count": 18,
+        "seeds": list(range(1, 11)),
+        "timeout_seconds": 1800,
+        "cell_count": 180,
     },
     "composite_seen": {
-        "DeliverStraw",
-        "GetToastedBread",
-        "KettleBoiling",
-        "LoadDishwasher",
-        "PackIdenticalLunches",
-        "PrepareCoffee",
-        "PreSoakPan",
-        "RinseSinkBasin",
-        "ScrubCuttingBoard",
-        "SearingMeat",
-        "SetUpCuttingStation",
-        "StackBowlsCabinet",
-        "SteamInMicrowave",
-        "StirVegetables",
-        "StoreLeftoversInBowl",
-        "WashLettuce",
+        "task_count": 16,
+        "seeds": list(range(1, 6)),
+        "timeout_seconds": 3600,
+        "cell_count": 80,
     },
     "composite_unseen": {
-        "ArrangeBreadBasket",
-        "ArrangeTea",
-        "BreadSelection",
-        "CategorizeCondiments",
-        "CuttingToolSelection",
-        "GarnishPancake",
-        "GatherTableware",
-        "HeatKebabSandwich",
-        "MakeIceLemonade",
-        "PanTransfer",
-        "PortionHotDogs",
-        "RecycleBottlesByType",
-        "SeparateFreezerRack",
-        "WaffleReheat",
-        "WashFruitColander",
-        "WeighIngredients",
+        "task_count": 16,
+        "seeds": list(range(1, 6)),
+        "timeout_seconds": 3600,
+        "cell_count": 80,
     },
-}
-
-MEMORYLESS_TASKS = {
-    "HeatKebabSandwich",
-    "PanTransfer",
-    "PortionHotDogs",
-    "SeparateFreezerRack",
-    "WaffleReheat",
-    "WashFruitColander",
-    "WeighIngredients",
 }
 
 
@@ -184,21 +130,19 @@ def test_target50_matrix_is_exact_and_has_no_duplicate_cells():
     manifest = _manifest()
     splits = manifest["splits"]
 
-    assert set(splits) == set(EXPECTED_TASKS)
-    assert splits["atomic"]["seeds"] == list(range(1, 11))
-    assert splits["composite_seen"]["seeds"] == list(range(1, 6))
-    assert splits["composite_unseen"]["seeds"] == list(range(1, 6))
-    assert splits["atomic"]["timeout_seconds"] == 1800
-    assert splits["composite_seen"]["timeout_seconds"] == 3600
-    assert splits["composite_unseen"]["timeout_seconds"] == 3600
+    assert set(splits) == set(EXPECTED_SPLIT_SHAPES)
 
     tasks: list[str] = []
     cells: list[tuple[str, str, int]] = []
-    for split_name, expected_tasks in EXPECTED_TASKS.items():
+    for split_name, expected_shape in EXPECTED_SPLIT_SHAPES.items():
         split = splits[split_name]
-        assert set(split["tasks"]) == expected_tasks
-        assert split["task_count"] == len(expected_tasks)
-        assert split["cell_count"] == len(expected_tasks) * len(split["seeds"])
+        assert split["task_count"] == expected_shape["task_count"]
+        assert split["seeds"] == expected_shape["seeds"]
+        assert split["timeout_seconds"] == expected_shape["timeout_seconds"]
+        assert split["cell_count"] == expected_shape["cell_count"]
+        assert len(split["tasks"]) == split["task_count"]
+        assert len(split["tasks"]) == len(set(split["tasks"]))
+        assert split["cell_count"] == len(split["tasks"]) * len(split["seeds"])
         tasks.extend(split["tasks"])
         cells.extend(
             (split_name, task, seed)
@@ -224,11 +168,13 @@ def test_target50_memory_and_retry_boundaries_are_frozen():
     assert memory["optional_files"] == ["<Task>.md"]
     assert memory["use_global_memory"] is False
     assert memory["use_cross_task_memory"] is False
-    assert set(memory["tasks_without_memory"]) == MEMORYLESS_TASKS
-    assert MEMORYLESS_TASKS < EXPECTED_TASKS["composite_unseen"]
-
-    all_tasks = set().union(*EXPECTED_TASKS.values())
-    assert memory["tasks_with_memory"] == len(all_tasks - MEMORYLESS_TASKS) == 43
+    memoryless_tasks = set(memory["tasks_without_memory"])
+    all_tasks = {
+        task for split in manifest["splits"].values() for task in split["tasks"]
+    }
+    assert len(memoryless_tasks) == 7
+    assert memoryless_tasks < set(manifest["splits"]["composite_unseen"]["tasks"])
+    assert memory["tasks_with_memory"] == len(all_tasks - memoryless_tasks) == 43
     assert manifest["retry_policy"] == {
         "retry_infrastructure_failure_without_valid_environment_result": True,
         "retry_valid_task_failure": False,
@@ -509,7 +455,10 @@ def test_published_results_cover_target50_and_match_split_totals():
             assert row["evaluated"] == len(split["seeds"])
             assert row["rate"] == 100 * row["successes"] // row["evaluated"]
 
-    assert set(by_task) == set().union(*EXPECTED_TASKS.values())
+    manifest_tasks = {
+        task for split in manifest["splits"].values() for task in split["tasks"]
+    }
+    assert set(by_task) == manifest_tasks
     task_weighted_rate = sum(
         100 * row["successes"] / row["evaluated"] for row in by_task.values()
     ) / len(by_task)
@@ -517,26 +466,3 @@ def test_published_results_cover_target50_and_match_split_totals():
     assert "**Overall (task-weighted)** | **50** | **N/A** | **57.00%**" in (
         RESULTS_PATH.read_text(encoding="utf-8")
     )
-
-
-def test_target50_documentation_uses_frozen_revisions():
-    frozen_values = {
-        "robocasa-harness-vla-v1",
-        "97cfbde4b68d8ec43dad20cf4747297866a6ca2e",
-        "587e9ecdcc5e7184fcc17f58713908edff5af041",
-        "551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b",
-    }
-
-    for path in DOCUMENTATION_PATHS:
-        contents = path.read_text(encoding="utf-8")
-        assert all(value in contents for value in frozen_values), path
-        assert "target50-constraints.txt" in contents, path
-        assert "target50-overrides.txt" in contents, path
-        assert "RLDX_MAX_CHUNKS" in contents, path
-        assert "RLDX_RESET_SEED" in contents, path
-        assert "--memory-profile hf" in contents, path
-        assert "NO_PROXY" in contents, path
-        assert "no_proxy" in contents, path
-        assert "export NO_PROXY" not in contents, path
-        assert "export no_proxy" not in contents, path
-        assert "result.json" in contents, path

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -477,4 +477,6 @@ def test_target50_documentation_uses_frozen_revisions():
         assert "target50-overrides.txt" in contents, path
         assert "RLDX_MAX_CHUNKS" in contents, path
         assert "RLDX_RESET_SEED" in contents, path
+        assert "NO_PROXY" in contents, path
+        assert "no_proxy" in contents, path
         assert "result.json" in contents, path

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -19,9 +19,18 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from types import SimpleNamespace
+
+from robots.robocasa import robot_spec
+from robots.robocasa.eval.result import build_cell_result, write_cell_result
+from robots.robocasa.eval.validate_target50 import validate_results
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 MANIFEST_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50.json"
+CONSTRAINTS_PATH = (
+    REPO_ROOT / "robots" / "robocasa" / "eval" / "target50-constraints.txt"
+)
+OVERRIDES_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50-overrides.txt"
 RESULTS_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50_codex_results.md"
 DOCUMENTATION_PATHS = [
     REPO_ROOT / "robots" / "robocasa" / "README.md",
@@ -115,6 +124,23 @@ def test_target50_manifest_identity_and_dependencies():
     assert manifest["total_cells"] == 340
 
     dependencies = manifest["dependencies"]
+    assert dependencies["runtime"] == {
+        "python": "3.10",
+        "cuda": "12.6",
+        "constraints_file": "robots/robocasa/eval/target50-constraints.txt",
+        "overrides_file": "robots/robocasa/eval/target50-overrides.txt",
+        "packages": {
+            "mujoco": "3.3.1",
+            "numpy": "1.26.4",
+            "pydantic": "2.13.5",
+            "pydantic-ai-slim": "2.1.0",
+            "rlinf-rldx": "1.0.1.post10",
+            "rlinf-robocasa365": "1.0.1",
+            "torch": "2.7.0",
+            "torchvision": "0.22.0",
+            "transformers": "4.57.6",
+        },
+    }
     assert dependencies["robosuite"]["commit"] == (
         "97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
     )
@@ -126,6 +152,30 @@ def test_target50_manifest_identity_and_dependencies():
         "repository_type": "dataset",
         "revision": "551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b",
         "include_pattern": "robocasa/**",
+    }
+
+
+def test_target50_constraints_match_manifest_packages():
+    packages = _manifest()["dependencies"]["runtime"]["packages"]
+    constraints = {
+        line.strip()
+        for line in CONSTRAINTS_PATH.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+    assert constraints == {f"{name}=={version}" for name, version in packages.items()}
+
+
+def test_target50_override_freezes_robosuite_source():
+    revision = _manifest()["dependencies"]["robosuite"]["commit"]
+    overrides = {
+        line.strip()
+        for line in OVERRIDES_PATH.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+    assert overrides == {
+        f"robosuite @ git+https://github.com/RLinf/robosuite.git@{revision}"
     }
 
 
@@ -197,6 +247,171 @@ def test_target50_codex_profile_is_reference_only():
     }
 
 
+def test_target50_runtime_protocol_is_frozen():
+    assert _manifest()["runtime_protocol"] == {
+        "scene_seed_source": "cli_seed_identity",
+        "use_reset_seed_override": False,
+        "result_schema_version": "1.0",
+        "result_filename": "result.json",
+        "rldx_max_chunks": 40,
+        "rldx_settle_patience": 999,
+        "rldx_action_steps_per_chunk": 8,
+    }
+
+
+def test_spawned_environment_uses_cli_seed_and_clears_legacy_override(
+    tmp_path, monkeypatch
+):
+    captured = {}
+
+    class FakeDaemon:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.setattr(robot_spec, "ProcessDaemon", FakeDaemon)
+    monkeypatch.setattr(robot_spec, "pick_free_port", lambda: 43210)
+    monkeypatch.setattr(robot_spec, "HttpRpcClient", lambda url: url)
+    args = SimpleNamespace(
+        env_endpoint=None,
+        task_name="OpenDrawer",
+        split="target",
+        seed=7,
+        cuda_device=0,
+    )
+
+    daemon, client = robot_spec._spawn_env_server(args, tmp_path)
+
+    seed_index = captured["cmd"].index("--seed")
+    assert captured["cmd"][seed_index + 1] == "7"
+    assert captured["env_overrides"]["RLDX_RESET_SEED"] == ""
+    assert captured["started"] is True
+    assert daemon is not None
+    assert client == "http://127.0.0.1:43210"
+
+
+def _cell_result(**overrides) -> dict:
+    values = {
+        "task_name": "OpenDrawer",
+        "environment_split": "target",
+        "seed": 1,
+        "success": False,
+        "environment_result_available": True,
+        "agent_error": None,
+        "elapsed_s": 12.34,
+        "planner": "codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "xhigh",
+        "max_turns": 100,
+        "cell_timeout_seconds": 1800,
+    }
+    values.update(overrides)
+    return build_cell_result(**values)
+
+
+def test_cell_result_uses_environment_success_and_sanitizes_errors(monkeypatch):
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+    monkeypatch.setenv("RLDX_SETTLE_PATIENCE", "999")
+    monkeypatch.setenv("RLDX_ACTION_STEPS_PER_CHUNK", "8")
+
+    result = _cell_result(
+        success=False,
+        agent_error="private provider connection failed at a secret endpoint",
+    )
+
+    assert result["protocol_id"] == "robocasa-harness-vla-v1"
+    assert result["evaluation_split"] == "atomic"
+    assert result["success"] is False
+    assert result["success_source"] == "state.success"
+    assert result["valid"] is False
+    assert result["termination_reason"] == "infrastructure_error"
+    assert result["runtime"] == {
+        "cell_timeout_seconds": 1800,
+        "rldx_max_chunks": 40,
+        "rldx_settle_patience": 999,
+        "rldx_action_steps_per_chunk": 8,
+    }
+    assert "secret" not in json.dumps(result)
+    assert "finish" not in result
+
+
+def test_cell_result_counts_planner_timeout_but_not_missing_environment_result():
+    timeout = _cell_result(agent_error="Codex SDK timed out after 1800s")
+    missing = _cell_result(
+        agent_error="Codex SDK timed out after 1800s",
+        environment_result_available=False,
+    )
+
+    assert timeout["termination_reason"] == "planner_timeout"
+    assert timeout["valid"] is True
+    assert timeout["success"] is False
+    assert missing["valid"] is False
+
+
+def test_cell_result_writer_is_atomic(tmp_path, monkeypatch):
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+
+    path = write_cell_result(
+        tmp_path,
+        **{
+            "task_name": "OpenDrawer",
+            "environment_split": "target",
+            "seed": 1,
+            "success": True,
+            "environment_result_available": True,
+            "agent_error": None,
+            "elapsed_s": 12.34,
+            "planner": "codex",
+            "model": "gpt-5.5",
+            "reasoning_effort": "xhigh",
+            "max_turns": 100,
+            "cell_timeout_seconds": 1800,
+        },
+    )
+
+    assert path == tmp_path / "result.json"
+    assert json.loads(path.read_text(encoding="utf-8"))["success"] is True
+    assert not (tmp_path / ".result.json.tmp").exists()
+
+
+def test_target50_validator_accepts_exactly_all_340_cells(tmp_path, monkeypatch):
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+    manifest = _manifest()
+
+    for split_name, split in manifest["splits"].items():
+        for task_name in split["tasks"]:
+            for seed in split["seeds"]:
+                output_dir = tmp_path / split_name / f"{task_name}_s{seed}"
+                output_dir.mkdir(parents=True)
+                write_cell_result(
+                    output_dir,
+                    task_name=task_name,
+                    environment_split="target",
+                    seed=seed,
+                    success=True,
+                    environment_result_available=True,
+                    agent_error=None,
+                    elapsed_s=1.0,
+                    planner="codex",
+                    model="gpt-5.5",
+                    reasoning_effort="xhigh",
+                    max_turns=100,
+                    cell_timeout_seconds=split["timeout_seconds"],
+                )
+
+    summary, errors = validate_results(tmp_path)
+
+    assert errors == []
+    assert summary["valid_cells"] == summary["expected_cells"] == 340
+    assert summary["overall"] == {
+        "metric": "task_weighted_success_rate",
+        "tasks": 50,
+        "success_rate": 1.0,
+    }
+
+
 def test_published_results_cover_target50_and_match_split_totals():
     manifest = _manifest()
     result_rows = re.findall(
@@ -242,6 +457,9 @@ def test_published_results_cover_target50_and_match_split_totals():
         100 * row["successes"] / row["evaluated"] for row in by_task.values()
     ) / len(by_task)
     assert task_weighted_rate == 57.0
+    assert "**Overall (task-weighted)** | **50** | **N/A** | **57.00%**" in (
+        RESULTS_PATH.read_text(encoding="utf-8")
+    )
 
 
 def test_target50_documentation_uses_frozen_revisions():
@@ -255,3 +473,8 @@ def test_target50_documentation_uses_frozen_revisions():
     for path in DOCUMENTATION_PATHS:
         contents = path.read_text(encoding="utf-8")
         assert all(value in contents for value in frozen_values), path
+        assert "target50-constraints.txt" in contents, path
+        assert "target50-overrides.txt" in contents, path
+        assert "RLDX_MAX_CHUNKS" in contents, path
+        assert "RLDX_RESET_SEED" in contents, path
+        assert "result.json" in contents, path

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -477,6 +477,7 @@ def test_target50_documentation_uses_frozen_revisions():
         assert "target50-overrides.txt" in contents, path
         assert "RLDX_MAX_CHUNKS" in contents, path
         assert "RLDX_RESET_SEED" in contents, path
+        assert "--memory-profile hf" in contents, path
         assert "NO_PROXY" in contents, path
         assert "no_proxy" in contents, path
         assert "result.json" in contents, path

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -480,4 +480,6 @@ def test_target50_documentation_uses_frozen_revisions():
         assert "--memory-profile hf" in contents, path
         assert "NO_PROXY" in contents, path
         assert "no_proxy" in contents, path
+        assert "export NO_PROXY" not in contents, path
+        assert "export no_proxy" not in contents, path
         assert "result.json" in contents, path

--- a/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_target50_protocol_contracts.py
@@ -1,0 +1,257 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contracts for the public RoboCasa Target50 evaluation manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MANIFEST_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50.json"
+RESULTS_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50_codex_results.md"
+DOCUMENTATION_PATHS = [
+    REPO_ROOT / "robots" / "robocasa" / "README.md",
+    REPO_ROOT / "docs" / "source-en" / "rst_source" / "usage" / "robocasa.rst",
+    REPO_ROOT / "docs" / "source-zh" / "rst_source" / "usage" / "robocasa.rst",
+]
+
+EXPECTED_TASKS = {
+    "atomic": {
+        "CloseBlenderLid",
+        "CloseFridge",
+        "CloseToasterOvenDoor",
+        "CoffeeSetupMug",
+        "NavigateKitchen",
+        "OpenCabinet",
+        "OpenDrawer",
+        "OpenStandMixerHead",
+        "PickPlaceCounterToCabinet",
+        "PickPlaceCounterToStove",
+        "PickPlaceDrawerToCounter",
+        "PickPlaceSinkToCounter",
+        "PickPlaceToasterToCounter",
+        "SlideDishwasherRack",
+        "TurnOffStove",
+        "TurnOnElectricKettle",
+        "TurnOnMicrowave",
+        "TurnOnSinkFaucet",
+    },
+    "composite_seen": {
+        "DeliverStraw",
+        "GetToastedBread",
+        "KettleBoiling",
+        "LoadDishwasher",
+        "PackIdenticalLunches",
+        "PrepareCoffee",
+        "PreSoakPan",
+        "RinseSinkBasin",
+        "ScrubCuttingBoard",
+        "SearingMeat",
+        "SetUpCuttingStation",
+        "StackBowlsCabinet",
+        "SteamInMicrowave",
+        "StirVegetables",
+        "StoreLeftoversInBowl",
+        "WashLettuce",
+    },
+    "composite_unseen": {
+        "ArrangeBreadBasket",
+        "ArrangeTea",
+        "BreadSelection",
+        "CategorizeCondiments",
+        "CuttingToolSelection",
+        "GarnishPancake",
+        "GatherTableware",
+        "HeatKebabSandwich",
+        "MakeIceLemonade",
+        "PanTransfer",
+        "PortionHotDogs",
+        "RecycleBottlesByType",
+        "SeparateFreezerRack",
+        "WaffleReheat",
+        "WashFruitColander",
+        "WeighIngredients",
+    },
+}
+
+MEMORYLESS_TASKS = {
+    "HeatKebabSandwich",
+    "PanTransfer",
+    "PortionHotDogs",
+    "SeparateFreezerRack",
+    "WaffleReheat",
+    "WashFruitColander",
+    "WeighIngredients",
+}
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_target50_manifest_identity_and_dependencies():
+    manifest = _manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert manifest["protocol_id"] == "robocasa-harness-vla-v1"
+    assert manifest["benchmark"] == "RoboCasa365"
+    assert manifest["environment_split"] == "target"
+    assert manifest["success_source"] == "state.success"
+    assert manifest["total_tasks"] == 50
+    assert manifest["total_cells"] == 340
+
+    dependencies = manifest["dependencies"]
+    assert dependencies["robosuite"]["commit"] == (
+        "97cfbde4b68d8ec43dad20cf4747297866a6ca2e"
+    )
+    assert dependencies["rldx_checkpoint"]["revision"] == (
+        "587e9ecdcc5e7184fcc17f58713908edff5af041"
+    )
+    assert dependencies["task_memory"] == {
+        "repository": "RLinf/RPent-memory",
+        "repository_type": "dataset",
+        "revision": "551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b",
+        "include_pattern": "robocasa/**",
+    }
+
+
+def test_target50_matrix_is_exact_and_has_no_duplicate_cells():
+    manifest = _manifest()
+    splits = manifest["splits"]
+
+    assert set(splits) == set(EXPECTED_TASKS)
+    assert splits["atomic"]["seeds"] == list(range(1, 11))
+    assert splits["composite_seen"]["seeds"] == list(range(1, 6))
+    assert splits["composite_unseen"]["seeds"] == list(range(1, 6))
+    assert splits["atomic"]["timeout_seconds"] == 1800
+    assert splits["composite_seen"]["timeout_seconds"] == 3600
+    assert splits["composite_unseen"]["timeout_seconds"] == 3600
+
+    tasks: list[str] = []
+    cells: list[tuple[str, str, int]] = []
+    for split_name, expected_tasks in EXPECTED_TASKS.items():
+        split = splits[split_name]
+        assert set(split["tasks"]) == expected_tasks
+        assert split["task_count"] == len(expected_tasks)
+        assert split["cell_count"] == len(expected_tasks) * len(split["seeds"])
+        tasks.extend(split["tasks"])
+        cells.extend(
+            (split_name, task, seed)
+            for task in split["tasks"]
+            for seed in split["seeds"]
+        )
+
+    assert len(tasks) == len(set(tasks)) == manifest["total_tasks"] == 50
+    assert len(cells) == len(set(cells)) == manifest["total_cells"] == 340
+    assert sum(split["cell_count"] for split in splits.values()) == 340
+
+
+def test_target50_memory_and_retry_boundaries_are_frozen():
+    manifest = _manifest()
+    memory = manifest["memory_policy"]
+
+    assert memory["scope"] == "same_task_seed_0"
+    assert memory["results_directory"] == "robocasa/results"
+    assert memory["required_files"] == [
+        "<Task>_s0.json",
+        "recipe_<Task>_s0.jsonl",
+    ]
+    assert memory["optional_files"] == ["<Task>.md"]
+    assert memory["use_global_memory"] is False
+    assert memory["use_cross_task_memory"] is False
+    assert set(memory["tasks_without_memory"]) == MEMORYLESS_TASKS
+    assert MEMORYLESS_TASKS < EXPECTED_TASKS["composite_unseen"]
+
+    all_tasks = set().union(*EXPECTED_TASKS.values())
+    assert memory["tasks_with_memory"] == len(all_tasks - MEMORYLESS_TASKS) == 43
+    assert manifest["retry_policy"] == {
+        "retry_infrastructure_failure_without_valid_environment_result": True,
+        "retry_valid_task_failure": False,
+        "retry_planner_timeout": False,
+    }
+
+
+def test_target50_codex_profile_is_reference_only():
+    reference = _manifest()["planner_reference"]
+
+    assert reference == {
+        "planner": "codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "xhigh",
+        "max_turns": 100,
+        "runtime_is_planner_agnostic": True,
+    }
+
+
+def test_published_results_cover_target50_and_match_split_totals():
+    manifest = _manifest()
+    result_rows = re.findall(
+        r"^\| \d+ \| (Atomic|Composite-Seen|Composite-Unseen) "
+        r"\| ([A-Za-z0-9]+) \| (\d+)/(\d+) \| (\d+)% \|$",
+        RESULTS_PATH.read_text(encoding="utf-8"),
+        flags=re.MULTILINE,
+    )
+
+    assert len(result_rows) == 50
+    by_task = {
+        task: {
+            "split": split,
+            "successes": int(successes),
+            "evaluated": int(evaluated),
+            "rate": int(rate),
+        }
+        for split, task, successes, evaluated, rate in result_rows
+    }
+    assert len(by_task) == 50
+
+    split_labels = {
+        "atomic": "Atomic",
+        "composite_seen": "Composite-Seen",
+        "composite_unseen": "Composite-Unseen",
+    }
+    expected_successes = {
+        "atomic": 163,
+        "composite_seen": 49,
+        "composite_unseen": 12,
+    }
+    for split_name, split in manifest["splits"].items():
+        rows = [by_task[task] for task in split["tasks"]]
+        assert {row["split"] for row in rows} == {split_labels[split_name]}
+        assert sum(row["successes"] for row in rows) == expected_successes[split_name]
+        assert sum(row["evaluated"] for row in rows) == split["cell_count"]
+        for row in rows:
+            assert row["evaluated"] == len(split["seeds"])
+            assert row["rate"] == 100 * row["successes"] // row["evaluated"]
+
+    assert set(by_task) == set().union(*EXPECTED_TASKS.values())
+    task_weighted_rate = sum(
+        100 * row["successes"] / row["evaluated"] for row in by_task.values()
+    ) / len(by_task)
+    assert task_weighted_rate == 57.0
+
+
+def test_target50_documentation_uses_frozen_revisions():
+    frozen_values = {
+        "robocasa-harness-vla-v1",
+        "97cfbde4b68d8ec43dad20cf4747297866a6ca2e",
+        "587e9ecdcc5e7184fcc17f58713908edff5af041",
+        "551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b",
+    }
+
+    for path in DOCUMENTATION_PATHS:
+        contents = path.read_text(encoding="utf-8")
+        assert all(value in contents for value in frozen_values), path

--- a/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
@@ -135,6 +135,17 @@ def test_environment_max_chunks_locks_the_formal_protocol(monkeypatch) -> None:
     assert result["effective_max_chunks"] == 40
 
 
+def test_ordinary_robocasa_keeps_default_max_chunks_at_70(monkeypatch) -> None:
+    task_language = "Open the left drawer."
+    primitives, rldx = _fake_primitives(task_language)
+    monkeypatch.delenv("RLDX_MAX_CHUNKS", raising=False)
+
+    result = primitives.rldx_skill(prompt=task_language)
+
+    assert rldx.calls[0]["max_chunks"] == 70
+    assert result["effective_max_chunks"] == 70
+
+
 def test_environment_locks_all_formal_rldx_runtime_values(monkeypatch) -> None:
     task_language = "Open the left drawer."
     primitives, rldx = _fake_primitives(task_language)

--- a/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
@@ -157,6 +157,31 @@ def test_environment_locks_all_formal_rldx_runtime_values(monkeypatch) -> None:
     assert result["effective_settle_patience"] == 999
 
 
+def test_invalid_vla_budgets_return_errors_without_executing_rldx(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("RLDX_MAX_CHUNKS", raising=False)
+    monkeypatch.delenv("RLDX_ACTION_STEPS_PER_CHUNK", raising=False)
+    monkeypatch.delenv("RLDX_SETTLE_PATIENCE", raising=False)
+
+    for arguments, parameter in (
+        ({"max_chunks": 0}, "max_chunks"),
+        ({"n_action_steps": 0}, "n_action_steps"),
+        ({"settle_patience": 0}, "settle_patience"),
+    ):
+        primitives, rldx = _fake_primitives("Open the left drawer.")
+
+        result = primitives.rldx_skill(
+            prompt="Open the left drawer.",
+            **arguments,
+        )
+
+        assert result == {
+            "error": f"{parameter} must be positive; VLA was not executed"
+        }
+        assert rldx.calls == []
+
+
 def test_matching_vla_prompt_is_reported_without_override() -> None:
     task_language = "Open the left drawer."
     primitives, rldx = _fake_primitives(task_language)

--- a/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_vla_protocol_contracts.py
@@ -116,10 +116,45 @@ def test_vla_always_uses_live_task_language_and_preserves_continuity() -> None:
     assert rldx.calls[1]["force_reset"] is False
     assert primitives._vla_desync is False
     assert first["effective_prompt"] == task_language
+    assert first["effective_max_chunks"] == 3
     assert first["prompt_overridden"] is True
     assert first["requested_prompt"] == "Pick the squash up."
     assert second["effective_prompt"] == task_language
+    assert second["effective_max_chunks"] == 4
     assert second["prompt_overridden"] is True
+
+
+def test_environment_max_chunks_locks_the_formal_protocol(monkeypatch) -> None:
+    task_language = "Open the left drawer."
+    primitives, rldx = _fake_primitives(task_language)
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+
+    result = primitives.rldx_skill(prompt=task_language, max_chunks=70)
+
+    assert rldx.calls[0]["max_chunks"] == 40
+    assert result["effective_max_chunks"] == 40
+
+
+def test_environment_locks_all_formal_rldx_runtime_values(monkeypatch) -> None:
+    task_language = "Open the left drawer."
+    primitives, rldx = _fake_primitives(task_language)
+    monkeypatch.setenv("RLDX_MAX_CHUNKS", "40")
+    monkeypatch.setenv("RLDX_ACTION_STEPS_PER_CHUNK", "8")
+    monkeypatch.setenv("RLDX_SETTLE_PATIENCE", "999")
+
+    result = primitives.rldx_skill(
+        prompt=task_language,
+        max_chunks=2,
+        n_action_steps=1,
+        settle_patience=2,
+    )
+
+    assert rldx.calls[0]["max_chunks"] == 40
+    assert rldx.calls[0]["n_action_steps"] == 8
+    assert rldx.calls[0]["settle_patience"] == 999
+    assert result["effective_max_chunks"] == 40
+    assert result["effective_n_action_steps"] == 8
+    assert result["effective_settle_patience"] == 999
 
 
 def test_matching_vla_prompt_is_reported_without_override() -> None:

--- a/tests/unit_tests/rpent/cli/test_main_contracts.py
+++ b/tests/unit_tests/rpent/cli/test_main_contracts.py
@@ -503,6 +503,7 @@ def test_full_cli_calls_robot_result_finalizer_without_robot_special_case(
     from rpent.robots import PromptBundle, RobotSpec, RunConfig
 
     captured: list[RunFinalizationContext] = []
+
     class FakeDaemon:
         stopped = False
 

--- a/tests/unit_tests/rpent/cli/test_main_contracts.py
+++ b/tests/unit_tests/rpent/cli/test_main_contracts.py
@@ -503,7 +503,6 @@ def test_full_cli_calls_robot_result_finalizer_without_robot_special_case(
     from rpent.robots import PromptBundle, RobotSpec, RunConfig
 
     captured: list[RunFinalizationContext] = []
-
     class FakeDaemon:
         stopped = False
 


### PR DESCRIPTION
## Summary

- define the immutable RoboCasa Target50 manifest for 18 Atomic, 16 Composite-Seen, and 16 Composite-Unseen tasks (340 cells)
- freeze the evaluated seed and RLDX runtime contract, compatibility-sensitive dependencies, Robosuite commit, RLDX-1 revision, and task-only memory snapshot
- define the RoboCasa environment-authoritative `result.json` schema, register it through #148's generic finalization hook, and provide a fixed-denominator validator with task-weighted aggregation
- document the complete source-checkout reproduction flow in the standalone README and aligned English/Chinese usage guides
- publish the supplied formal Target50 Codex results for per-task comparison

This PR is rebased directly on `upstream/main@0e4b8d0`, including the merged live-task-language fix in #140, hostname-based proxy fix in #144, RoboTwin mirror fix in #145, session-aware RPC support in #132, generic result finalizer in #148, and unified cross-robot memory refactor in #142. It does not add a planner-specific RoboCasa path, sandbox, supervisor, runner, or global memory.

## Proxy behavior

With the merged #144, HTTP RPC endpoints whose hostname is exactly `127.0.0.1` or `localhost` use request-local direct access, whether RPent starts the worker or the user supplies the endpoint. Every other hostname and IP uses standard environment proxy resolution. Codex scopes the same two-host exception to its child environment for the local MCP connection. Users keep `HTTP_PROXY` and `HTTPS_PROXY` for remote Hugging Face and planner traffic; the default runtime requires no shell-wide `NO_PROXY` setup. A custom local hostname can still be added to the user's existing `NO_PROXY` / `no_proxy` configuration when direct access is desired.

## Frozen protocol

- protocol: `robocasa-harness-vla-v1`
- scene identity: ordinary `--seed`; spawned RoboCasa workers clear legacy `RLDX_RESET_SEED`
- Target50 RLDX execution: `max_chunks=40`, `settle_patience=999`, `n_action_steps=8`; ordinary RoboCasa retains `max_chunks=70`
- Robosuite: `97cfbde4b68d8ec43dad20cf4747297866a6ca2e`
- RLDX-1: `587e9ecdcc5e7184fcc17f58713908edff5af041`
- RPent memory: `551fc3157b3e56b40a3d3a3b4c7ff81721ebe89b`
- reference planner: Codex SDK, `gpt-5.5`, `xhigh`, `max_turns=100`
- success source: final environment `state.success`; planner `finish(status=...)` is never an evaluation label
- retries: only infrastructure failures without a valid environment result

Memory remains restricted to the current task's seed-0 files. All seven memory-free Unseen tasks stay in the denominator, and no global or cross-task memory is used. The #142 memory manager owns the corpus root at `memory/robocasa`; the frozen public snapshot's task files remain in its `results/` subtree with their published filenames.

## Runtime and result contract

- Target50 environment variables override planner-supplied RLDX budgets; without that environment, both public VLA tools default to `max_chunks=70`
- invalid VLA budgets return planner-visible errors without executing RLDX
- RoboCasa registers a robot-owned finalizer that maps shared run context to an atomically written, sanitized `result.json`; the generic lifecycle and atomic writer are provided by merged #148
- planner timeouts are valid failed cells; infrastructure errors are invalid and eligible for rerun
- `python -m robots.robocasa.eval.validate_target50 <results-root>` verifies all 340 identities, planner/runtime settings, success source, and the task-weighted score
- the validated install uses one `uv pip install` command with Target50 constraints plus a direct-source override for the exact Robosuite commit

## Formal results

| Split | Reproduction | Reference | Difference |
| --- | ---: | ---: | ---: |
| Atomic | 163/180 (90.56%) | 165/180 (91.67%) | -1.11 pp |
| Composite-Seen | 49/80 (61.25%) | 45/80 (56.25%) | +5.00 pp |
| Composite-Unseen | 12/80 (15.00%) | 11/80 (13.75%) | +1.25 pp |
| Task-weighted overall | 57.00% | 55.40% | +1.60 pp |

These are the formal results for the protocol documented by this PR. The supplied result artifact contains task-level aggregate counts rather than per-seed traces, so the published page supports exact per-task comparison but does not invent unavailable failure classifications.

## Validation

- rebased directly onto `upstream/main@0e4b8d0`; the ten existing PR commits were replayed and the documentation conflicts were reconciled with #142's shared memory root
- reviewer follow-up commit `153d89b` restores ordinary `max_chunks=70`, keeps Target50's environment-locked `40`, removes duplicated task identities and wording-coupled documentation assertions, and describes only current camera behavior
- clean Python 3.10 editable install with the documented constraints/override: passed
- `uv pip check`: all 262 installed packages compatible
- exact sensitive versions verified, including MuJoCo 3.3.1, NumPy 1.26.4, Torch 2.7.0+cu126, Transformers 4.57.6, Pydantic 2.13.5, and Pydantic-AI Slim 2.1.0
- Robosuite direct-source metadata resolves the exact frozen commit
- `pytest tests/unit_tests -q`: 230 passed on `upstream/main@0e4b8d0`
- opt-in real-environment matrix: all 340 task/seed cells passed the construction/reset, 12D action, three operation-camera, nav RGB-D/world-map, native success, and close contract
- one `SeparateFreezerRack` seed-2 initialization took longer than the repository's 60-second pytest timeout; the test now has a 180-second real-simulator budget and the cell passed on rerun
- 8 base-forward steps changed base position, `mobilebase0_navview` extrinsics, and rendered pixels
- the fixed HF revision was downloaded again after the rebase: 43 audit JSON, 43 recipe JSONL, 25 task Markdown, 0 global memory; all 111 files match the reviewed staging corpus byte-for-byte
- the shared memory boundary reads the immutable `robocasa/results` corpus while retaining read-only, inbox-write, and cross-robot isolation contracts
- RoboCasa finalizer tests verify hook registration, environment-authoritative field mapping, unavailable-environment handling, and compatibility with the exact 340-cell validator
- hostname-based proxy behavior is inherited from merged #144 and remains unchanged
- pre-commit, Ruff, Ruff format, strict English/Chinese Sphinx builds, wheel build, local-link checks, and secret/private-endpoint/absolute-path scans: passed

The 340-cell opt-in test validates every real environment identity and interface. It does not rerun the planner or RLDX policy; the formal policy results above come from the supplied completed evaluation.

## Scope note

The shared finalization lifecycle and atomic JSON helper are provided by merged #148. This PR registers `robots.robocasa.eval.result.finalize_cell_result`; no RoboCasa name check or Target50 schema remains in the shared CLI. Its only shared-memory adjustment is adding the immutable RoboCasa `results/` subtree to published read-only scopes required by the final HF snapshot; write permissions and cross-robot isolation are unchanged. Planner implementations, LIBERO, RoboTwin, public RPC APIs, and resource synchronization behavior are otherwise unchanged.

The repository's existing wheel configuration packages `rpent/**` but not top-level `robots/**`. This PR preserves the documented source-checkout/editable-install workflow and leaves repository-wide robot-extension wheel packaging to a separate change.
