### PR TITLE
fix(rpc): bypass proxies for localhost HTTP endpoints

### DIFF
--- a/rpent/planner/codex.py
+++ b/rpent/planner/codex.py
@@ -58,6 +58,23 @@ logger = get_logger("codex")
 
 PROVIDER_ID = "rpent_proxy"
 PROVIDER_ENV_KEY = "RPENT_CODEX_PROVIDER_KEY"
+_LOOPBACK_NO_PROXY_HOSTS = ("127.0.0.1", "localhost")
+
+
+def _codex_environment() -> dict[str, str]:
+    """Build the Codex child environment with direct access to its local MCP."""
+    env = {**os.environ}
+    entries: list[str] = []
+    for key in ("NO_PROXY", "no_proxy"):
+        entries.extend(item.strip() for item in env.get(key, "").split(","))
+    entries = list(
+        dict.fromkeys(item for item in (*entries, *_LOOPBACK_NO_PROXY_HOSTS) if item)
+    )
+    bypass = ",".join(entries)
+    env["NO_PROXY"] = bypass
+    env["no_proxy"] = bypass
+    return env
+
 
 # ---------------------------------------------------------------------------
 # Public backend
@@ -436,7 +453,7 @@ class CodexPlanner:
     # -- config builder ----------------------------------------------------
 
     def _build_config(self, mcp_url: str) -> Any:
-        env = {**os.environ}
+        env = _codex_environment()
         if self._api_key:
             env[PROVIDER_ENV_KEY] = self._api_key
         kwargs: dict[str, Any] = {

--- a/rpent/planner/utils/http_mcp_server.py
+++ b/rpent/planner/utils/http_mcp_server.py
@@ -164,7 +164,9 @@ def _wait_for_ready(url: str, *, timeout_s: float) -> None:
     }
     transport = httpx.HTTPTransport(retries=10)
     with httpx.Client(
-        transport=transport, timeout=httpx.Timeout(timeout_s, connect=2)
+        transport=transport,
+        timeout=httpx.Timeout(timeout_s, connect=2),
+        trust_env=False,
     ) as c:
         resp = c.post(url, json=body, headers={"Accept": "application/json"})
         body_preview = resp.text[:200]

--- a/rpent/utils/rpc/http_rpc.py
+++ b/rpent/utils/rpc/http_rpc.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import base64
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Callable
@@ -37,8 +38,15 @@ from rpent.utils.rpc.rpc_client import RpcClient, RpcError, check_response
 from rpent.utils.rpc.rpc_facade import make_error_response
 
 DEFAULT_TIMEOUT_S = 30.0
+_DIRECT_HOSTS = frozenset({"127.0.0.1", "localhost"})
 
 logger = get_logger("http_rpc")
+
+
+def _is_direct_url(url: str) -> bool:
+    """Return whether *url* uses a hostname that must bypass HTTP proxies."""
+    hostname = urllib.parse.urlsplit(url).hostname
+    return hostname is not None and hostname.lower() in _DIRECT_HOSTS
 
 
 def _from_json(obj: Any) -> Any:
@@ -66,11 +74,19 @@ class HttpRpcClient(RpcClient):
     ----------
     base_url : str
         Server address, e.g. ``"http://127.0.0.1:8080"``.
