### PR TITLE
feat(eval): add extensible run-result finalization

### DIFF
--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -426,6 +426,38 @@ robots. The runners do not handle these environment details. See
 ``robots/libero/robot_spec.py`` and ``robots/robocasa/robot_spec.py`` for the
 reference pattern.
 
+Optional run-result finalizer
+-----------------------------
+
+A robot that publishes machine-readable evaluation artifacts may set
+``RobotSpec.finalize_run``. The default is ``None`` and leaves the runner
+unchanged. When the hook is present, the normal terminal runner captures
+``toolkit.solved()`` before closing the toolkit, then passes a structured
+``RunFinalizationContext`` to the hook after runtime cleanup. The hook owns the
+artifact schema and filename; RPent only defines the lifecycle boundary.
+
+Use ``write_json_atomic`` when the artifact is JSON so an interrupted write
+cannot leave a partial result:
+
+.. code-block:: python
+
+   from rpent.evaluation import RunFinalizationContext, write_json_atomic
+
+   def _finalize_run(context: RunFinalizationContext):
+       return write_json_atomic(
+           context.output_dir / "result.json",
+           {
+               "robot": context.robot_name,
+               "task": dict(context.task_desc),
+               "success": context.environment_success,
+           },
+       )
+
+Register the callback as ``RobotSpec(..., finalize_run=_finalize_run)``. This
+hook is currently limited to normal terminal runs; the Dashboard does not call
+it. Keep benchmark manifests, robot-specific runtime fields, and aggregation
+logic in the robot package rather than the shared CLI.
+
 Smoke test
 ----------
 

--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -429,12 +429,15 @@ reference pattern.
 Optional run-result finalizer
 -----------------------------
 
-A robot that publishes machine-readable evaluation artifacts may set
-``RobotSpec.finalize_run``. The default is ``None`` and leaves the runner
-unchanged. When the hook is present, the normal terminal runner captures
-``toolkit.solved()`` before closing the toolkit, then passes a structured
-``RunFinalizationContext`` to the hook after runtime cleanup. The hook owns the
-artifact schema and filename; RPent only defines the lifecycle boundary.
+``RobotSpec.finalize_run`` is a universal, robot-agnostic end-of-run hook.
+RoboCasa is its current consumer and uses it to record per-cell evaluation
+results for later statistics and aggregation. Any robot that publishes
+machine-readable evaluation artifacts may register the hook. The default is
+``None`` and leaves the runner unchanged. When the hook is present, the normal
+terminal runner captures ``toolkit.solved()`` before closing the toolkit, then
+passes a structured ``RunFinalizationContext`` to the hook after runtime
+cleanup. The hook owns the artifact schema and filename; RPent only defines the
+lifecycle boundary.
 
 Use ``write_json_atomic`` when the artifact is JSON so an interrupted write
 cannot leave a partial result:

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -391,6 +391,35 @@ endpoint（``--env-endpoint``、``--vla-endpoint``，以及 LIBERO 的
 一致；runner 不处理这些环境细节。参考模式见 ``robots/libero/robot_spec.py`` 和
 ``robots/robocasa/robot_spec.py``。
 
+可选的运行结果 finalizer
+------------------------
+
+需要发布机器可读评测产物的机器人可以设置 ``RobotSpec.finalize_run``。其默认值为
+``None``，不会改变 runner 行为。配置该钩子后，普通终端 runner 会在关闭 toolkit
+前读取 ``toolkit.solved()``，完成运行时清理后再把结构化的
+``RunFinalizationContext`` 传给钩子。产物 schema 与文件名由钩子负责，RPent 只定义
+生命周期边界。
+
+JSON 产物应使用 ``write_json_atomic``，避免中断写入留下不完整结果：
+
+.. code-block:: python
+
+   from rpent.evaluation import RunFinalizationContext, write_json_atomic
+
+   def _finalize_run(context: RunFinalizationContext):
+       return write_json_atomic(
+           context.output_dir / "result.json",
+           {
+               "robot": context.robot_name,
+               "task": dict(context.task_desc),
+               "success": context.environment_success,
+           },
+       )
+
+通过 ``RobotSpec(..., finalize_run=_finalize_run)`` 注册回调。该钩子目前只用于普通
+终端运行，Dashboard 不会调用。benchmark manifest、机器人专用 runtime 字段和
+聚合逻辑应继续放在机器人目录中，而不是共享 CLI。
+
 冒烟测试
 --------
 

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -394,11 +394,12 @@ endpoint（``--env-endpoint``、``--vla-endpoint``，以及 LIBERO 的
 可选的运行结果 finalizer
 ------------------------
 
