### PR TITLE
fix: serialize concurrent MCP tool calls across planner backends

### DIFF
--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -719,7 +719,11 @@ def _api_error_text(error: Exception, *, no_images: bool) -> str:
 def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
     """Build the API-only image reader plus pydantic-ai toolkit wrappers."""
     image_reader = _make_image_reader(toolkit.state, no_images=no_images)
-    tools: list[Tool] = [Tool(image_reader, name="read_image")]
+    # sequential=True serializes a turn's tool calls so the toolkit's
+    # single-operation lock never rejects an overlapping call.
+    tools: list[Tool] = [
+        Tool(image_reader, name="read_image", sequential=True)
+    ]
     for spec in toolkit.get_tools_spec():
         name = spec["name"]
         tools.append(
@@ -730,6 +734,7 @@ def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
                 json_schema=spec.get("input_schema")
                 or {"type": "object", "properties": {}},
                 takes_ctx=False,
+                sequential=True,
             )
         )
     return tools

--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -721,9 +721,7 @@ def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
     image_reader = _make_image_reader(toolkit.state, no_images=no_images)
     # sequential=True serializes a turn's tool calls so the toolkit's
     # single-operation lock never rejects an overlapping call.
-    tools: list[Tool] = [
-        Tool(image_reader, name="read_image", sequential=True)
-    ]
+    tools: list[Tool] = [Tool(image_reader, name="read_image", sequential=True)]
     for spec in toolkit.get_tools_spec():
         name = spec["name"]
         tools.append(

--- a/rpent/planner/utils/http_mcp_server.py
+++ b/rpent/planner/utils/http_mcp_server.py
@@ -86,9 +86,15 @@ def _strip_mcp_prefix(name: str) -> str:
     return name
 
 
-def _build_asgi_app(toolkit: Toolkit) -> Any:
-    """Build a raw ASGI3 app wrapping an MCP ``Server`` + streamable HTTP."""
+def _build_mcp_server(toolkit: Toolkit) -> Server:
+    """Build a low-level MCP server exposing the toolkit's tools.
+
+    Concurrent ``tools/call`` requests are serialized through an
+    ``asyncio.Lock`` so overlapping calls don't trip the toolkit's
+    single-operation lock (which *rejects* rather than queues).
+    """
     mcp_app: Server = Server(SERVER_NAME, version="0.1.0")
+    tool_execution_lock = asyncio.Lock()
 
     @mcp_app.list_tools()
     async def _list_tools() -> list[types.Tool]:
@@ -106,11 +112,19 @@ def _build_asgi_app(toolkit: Toolkit) -> Any:
     @mcp_app.call_tool()
     async def _call_tool(name: str, arguments: dict[str, Any]) -> types.CallToolResult:
         lookup = _strip_mcp_prefix(name)
-        tr = await asyncio.get_running_loop().run_in_executor(
-            None, toolkit.execute_tool, lookup, arguments or {}
-        )
+        async with tool_execution_lock:
+            tr = await asyncio.get_running_loop().run_in_executor(
+                None, toolkit.execute_tool, lookup, arguments or {}
+            )
         content, is_error = _toolkit_to_mcp_content(tr)
         return types.CallToolResult(content=content, isError=is_error)
+
+    return mcp_app
+
+
+def _build_asgi_app(toolkit: Toolkit) -> Any:
+    """Build a raw ASGI3 app wrapping an MCP ``Server`` + streamable HTTP."""
+    mcp_app = _build_mcp_server(toolkit)
 
     session_manager = StreamableHTTPSessionManager(
         app=mcp_app,

--- a/rpent/planner/utils/http_mcp_server.py
+++ b/rpent/planner/utils/http_mcp_server.py
@@ -86,13 +86,8 @@ def _strip_mcp_prefix(name: str) -> str:
     return name
 
 
-def _build_mcp_server(toolkit: Toolkit) -> Server:
-    """Build a low-level MCP server exposing the toolkit's tools.
-
-    Concurrent ``tools/call`` requests are serialized through an
-    ``asyncio.Lock`` so overlapping calls don't trip the toolkit's
-    single-operation lock (which *rejects* rather than queues).
-    """
+def _build_asgi_app(toolkit: Toolkit) -> Any:
+    """Build a raw ASGI3 app wrapping an MCP ``Server`` + streamable HTTP."""
     mcp_app: Server = Server(SERVER_NAME, version="0.1.0")
     tool_execution_lock = asyncio.Lock()
 
@@ -118,13 +113,6 @@ def _build_mcp_server(toolkit: Toolkit) -> Server:
             )
         content, is_error = _toolkit_to_mcp_content(tr)
         return types.CallToolResult(content=content, isError=is_error)
-
-    return mcp_app
-
-
-def _build_asgi_app(toolkit: Toolkit) -> Any:
-    """Build a raw ASGI3 app wrapping an MCP ``Server`` + streamable HTTP."""
-    mcp_app = _build_mcp_server(toolkit)
 
     session_manager = StreamableHTTPSessionManager(
         app=mcp_app,

--- a/tests/unit_tests/rpent/planner/test_api_contracts.py
+++ b/tests/unit_tests/rpent/planner/test_api_contracts.py
@@ -248,6 +248,7 @@ def test_tool_schema_and_dispatch_are_mapped_to_pydantic_ai() -> None:
     tools = _build_tools(toolkit)
 
     assert [tool.name for tool in tools] == ["read_image", "finish"]
+    assert all(tool.sequential for tool in tools)
     finish = tools[1]
     assert finish.description == "Finish after the environment accepts the result."
     assert (

--- a/tests/unit_tests/rpent/planner/test_http_mcp_server.py
+++ b/tests/unit_tests/rpent/planner/test_http_mcp_server.py
@@ -20,11 +20,12 @@ import time
 from pathlib import Path
 from typing import Any
 
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
 
 from rpent.dashboard.events import DashboardEventSink
 from rpent.memory.manager import MemoryManager
-from rpent.planner.utils.http_mcp_server import _build_mcp_server
+from rpent.planner.utils.http_mcp_server import HttpMcpServer
 from rpent.session import EnvState
 from rpent.tools.toolkit import Toolkit, readonly
 from rpent.utils.logging import init_output_dir
@@ -138,11 +139,22 @@ class FakeToolkit(Toolkit):
 def test_http_mcp_server_serializes_concurrent_tool_calls(tmp_path: Path) -> None:
     init_output_dir(tmp_path / "log")
     toolkit = FakeToolkit(tmp_path)
-    mcp_app = _build_mcp_server(toolkit)
+    server = HttpMcpServer(toolkit)
+    try:
+        url = server.start()
+        rejected = asyncio.run(_fire_concurrent(url))
+    finally:
+        server.stop()
 
-    async def _fire() -> int:
-        rejected = 0
-        async with create_connected_server_and_client_session(mcp_app) as session:
+    assert rejected == 0
+    assert toolkit.overlap_errors == []
+
+
+async def _fire_concurrent(url: str) -> int:
+    rejected = 0
+    async with streamable_http_client(url) as (read, write, _get_session_id):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
             results = await asyncio.gather(
                 *(session.call_tool(name, args) for name, args in CONCURRENT_CALLS)
             )
@@ -151,9 +163,4 @@ def test_http_mcp_server_serializes_concurrent_tool_calls(tmp_path: Path) -> Non
                     result.content, default=str
                 ):
                     rejected += 1
-        return rejected
-
-    rejected = asyncio.run(_fire())
-
-    assert rejected == 0
-    assert toolkit.overlap_errors == []
+    return rejected

--- a/tests/unit_tests/rpent/planner/test_http_mcp_server.py
+++ b/tests/unit_tests/rpent/planner/test_http_mcp_server.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from rpent.dashboard.events import DashboardEventSink
+from rpent.memory.manager import MemoryManager
+from rpent.planner.utils.http_mcp_server import _build_mcp_server
+from rpent.session import EnvState
+from rpent.tools.toolkit import Toolkit, readonly
+from rpent.utils.logging import init_output_dir
+
+CONCURRENT_CALLS = [
+    ("list_dir", {"path": "resources/libero/memory"}),
+    ("read_text_file", {"path": "robots/libero/guides/strict_hybrid_guide.md"}),
+    ("read_text_file", {"path": "robots/libero/guides/pro_hybrid_guide.md"}),
+    ("read_text_file", {"path": "robots/libero/guides/env_calibration.md"}),
+    ("view_env_state", {"step": 0}),
+]
+
+
+class RecordingSink(DashboardEventSink):
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class FakeToolkit(Toolkit):
+    """Minimal toolkit whose tools sleep to widen the overlap window."""
+
+    def __init__(self, state_dir: Path) -> None:
+        super().__init__(
+            dashboard_events=RecordingSink(),
+            state=EnvState(state_dir),
+            memory=MemoryManager(state_dir / "memory"),
+        )
+        self.overlap_errors: list[tuple[str, dict[str, Any]]] = []
+        self._register_fake_tools()
+
+    def _register_fake_tools(self) -> None:
+        @readonly
+        def read_text_file(path: str, max_chars: int = 40000) -> dict:
+            time.sleep(0.05)
+            p = Path(path)
+            return {"path": str(p), "size": 0, "content": "fake content"}
+
+        @readonly
+        def list_dir(path: str = "") -> dict:
+            time.sleep(0.05)
+            return {"path": path, "count": 0, "files": []}
+
+        def view_env_state(step: int = -1) -> dict:
+            time.sleep(0.3)
+            return {"step": step, "mode": "evaluation"}
+
+        self.add_tool(
+            "read_text_file",
+            {
+                "name": "read_text_file",
+                "description": "Read a UTF-8 text file.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+            read_text_file,
+        )
+        self.add_tool(
+            "list_dir",
+            {
+                "name": "list_dir",
+                "description": "List files in a directory.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+            list_dir,
+        )
+        self.add_tool(
+            "view_env_state",
+            {
+                "name": "view_env_state",
+                "description": "View the current environment state.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"step": {"type": "integer"}},
+                },
+            },
+            view_env_state,
+        )
+
+    def execute_tool(self, name: str, input_dict: dict[str, Any]) -> Any:
+        result = super().execute_tool(name, input_dict)
+        if result.result.get("error") == "another tool operation is still active":
+            self.overlap_errors.append((name, dict(input_dict)))
+        return result
+
+    def get_env_state(
+        self,
+        *,
+        command: dict[str, Any],
+        result: dict[str, Any],
+        elapsed_s: float,
+    ) -> dict[str, Any]:
+        return {"observed": True}
+
+    def solved(self) -> bool:
+        return False
+
+
+def test_http_mcp_server_serializes_concurrent_tool_calls(tmp_path: Path) -> None:
+    init_output_dir(tmp_path / "log")
+    toolkit = FakeToolkit(tmp_path)
+    mcp_app = _build_mcp_server(toolkit)
+
+    async def _fire() -> int:
+        rejected = 0
+        async with create_connected_server_and_client_session(mcp_app) as session:
+            results = await asyncio.gather(
+                *(session.call_tool(name, args) for name, args in CONCURRENT_CALLS)
+            )
+            for result in results:
+                if "another tool operation is still active" in json.dumps(
+                    result.content, default=str
+                ):
+                    rejected += 1
+        return rejected
+
+    rejected = asyncio.run(_fire())
+
+    assert rejected == 0
+    assert toolkit.overlap_errors == []


### PR DESCRIPTION
Fixes "another tool operation is still active" errors when a planner turn
issues several MCP tool calls at once.

Before the fix, one planner turn fired 5 tool calls concurrently and the
toolkit's single-operation lock rejected all but one:

```
2026-09-01 09:21:41 I [api_loop] === turn 2/100 ===
2026-09-01 09:21:41 I [api_loop] [tool>] list_dir({"path": "resources/libero/memory"})
2026-09-01 09:21:41 I [api_loop] [tool>] read_text_file({"path": "robots/libero/guides/strict_hybrid_guide.md"})
2026-09-01 09:21:41 I [api_loop] [tool>] read_text_file({"path": "robots/libero/guides/pro_hybrid_guide.md"})
2026-09-01 09:21:41 I [api_loop] [tool>] read_text_file({"path": "robots/libero/guides/env_calibration.md"})
2026-09-01 09:21:41 I [api_loop] [tool>] view_env_state({"step": 0})
2026-09-01 09:21:41 I [api_loop] [usage] in=25852 out=283 cache_read=10752 cache_write=0 requests=2
2026-09-01 09:21:41 I [api_loop] [tool<] view_env_state: { "error": "another tool operation is still active" }
2026-09-01 09:21:41 I [api_loop] [tool<] read_text_file: { "error": "another tool operation is still active" }
2026-09-01 09:21:41 I [api_loop] [tool<] read_text_file: { "error": "another tool operation is still active" }
2026-09-01 09:21:41 I [api_loop] [tool<] read_text_file: { "error": "another tool operation is still active" }
2026-09-01 09:21:41 I [api_loop] [tool<] list_dir: { "path": "/mnt/public/yuanhua/RPent/resources/libero/memory", "count": 50, ... }
```

- api_loop: mark tools as barriers via pydantic-ai `sequential=True`.
- codex HttpMcpServer: serialize `_call_tool` with an `asyncio.Lock`.

The toolkit's single-operation lock rejects overlapping calls; both fixes
prevent overlap at the caller, keeping the lock as a safety net. Adds a test
firing 5 concurrent calls against the MCP server asserting 0 rejections.