+
+        ``127.0.0.1`` and ``localhost`` bypass HTTP proxies. Other hostnames
+        use the process proxy configuration.
     """
 
     def __init__(self, base_url: str) -> None:
         """Initialize with a base URL, e.g. ``"http://127.0.0.1:8080"``."""
         self._base_url = base_url.rstrip("/")
+        self._opener = (
+            urllib.request.build_opener(urllib.request.ProxyHandler({}))
+            if _is_direct_url(self._base_url)
+            else None
+        )
 
     def call(
         self,
@@ -97,7 +113,8 @@ class HttpRpcClient(RpcClient):
             method="POST",
         )
         try:
-            with urllib.request.urlopen(req, timeout=request_timeout) as resp:
+            open_request = self._opener.open if self._opener else urllib.request.urlopen
+            with open_request(req, timeout=request_timeout) as resp:
                 raw = resp.read()
         except urllib.error.HTTPError as exc:
             # HTTPError is an OSError subclass; catch first so we can parse

--- a/tests/unit_tests/rpent/planner/test_codex_contracts.py
+++ b/tests/unit_tests/rpent/planner/test_codex_contracts.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import os
 import queue
 from pathlib import Path
 from types import SimpleNamespace
@@ -31,7 +32,10 @@ from rpent.planner.codex import (
     _codex_mcp_config_overrides,
     _interrupt,
 )
-from rpent.planner.utils.http_mcp_server import _toolkit_to_mcp_content
+from rpent.planner.utils.http_mcp_server import (
+    HttpMcpServer,
+    _toolkit_to_mcp_content,
+)
 from rpent.tools.toolkit import ToolResult
 
 
@@ -186,6 +190,23 @@ def test_mcp_content_conversion_preserves_text_images_and_error_status() -> None
     assert is_error is True
 
 
+def test_http_mcp_readiness_ignores_environment_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    server = HttpMcpServer(FakeToolkit())
+
+    try:
+        url = server.start(ready_timeout_s=3.0)
+    finally:
+        server.stop()
+
+    assert url.startswith("http://127.0.0.1:")
+
+
 def test_config_overrides_normalize_provider_url() -> None:
     assert _codex_mcp_config_overrides(
         mcp_url="http://fake.invalid/mcp/",
@@ -249,6 +270,39 @@ def test_build_config_constructs_with_the_installed_codex_sdk(
     assert config.experimental_api is True
     assert config.env[PROVIDER_ENV_KEY] == "contract-key"
     assert f'model_provider="{PROVIDER_ID}"' in config.config_overrides
+
+
+def test_build_config_scopes_loopback_no_proxy_to_codex_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.invalid:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.invalid:8080")
+    monkeypatch.setenv("NO_PROXY", "metadata.internal")
+    monkeypatch.setenv("no_proxy", ".corp.invalid")
+    captured: list[dict[str, Any]] = []
+
+    def codex_config(**kwargs: Any) -> dict[str, Any]:
+        captured.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(codex_module.openai_codex, "CodexConfig", codex_config)
+    planner = make_planner(tmp_path, RecordingSink())
+
+    config = planner._build_config("http://127.0.0.1:8765/mcp/")
+
+    child_env = config["env"]
+    assert child_env["HTTP_PROXY"] == "http://proxy.invalid:8080"
+    assert child_env["HTTPS_PROXY"] == "http://proxy.invalid:8080"
+    assert child_env["NO_PROXY"].split(",") == [
+        "metadata.internal",
+        ".corp.invalid",
+        "127.0.0.1",
+        "localhost",
+    ]
+    assert child_env["no_proxy"] == child_env["NO_PROXY"]
+    assert os.environ["NO_PROXY"] == "metadata.internal"
+    assert os.environ["no_proxy"] == ".corp.invalid"
 
 
 def test_successful_fake_codex_lifecycle_uses_fake_mcp_and_accounts_events(

--- a/tests/unit_tests/rpent/utils/rpc/test_transport_loopback.py
+++ b/tests/unit_tests/rpent/utils/rpc/test_transport_loopback.py
@@ -14,12 +14,15 @@
 
 from __future__ import annotations
 
+import os
 import socket
 import threading
 import time
+import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Literal
 
 import numpy as np
@@ -33,8 +36,26 @@ from rpent.utils.rpc import (
     make_rpc_client,
     wait_for_ready,
 )
+from rpent.utils.rpc.http_rpc import HttpRpcClient, _is_direct_url
 
 Transport = Literal["http", "socket"]
+PROXY_ENVIRONMENT_VARIABLES = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_proxy_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in PROXY_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(urllib.request, "_opener", None)
 
 
 class ContractFacade(RpcFacade):
@@ -94,7 +115,11 @@ def _port_accepts_connections(port: int) -> bool:
 
 
 @contextmanager
-def _running_facade(transport: Transport) -> Iterator[RunningFacade]:
+def _running_facade(
+    transport: Transport,
+    *,
+    client_host: str = "127.0.0.1",
+) -> Iterator[RunningFacade]:
     facade = ContractFacade()
     port = pick_free_port()
     thread = threading.Thread(
@@ -107,7 +132,7 @@ def _running_facade(transport: Transport) -> Iterator[RunningFacade]:
         daemon=True,
     )
     thread.start()
-    client = make_rpc_client(f"{transport}://127.0.0.1:{port}")
+    client = make_rpc_client(f"{transport}://{client_host}:{port}")
 
     try:
         wait_for_ready(client, timeout_s=3.0, poll_interval_s=0.01)
@@ -154,6 +179,103 @@ def test_transport_round_trips_nested_numpy_payloads(transport: Transport) -> No
         }
         result["values"][0, 0] = -1
         assert original[0, 0] == 0
+
+
+def _configure_dead_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.setattr(urllib.request, "_opener", None)
+
+
+class _RecordingProxyHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args) -> None:  # noqa: A002
+        return
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length:
+            self.rfile.read(content_length)
+        self.server.request_targets.append(self.path)  # type: ignore[attr-defined]
+        body = b'{"ok": true, "result": {"status": "proxied"}}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextmanager
+def _running_http_proxy() -> Iterator[tuple[int, list[str]]]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingProxyHandler)
+    request_targets: list[str] = []
+    server.request_targets = request_targets  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield int(server.server_port), request_targets
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=3.0)
+
+    assert not thread.is_alive()
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+def test_http_local_hosts_bypass_proxy_without_mutating_environment(
+    host: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_dead_proxy(monkeypatch)
+    proxy_environment = {
+        name: value
+        for name in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "no_proxy")
+        if (value := os.environ.get(name)) is not None
+    }
+
+    with _running_facade("http", client_host=host) as running:
+        assert running.client.call("healthz", timeout_s=1.0) == {"status": "ok"}
+
+    assert {
+        name: value
+        for name in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "no_proxy")
+        if (value := os.environ.get(name)) is not None
+    } == proxy_environment
+
+
+@pytest.mark.parametrize("host", ["service.example.invalid", "127.0.0.2"])
+def test_other_http_hosts_use_environment_proxy(
+    host: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _running_http_proxy() as (proxy_port, request_targets):
+        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_port}")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        monkeypatch.setattr(urllib.request, "_opener", None)
+        client = HttpRpcClient(f"http://{host}:8123")
+
+        assert client.call("healthz", timeout_s=1.0) == {"status": "proxied"}
+
+    assert request_targets == [f"http://{host}:8123/call"]
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://127.0.0.1:8000", True),
+        ("http://localhost:8000", True),
+        ("http://LOCALHOST:8000", True),
+        ("http://127.0.0.2:8000", False),
+        ("http://[::1]:8000", False),
+        ("http://service.example.invalid:8000", False),
+    ],
+)
+def test_http_direct_host_classification(url: str, expected: bool) -> None:
+    assert _is_direct_url(url) is expected
 
 
 @pytest.mark.parametrize("transport", ["http", "socket"])


### PR DESCRIPTION
## Summary

- Make `HttpRpcClient` bypass HTTP proxies automatically for exact `127.0.0.1` and `localhost` hostnames.
- Keep every other HTTP RPC hostname on standard environment proxy resolution.
- Keep direct routing request-local; RPent does not mutate the parent `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, or lowercase variants.
- Keep the Codex local MCP readiness probe and child connection local while preserving user proxy settings for remote planner/model traffic.

## Routing contract

| Endpoint hostname | HTTP behavior |
| --- | --- |
| `127.0.0.1` | Direct |
| `localhost` (case-insensitive) | Direct |
| Any other hostname or IP | Standard environment proxy resolution |

There is no public or internal `proxy_mode` switch. The same hostname rule applies to RPent-started workers and user-supplied HTTP RPC endpoints. Socket/WebSocket transports are unchanged.

## Rationale

Local HTTP RPC and MCP connections must not be sent through a remote proxy, while remote/custom endpoints, Hugging Face access, and planner/model requests must retain the users proxy configuration. Centralizing the hostname rule gives LIBERO, RoboTwin, and RoboCasa the same behavior without robot-specific call-site flags.

## Validation

- Exact-host direct tests for `127.0.0.1` and `localhost` under an unreachable proxy with no `NO_PROXY`.
- Recording-proxy tests for a normal remote hostname and `127.0.0.2`.
- Classification coverage for uppercase `LOCALHOST`, `127.0.0.2`, IPv6 loopback, and a remote hostname.
- Codex child-environment and local MCP readiness regression tests.
- `204 passed` across `tests/unit_tests`.
- `pre-commit run --all-files` passed.
- Secret and absolute-path scan passed.