-需要发布机器可读评测产物的机器人可以设置 ``RobotSpec.finalize_run``。其默认值为
-``None``，不会改变 runner 行为。配置该钩子后，普通终端 runner 会在关闭 toolkit
-前读取 ``toolkit.solved()``，完成运行时清理后再把结构化的
-``RunFinalizationContext`` 传给钩子。产物 schema 与文件名由钩子负责，RPent 只定义
-生命周期边界。
+``RobotSpec.finalize_run`` 是面向所有机器人、与具体 benchmark 无关的通用运行结束
+钩子。RoboCasa 是当前使用方，用它记录单 cell 评测结果，供后续结果统计和聚合。
+任何需要发布机器可读评测产物的机器人都可以注册该钩子。其默认值为 ``None``，不会
+改变 runner 行为。配置该钩子后，普通终端 runner 会在关闭 toolkit 前读取
+``toolkit.solved()``，完成运行时清理后再把结构化的 ``RunFinalizationContext`` 传给
+钩子。产物 schema 与文件名由钩子负责，RPent 只定义生命周期边界。
 
 JSON 产物应使用 ``write_json_atomic``，避免中断写入留下不完整结果：
 

--- a/rpent/cli/main.py
+++ b/rpent/cli/main.py
@@ -52,6 +52,7 @@ from rpent.dashboard.events import (
     NullDashboardEventSink,
     RunStartedEvent,
 )
+from rpent.evaluation import RunFinalizationContext
 from rpent.memory import MemoryManager
 from rpent.planner.base import REASONING_EFFORTS, build_planner
 from rpent.robots import enumerate_robots, get_robot_spec, get_toolkit
@@ -422,6 +423,7 @@ def main() -> int:
         sessions = 1
     recipe_path = ""
     solved = False
+    environment_success: bool | None = None
     memory_manager: MemoryManager | None = None
     try:
         if first_user_msg is not None:
@@ -483,7 +485,12 @@ def main() -> int:
                     if solved:
                         recipe_path = toolkit.write_recipe(recipe_tag)
             finally:
-                toolkit.close()
+                try:
+                    if robot_spec.finalize_run is not None:
+                        environment_success = bool(toolkit.solved())
+                        solved = environment_success
+                finally:
+                    toolkit.close()
             if solved:
                 break
             if agent_error:
@@ -532,6 +539,33 @@ def main() -> int:
         stats.get("tool_calls", "?"),
     )
     logger.info("transcript: %s", transcript_path)
