### PR TITLE
fix(robotwin): use mirror for pinned runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ robocasa = [
 robotwin = [
     # TODO: replace fixed owner-controlled revisions with released versions.
     "rpent[rlinf]",
-    "rlinf-robotwin-runtime @ git+https://github.com/RoboTwin-Platform/RoboTwin.git@11d2d4ba1ba4819ebf63bb91ba0c5dfd4b0f81f2",
+    "rlinf-robotwin-runtime @ git+https://github.com/Sonorous281/RoboTwin.git@11d2d4ba1ba4819ebf63bb91ba0c5dfd4b0f81f2",
     "rlinf-lingbotvla @ git+https://github.com/RLinf/lingbot-vla.git@e158cce02f50dbb48b7f5bf76fdb34c1c1f97e12",
 ]
 


### PR DESCRIPTION
The pinned commit 11d2d4 has no branch/tag on RoboTwin-Platform/RoboTwin (RLinf_support sits at the older 0008ae), so a fresh uv/Git resolve of the SHA can fail. The Sonorous281/RoboTwin fork's rpent-package-first branch holds this exact commit reachable.

Same SHA, same tree (verified: 58419490f6d0775db981b38d6847a21cacc3f922 on both repos), no runtime behaviour change. Temporary mirror; switch back to the upstream repo once it publishes a stable ref at this commit.
