### PR TITLE
fix(libero): pi0 dtype quick fix using autocast context

### DIFF
--- a/rpent/robots/components/pi05_vla_server.py
+++ b/rpent/robots/components/pi05_vla_server.py
@@ -165,7 +165,11 @@ class Pi05VLAFacade(BaseVLAFacade):
         the openpi wire format (see ``Pi05VLAClient.encode_obs``).
         """
         mode = (options or {}).get("mode", "eval")
-        with torch.no_grad():
+        # OpenPI inference mixes fp32 activations with bf16 Pi0.5 weights.
+        with torch.inference_mode(), torch.autocast(
+            device_type = next(self._model.parameters()).device.type,
+            dtype = torch.bfloat16,
+        ):
             actions, _ = self._model.predict_action_batch(obs, mode=mode)
         return (
             actions.detach().cpu().numpy()


### PR DESCRIPTION
## PR title

fix(libero): run Pi0.5 inference under bf16 autocast

## Description

This fixes a Pi0.5 LIBERO VLA inference failure caused by mixed fp32 activations and bf16 model weights.

The Pi0.5 model loader converts selected PaliGemma/expert parameters to bf16, while the OpenPI inference path can still produce fp32 intermediate activations during action sampling. This could fail before motion with errors like:

```text
expected scalar type BFloat16 but found Float
```

The change wraps `predict_action_batch()` in `torch.inference_mode()` and bf16 autocast inside the Pi0.5 VLA server. The autocast device type is inferred from the loaded model parameters instead of hardcoding CUDA.

Runtime impact: Pi0.5 inference now uses bf16 autocast for model prediction, matching the intended mixed-precision inference path. No API or config changes.

## Testing

```text
.venv/bin/python -m py_compile rpent/robots/components/pi05_vla_server.py
```

Passed.


## Manual verification

Not run on GPU/simulator in this PR. The failure was localized from a LIBERO Pi0.5 API run log where `pi0_pick` failed before motion with a bf16/fp32 dtype mismatch.

## Checklist

- [] My code follows the code style of this project.
- [] I have updated related documentation when needed.
- [] I have added tests to cover my changes when needed.
- [] All new and existing tests passed.