+
+    if robot_spec.finalize_run is not None:
+        try:
+            result_path = robot_spec.finalize_run(
+                RunFinalizationContext(
+                    output_dir=Path(output_dir),
+                    robot_name=robot_name,
+                    task_desc=dict(task_desc),
+                    environment_success=environment_success,
+                    agent_error=agent_error,
+                    elapsed_s=elapsed,
+                    planner=args.planner,
+                    model=args.model,
+                    reasoning_effort=args.reasoning_effort,
+                    max_turns=args.max_turns,
+                    planner_timeout_s=args.planner_timeout_s,
+                    finish_result=(
+                        dict(finish_result) if finish_result is not None else None
+                    ),
+                    stats=dict(stats),
+                )
+            )
+            if result_path:
+                logger.info("run result: %s", result_path)
+        except Exception as exc:
+            agent_error = f"result finalization failed: {type(exc).__name__}: {exc}"
+            logger.error("%s", agent_error)
 
     # Publish exploration artifacts into the corpus after the session loop.
     if (

--- a/rpent/evaluation/__init__.py
+++ b/rpent/evaluation/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluation result finalization contracts."""
+
+from rpent.evaluation.result import (
+    RunFinalizationContext,
+    RunFinalizer,
+    write_json_atomic,
+)
+
+__all__ = ["RunFinalizationContext", "RunFinalizer", "write_json_atomic"]

--- a/rpent/evaluation/result.py
+++ b/rpent/evaluation/result.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared contracts for robot-specific run-result artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RunFinalizationContext:
+    """Structured runner state supplied to a robot result finalizer."""
+
+    output_dir: Path
+    robot_name: str
+    task_desc: Mapping[str, Any]
+    environment_success: bool | None
+    agent_error: str | None
+    elapsed_s: float
+    planner: str
+    model: str | None
+    reasoning_effort: str
+    max_turns: int
+    planner_timeout_s: int | None
+    finish_result: Mapping[str, Any] | None
+    stats: Mapping[str, Any]
+
+
+RunFinalizer = Callable[[RunFinalizationContext], Path | str | None]
+
+
+def write_json_atomic(
+    destination: Path | str,
+    record: Mapping[str, Any],
+) -> Path:
+    """Write one JSON object atomically and return its destination path."""
+    path = Path(destination)
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as file:
+            json.dump(record, file, indent=2)
+            file.write("\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return path

--- a/rpent/robots/robot_spec.py
+++ b/rpent/robots/robot_spec.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rpent.dashboard.events import DashboardEventSink
+from rpent.evaluation import RunFinalizer
 from rpent.robots.prompt_bundle import PromptBundle
 
 if TYPE_CHECKING:
@@ -63,3 +64,4 @@ class RobotSpec:
     ]
     dashboard: dict[str, Any] | None = None
     resources_repo_id: str = "RLinf/RPent-memory"
+    finalize_run: RunFinalizer | None = None

--- a/tests/unit_tests/rpent/cli/test_main_contracts.py
+++ b/tests/unit_tests/rpent/cli/test_main_contracts.py
@@ -493,3 +493,134 @@ def test_full_cli_exploration_finalizes_memory_without_starting_gpu_runtime(
     assert transcript["messages"] == [
         {"role": "assistant", "content": "finished offline"}
     ]
+
+
+def test_full_cli_calls_robot_result_finalizer_without_robot_special_case(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = _cli_module()
+    from rpent.evaluation import RunFinalizationContext, write_json_atomic
+    from rpent.planner.base import PlannerResult
+    from rpent.robots import PromptBundle, RobotSpec, RunConfig
+
+    captured: list[RunFinalizationContext] = []
+
+    class FakeDaemon:
+        stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    class FakeToolkit:
+        memory = SimpleNamespace()
+        closed = False
+
+        def solved(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakePlanner:
+        def solve(self, **kwargs: Any) -> PlannerResult:
+            del kwargs
+            return PlannerResult(
+                finish_result={"status": "success", "summary": "planner claim"},
+                messages=[],
+                stats={"tool_calls": 0},
+            )
+
+    def add_cli_args(parser: Any, use_dashboard: bool) -> None:
+        del use_dashboard
+        parser.add_argument("--task-name", required=True)
+        parser.add_argument("--seed", type=int, default=0)
+
+    def parse_config(args: Any) -> RunConfig:
+        return RunConfig(
+            recipe_tag=f"{args.task_name}_s{args.seed}",
+            output_dir=Path(args.output_dir),
+            prompt_vars={"memory_dir": args.memory_dir},
+            task_desc={"task_name": args.task_name, "seed": args.seed},
+        )
+
+    def finalize_run(context: RunFinalizationContext) -> Path:
+        captured.append(context)
+        assert robot_toolkit.closed is True
+        return write_json_atomic(
+            context.output_dir / "result.json",
+            {
+                "robot": context.robot_name,
+                "task": dict(context.task_desc),
+                "success": context.environment_success,
+                "planner_claim": context.finish_result,
+            },
+        )
+
+    daemon = FakeDaemon()
+    robot_toolkit = FakeToolkit()
+    robot_spec = RobotSpec(
+        name="testrobot",
+        prompts=PromptBundle(
+            system=lambda variables: "system",
+            user=lambda variables: "task",
+        ),
+        add_cli_args=add_cli_args,
+        parse_config=parse_config,
+        init_runtime=lambda *args: ([daemon], {"runtime": "simulated"}),
+        finalize_run=finalize_run,
+    )
+
+    monkeypatch.setattr(cli, "enumerate_robots", lambda: ("testrobot",))
+    monkeypatch.setattr(cli, "get_robot_spec", lambda name: robot_spec)
+    monkeypatch.setattr(cli, "build_planner", lambda *args, **kwargs: FakePlanner())
+    monkeypatch.setattr(cli, "get_toolkit", lambda *args, **kwargs: robot_toolkit)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rpent",
+            "--robot",
+            "testrobot",
+            "--task-name",
+            "OpenDrawer",
+            "--seed",
+            "1",
+            "--planner",
+            "codex",
+            "--model",
+            "gpt-5.5",
+            "--reasoning-effort",
+            "xhigh",
+            "--planner-timeout-s",
+            "1800",
+            "--memory-profile",
+            "local",
+            "--memory-dir",
+            str(tmp_path / "memory"),
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert cli.main() == 0
+
+    assert len(captured) == 1
+    context = captured[0]
+    assert context.robot_name == "testrobot"
+    assert context.environment_success is False
+    assert context.agent_error is None
+    assert context.planner == "codex"
+    assert context.model == "gpt-5.5"
+    assert context.reasoning_effort == "xhigh"
+    assert context.max_turns == 100
+    assert context.planner_timeout_s == 1800
+    assert context.stats == {"tool_calls": 0}
+    assert json.loads((tmp_path / "result.json").read_text(encoding="utf-8")) == {
+        "robot": "testrobot",
+        "task": {"task_name": "OpenDrawer", "seed": 1},
+        "success": False,
+        "planner_claim": {"status": "success", "summary": "planner claim"},
+    }
+    assert robot_toolkit.closed is True
+    assert daemon.stopped is True

--- a/tests/unit_tests/rpent/evaluation/test_result.py
+++ b/tests/unit_tests/rpent/evaluation/test_result.py
@@ -1,0 +1,57 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from rpent.evaluation import write_json_atomic
+
+
+def test_write_json_atomic_replaces_complete_record(tmp_path: Path) -> None:
+    destination = tmp_path / "result.json"
+    destination.write_text('{"status": "old"}\n', encoding="utf-8")
+
+    result = write_json_atomic(destination, {"status": "complete", "success": True})
+
+    assert result == destination
+    assert json.loads(destination.read_text(encoding="utf-8")) == {
+        "status": "complete",
+        "success": True,
+    }
+    assert not (tmp_path / ".result.json.tmp").exists()
+
+
+def test_write_json_atomic_cleans_temporary_file_on_replace_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "result.json"
+    destination.write_text('{"status": "old"}\n', encoding="utf-8")
+
+    def fail_replace(source: Path, target: Path) -> None:
+        del source, target
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        write_json_atomic(destination, {"status": "new"})
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"status": "old"}
+    assert not (tmp_path / ".result.json.tmp").exists()


### PR DESCRIPTION
## Summary

- add an optional `RobotSpec.finalize_run` hook for robot-owned run artifacts
- capture the environment-authoritative success state before toolkit shutdown
- pass structured run metadata to the finalizer after runtime cleanup
- provide a small atomic JSON writer shared by robot-specific result adapters

## Scope

This PR defines lifecycle plumbing only. It does not define a benchmark manifest, result schema, scheduler, retry policy, or robot-specific behavior. Robots that do not register a finalizer retain the current runtime behavior. The normal terminal CLI invokes the hook; Dashboard support remains out of scope.

RoboCasa Target50 PR #141 is the immediate consumer and will be updated to keep only its robot-owned schema adapter.

## Validation

- `207 passed` across `tests/unit_tests`
- `29 passed` for loopback RPC and Codex contracts with `NO_PROXY`/`no_proxy` unset
- `pre-commit run --all-files`
- strict English and Chinese Sphinx builds
- wheel build, including `rpent/evaluation/**`
- secret and absolute-path scan