### PR TITLE
feat(planner): load external planner factories

### DIFF
--- a/docs/source-en/rst_source/quickstart.rst
+++ b/docs/source-en/rst_source/quickstart.rst
@@ -110,7 +110,7 @@ robot configuration.
      - Description
    * - ``--planner``
      - ``api``
-     - ``api`` | ``claude_code`` | ``codex``
+     - ``api`` | ``claude_code`` | ``codex`` | ``package.module:factory``
    * - ``--model``
      - —
      - Model id; for ``api``, prefix the provider (``anthropic:…``,

--- a/docs/source-en/rst_source/usage/configure_planner.rst
+++ b/docs/source-en/rst_source/usage/configure_planner.rst
@@ -5,12 +5,12 @@ Select the Agentic Planner backend with one CLI flag:
 
 .. code-block:: bash
 
-   --planner {api, claude_code, codex}
+   --planner {api, claude_code, codex, package.module:factory}
 
-All three planners receive the same rendered system and user prompts
-and use the RPent tool schemas from the same toolkit. They differ in
-how those schemas are connected to the model, how the tool-calling
-loop is orchestrated, and which model SDK is used.
+Every planner receives the same rendered system and user prompts and uses the
+RPent tool schemas from the same toolkit. Planners differ in how those schemas
+are connected to the model, how the tool-calling loop is orchestrated, and
+which model SDK is used.
 
 .. list-table::
    :header-rows: 1
@@ -39,6 +39,10 @@ loop is orchestrated, and which model SDK is used.
        Streamable HTTP MCP server that connects the toolkit to Codex.
      - You want the agent capabilities built into Codex or already have
        OpenAI or Codex quota available.
+   * - ``package.module:factory``
+     - An importable external factory that returns a custom planner.
+     - You want to develop or distribute a planner without editing RPent's
+       planner construction code.
 
 The ``api`` planner (direct model API)
 ---------------------------------------
@@ -142,17 +146,20 @@ Notes:
 Add a custom planner
 --------------------
 
-If none of the three planners fit — say you want to plug in an
-in-house planner, a research prototype, or a different agent SDK —
-implement the ``rpent.planner.base.Planner`` protocol and add a
-construction branch to ``rpent.planner.base.build_planner``:
+If none of the three built-in planners fit — say you want to plug in an
+in-house planner, a research prototype, or a different agent SDK — implement
+the ``rpent.planner.base.Planner`` protocol and expose a factory from an
+importable module:
 
 .. code-block:: python
 
-   # rpent/planner/my_planner.py
-   from rpent.planner.base import PlannerResult
+   # my_package/my_planner.py
+   from rpent.planner.base import PlannerBuildConfig, PlannerResult
 
    class MyPlanner:
+       def __init__(self, config: PlannerBuildConfig):
+           self.config = config
+
        def solve(
            self,
            *,
@@ -161,6 +168,7 @@ construction branch to ``rpent.planner.base.build_planner``:
            toolkit,
            max_turns,
            input_queue=None,
+           dashboard_interaction=None,
        ):
            tool_specs = toolkit.get_tools_spec()
            # Call the model with system_prompt, user_message, and tool_specs.
@@ -174,6 +182,25 @@ construction branch to ``rpent.planner.base.build_planner``:
                error=error,
            )
 
+   def create_planner(config: PlannerBuildConfig) -> MyPlanner:
+       return MyPlanner(config)
+
+Install the module into the same Python environment as RPent, then pass its
+``module:factory`` reference on the command line:
+
+.. code-block:: bash
+
+   pip install -e /path/to/my-package
+   rpent --planner my_package.my_planner:create_planner ...
+
+RPent imports the factory lazily and calls it once per planner session with a
+``PlannerBuildConfig``. The config contains the output directory, recipe and
+robot names, model and endpoint options, token and timeout limits, reasoning
+effort, image setting, and Dashboard event sink. The returned object must have
+a callable ``solve`` method matching the protocol above. Invalid modules,
+missing factories, and invalid return objects produce focused construction
+errors.
+
 Any planner must:
 
 1. Accept the rendered ``system_prompt`` and ``user_message``.
@@ -185,12 +212,14 @@ Any planner must:
    ``max_turns`` and any other limits.
 5. Return a ``PlannerResult`` containing the finish state, messages,
    statistics, and an optional error.
+6. Accept the optional ``input_queue`` and ``dashboard_interaction`` keyword
+   arguments, even if the custom backend does not support interactive modes.
 
-Because the RPent tool schemas and prompt-rendering path stay the same,
-adding a planner does not require changes to tools or environment
-servers. See :doc:`../development/architecture` for the interface, and
-:doc:`../development/add_primitive` if you want to expose new tools to
-your custom planner.
+Because the RPent tool schemas and prompt-rendering path stay the same, adding
+a planner does not require changes to RPent, its tools, or environment servers.
+See :doc:`../development/architecture` for the interface, and
+:doc:`../development/add_primitive` if you want to expose new tools to your
+custom planner.
 
 Configure planner limits
 ------------------------

--- a/docs/source-zh/rst_source/quickstart.rst
+++ b/docs/source-zh/rst_source/quickstart.rst
@@ -107,7 +107,7 @@ LIBERO-PRO 仿真资源。下面以 LIBERO-PRO 和 ``claude_code`` planner
      - 说明
    * - ``--planner``
      - ``api``
-     - ``api`` | ``claude_code`` | ``codex``
+     - ``api`` | ``claude_code`` | ``codex`` | ``package.module:factory``
    * - ``--model``
      - —
      - 模型 ID；``api`` 需带 provider 前缀（``anthropic:…``、

--- a/docs/source-zh/rst_source/usage/configure_planner.rst
+++ b/docs/source-zh/rst_source/usage/configure_planner.rst
@@ -5,9 +5,9 @@ RPent 通过一个 CLI 参数选择 Agentic Planner 的后端：
 
 .. code-block:: bash
 
-   --planner {api, claude_code, codex}
+   --planner {api, claude_code, codex, package.module:factory}
 
-三种 planner 接收相同的系统提示词和用户提示词，也使用同一套 RPent 工具定义。
+所有 planner 都接收相同的系统提示词和用户提示词，也使用同一套 RPent 工具定义。
 它们的区别在于如何将这些工具接入模型、如何组织工具调用循环，以及使用哪个模型
 SDK。
 
@@ -35,6 +35,9 @@ SDK。
        Streamable HTTP MCP 服务，把 toolkit 接入 Codex。
      - 想使用 Codex 原生提供的 agent 能力，或者已有可用的 OpenAI
        或 Codex 配额。
+   * - ``package.module:factory``
+     - 可导入的外部工厂函数，由它返回自定义 planner。
+     - 希望开发或分发 planner，而不修改 RPent 的 planner 构造代码。
 
 ``api`` planner（直接调用模型 API）
 -------------------------------------
@@ -131,15 +134,18 @@ RPent 通过 SDK 创建进程内 MCP 服务，并把 toolkit 的工具注册到
 ------------------
 
 如果三种内置 planner 都不合适，例如需要接入内部 planner、研究原型或其他
-agent SDK，可以实现 ``rpent.planner.base.Planner`` 协议，并在
-``rpent.planner.base.build_planner`` 中增加对应的构造分支：
+agent SDK，可以实现 ``rpent.planner.base.Planner`` 协议，并从一个可导入模块
+中暴露工厂函数：
 
 .. code-block:: python
 
-   # rpent/planner/my_planner.py
-   from rpent.planner.base import PlannerResult
+   # my_package/my_planner.py
+   from rpent.planner.base import PlannerBuildConfig, PlannerResult
 
    class MyPlanner:
+       def __init__(self, config: PlannerBuildConfig):
+           self.config = config
+
        def solve(
            self,
            *,
@@ -148,6 +154,7 @@ agent SDK，可以实现 ``rpent.planner.base.Planner`` 协议，并在
            toolkit,
            max_turns,
            input_queue=None,
+           dashboard_interaction=None,
        ):
            tool_specs = toolkit.get_tools_spec()
            # 使用 system_prompt、user_message 和 tool_specs 调用模型。
@@ -161,6 +168,23 @@ agent SDK，可以实现 ``rpent.planner.base.Planner`` 协议，并在
                error=error,
            )
 
+   def create_planner(config: PlannerBuildConfig) -> MyPlanner:
+       return MyPlanner(config)
+
+先把模块安装到 RPent 所在的同一 Python 环境，再通过
+``module:factory`` 引用传给命令行：
+
+.. code-block:: bash
+
+   pip install -e /path/to/my-package
+   rpent --planner my_package.my_planner:create_planner ...
+
+RPent 会延迟导入该工厂，并在每个 planner session 创建时传入一个
+``PlannerBuildConfig``。其中包含输出目录、recipe 与 robot 名称、模型与端点
+选项、token 与超时限制、推理强度、图片设置以及 Dashboard 事件接收器。
+返回对象必须具有符合上述协议的可调用 ``solve`` 方法。模块无法导入、工厂
+不存在或返回对象无效时，会给出明确的构造错误。
+
 任何 planner 必须：
 
 1. 接收已经渲染好的 ``system_prompt`` 和 ``user_message``。
@@ -170,10 +194,11 @@ agent SDK，可以实现 ``rpent.planner.base.Planner`` 协议，并在
    所需的格式。
 4. 识别 ``ToolResult.is_finish``，并按 ``max_turns`` 等限制终止循环。
 5. 返回包含结束状态、消息、统计信息和可选错误的 ``PlannerResult``。
+6. 接受可选的 ``input_queue`` 和 ``dashboard_interaction`` 关键字参数，即使
+   自定义后端不支持交互模式也应保留这两个参数。
 
 由于 RPent 工具定义和 prompt 渲染流程保持不变，新增 planner 不需要修改
-工具或环境服务。接口参见
-:doc:`../development/architecture`；想给
+RPent、工具或环境服务。接口参见 :doc:`../development/architecture`；想给
 自定义 planner 暴露新工具，见 :doc:`../development/add_primitive`。
 
 设置 planner 的运行限制

--- a/rpent/cli/main.py
+++ b/rpent/cli/main.py
@@ -54,7 +54,7 @@ from rpent.dashboard.events import (
 )
 from rpent.evaluation import RunFinalizationContext
 from rpent.memory import MemoryManager
-from rpent.planner.base import REASONING_EFFORTS, build_planner
+from rpent.planner.base import REASONING_EFFORTS, build_planner, is_planner_reference
 from rpent.robots import enumerate_robots, get_robot_spec, get_toolkit
 from rpent.utils.config import get_memory_dir
 from rpent.utils.logging import get_logger, init_output_dir
@@ -100,6 +100,16 @@ def _serialize_messages(messages: list[dict]) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
+def _planner_reference(value: str) -> str:
+    """Validate a built-in planner name or an external ``module:factory`` ref."""
+    if is_planner_reference(value):
+        return value
+    raise argparse.ArgumentTypeError(
+        f"invalid planner {value!r}; choose api, claude_code, codex, or use "
+        "package.module:factory"
+    )
+
+
 def _build_argparser() -> argparse.ArgumentParser:
     known_robots = enumerate_robots()
     known_robots_text = ", ".join(known_robots) if known_robots else "none"
@@ -127,8 +137,9 @@ def _build_argparser() -> argparse.ArgumentParser:
     ap.add_argument(
         "--planner",
         default="api",
-        choices=["api", "claude_code", "codex"],
-        help="LLM backend: api | claude_code | codex.",
+        type=_planner_reference,
+        metavar="BACKEND",
+        help="LLM backend: api | claude_code | codex | package.module:factory.",
     )
     ap.add_argument(
         "--model",

--- a/rpent/dashboard/static/dashboard.js
+++ b/rpent/dashboard/static/dashboard.js
@@ -1282,9 +1282,16 @@ setupSplitter($("#composerGrip"), {
 // --- launcher (start screen) ---
 function populateModelPresets(planner, selected = "") {
   const preset = $("#f-model_preset");
-  const values = MODEL_PRESETS[planner];
-  const model = selected || values[0];
+  const values = MODEL_PRESETS[planner] || [];
+  const model = selected || values[0] || "";
   preset.innerHTML = "";
+  preset.disabled = values.length === 0;
+  if (values.length === 0) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "—";
+    preset.appendChild(option);
+  }
   for (const value of values) {
     const option = document.createElement("option");
     option.value = value;
@@ -1292,7 +1299,7 @@ function populateModelPresets(planner, selected = "") {
     preset.appendChild(option);
   }
   const selectedPreset = values.includes(model);
-  preset.value = selectedPreset ? model : values[0];
+  preset.value = selectedPreset ? model : values[0] || "";
   $("#f-model_custom").value = selectedPreset ? "" : model;
 }
 
@@ -1302,8 +1309,15 @@ function selectedModel() {
 
 function showLauncher(defaults) {
   const d = defaults || {};
-  const planner = MODEL_PRESETS[d.planner] ? d.planner : "claude_code";
-  const defaultModel = d.model || MODEL_PRESETS[planner][0];
+  const planner = d.planner || "claude_code";
+  const plannerSelect = $("#f-planner");
+  if (![...plannerSelect.options].some(option => option.value === planner)) {
+    const option = document.createElement("option");
+    option.value = planner;
+    option.textContent = planner;
+    plannerSelect.appendChild(option);
+  }
+  const defaultModel = d.model || MODEL_PRESETS[planner]?.[0] || "";
   const set = (id, val) => { $(id).value = val == null ? "" : val; };
   set("#f-max-turns", d["max-turns"]);
   set("#f-max-episode-steps", d["max-episode-steps"]);
@@ -1317,7 +1331,7 @@ function showLauncher(defaults) {
   }
   launcherModelSelections[planner] = defaultModel;
   activeLauncherPlanner = planner;
-  $("#f-planner").value = planner;
+  plannerSelect.value = planner;
   populateModelPresets(planner, defaultModel);
   updatePlannerFields();
   $("#launcher").classList.remove("hidden");

--- a/rpent/planner/base.py
+++ b/rpent/planner/base.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import queue
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast
 
 from rpent.dashboard.events import DashboardEventSink
 from rpent.dashboard.interaction import DashboardInteractionPort
@@ -32,6 +34,7 @@ from rpent.utils.config import (
 #: MCP namespace prefix for RPent tools (``mcp__<server>__<tool>``).
 #: Toolkits expose plain tool names; planners add/strip this prefix.
 MCP_TOOL_PREFIX = "mcp__rpent__"
+BUILTIN_PLANNERS = ("api", "claude_code", "codex")
 REASONING_EFFORTS = ("none", "low", "medium", "high", "xhigh")
 
 
@@ -107,6 +110,69 @@ class Planner(Protocol):
             token-usage stats, and optional error string.
         """
         ...
+
+
+@dataclass(frozen=True, slots=True)
+class PlannerBuildConfig:
+    """Shared runtime configuration passed to an external planner factory."""
+
+    output_dir: Path
+    recipe_tag: str
+    robot_name: str
+    base_url: str | None
+    model: str | None
+    max_tokens: int
+    planner_timeout_s: int | None
+    reasoning_effort: str
+    dashboard_events: DashboardEventSink
+    no_images: bool
+
+
+def is_planner_reference(value: str) -> bool:
+    """Return whether ``value`` names a built-in or external planner factory."""
+    if value in BUILTIN_PLANNERS:
+        return True
+    module_name, separator, factory_name = value.partition(":")
+    return bool(
+        separator
+        and ":" not in factory_name
+        and factory_name.isidentifier()
+        and all(part.isidentifier() for part in module_name.split("."))
+    )
+
+
+def _load_external_planner(
+    reference: str,
+    config: PlannerBuildConfig,
+) -> Planner:
+    """Load ``module:factory`` and build a planner from ``config``."""
+    module_name, separator, factory_name = reference.partition(":")
+    if not separator or not module_name or not factory_name:
+        raise ValueError(
+            f"invalid planner reference {reference!r}; expected 'module:factory'"
+        )
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as error:
+        raise ValueError(
+            f"could not import custom planner module {module_name!r}: {error}"
+        ) from error
+    try:
+        factory = getattr(module, factory_name)
+    except AttributeError as error:
+        raise ValueError(
+            f"custom planner module {module_name!r} has no factory {factory_name!r}"
+        ) from error
+    if not callable(factory):
+        raise TypeError(f"custom planner factory {reference!r} is not callable")
+
+    planner = factory(config)
+    if not callable(getattr(planner, "solve", None)):
+        raise TypeError(
+            f"custom planner factory {reference!r} returned an object without "
+            "a callable solve method"
+        )
+    return cast(Planner, planner)
 
 
 # ---------------------------------------------------------------------------
@@ -217,5 +283,21 @@ def build_planner(
             output_path=Path(output_dir) / f"codex_{recipe_tag}.txt",
             dashboard_events=dashboard_events,
             reasoning_effort=reasoning_effort,
+        )
+    if is_planner_reference(planner_type):
+        return _load_external_planner(
+            planner_type,
+            PlannerBuildConfig(
+                output_dir=Path(output_dir),
+                recipe_tag=recipe_tag,
+                robot_name=robot_name,
+                base_url=base_url,
+                model=model,
+                max_tokens=max_tokens,
+                planner_timeout_s=planner_timeout_s,
+                reasoning_effort=reasoning_effort,
+                dashboard_events=dashboard_events,
+                no_images=no_images,
+            ),
         )
     raise ValueError(f"unknown planner_type: {planner_type}")

--- a/tests/unit_tests/rpent/cli/test_main_contracts.py
+++ b/tests/unit_tests/rpent/cli/test_main_contracts.py
@@ -143,6 +143,31 @@ def test_shared_cli_defaults_reach_robot_config_parser(
     assert args.memory_profile == "hf"
 
 
+def test_shared_cli_accepts_external_planner_factory_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, args = _capture_validated_args(
+        monkeypatch,
+        ["--robot", "libero", "--planner", "acme.planner:create_planner"],
+    )
+
+    assert args.planner == "acme.planner:create_planner"
+
+
+def test_shared_cli_rejects_malformed_planner_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli = _cli_module()
+    monkeypatch.setattr(cli, "enumerate_robots", lambda: ("libero",))
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli._build_argparser().parse_args(["--planner", "acme-planner"])
+
+    assert exc_info.value.code == 2
+    assert "package.module:factory" in capsys.readouterr().err
+
+
 def test_deprecated_env_alias_routes_to_the_same_robot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/rpent/planner/test_base_contracts.py
+++ b/tests/unit_tests/rpent/planner/test_base_contracts.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from rpent.dashboard.events import NullDashboardEventSink
+from rpent.planner.base import PlannerBuildConfig, build_planner
+
+
+class StubPlanner:
+    """Minimal object satisfying the runtime planner check."""
+
+    def solve(self, **kwargs):
+        raise AssertionError(f"not exercised by factory tests: {kwargs!r}")
+
+
+def _build(reference: str, tmp_path: Path, sink: NullDashboardEventSink):
+    return build_planner(
+        reference,
+        output_dir=tmp_path,
+        recipe_tag="pick_s0",
+        robot_name="testbot",
+        base_url="https://planner.example/v1",
+        model="research-model",
+        max_tokens=1234,
+        planner_timeout_s=56,
+        reasoning_effort="high",
+        claude_code_max_budget_usd=None,
+        dashboard_events=sink,
+        no_images=True,
+    )
+
+
+def test_external_planner_factory_receives_shared_build_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = ModuleType("test_external_planner")
+    expected = StubPlanner()
+    received: list[PlannerBuildConfig] = []
+
+    def create_planner(config: PlannerBuildConfig) -> StubPlanner:
+        received.append(config)
+        return expected
+
+    module.create_planner = create_planner  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    sink = NullDashboardEventSink()
+
+    planner = _build("test_external_planner:create_planner", tmp_path, sink)
+
+    assert planner is expected
+    assert received == [
+        PlannerBuildConfig(
+            output_dir=tmp_path,
+            recipe_tag="pick_s0",
+            robot_name="testbot",
+            base_url="https://planner.example/v1",
+            model="research-model",
+            max_tokens=1234,
+            planner_timeout_s=56,
+            reasoning_effort="high",
+            dashboard_events=sink,
+            no_images=True,
+        )
+    ]
+
+
+def test_external_planner_factory_must_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = ModuleType("test_missing_factory")
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    with pytest.raises(ValueError, match="has no factory 'create_planner'"):
+        _build(
+            "test_missing_factory:create_planner",
+            tmp_path,
+            NullDashboardEventSink(),
+        )
+
+
+def test_external_planner_module_must_be_importable(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="could not import custom planner module"):
+        _build(
+            "rpent_missing_test_module:create_planner",
+            tmp_path,
+            NullDashboardEventSink(),
+        )
+
+
+@pytest.mark.parametrize("factory_value", [None, object()])
+def test_external_planner_factory_must_be_callable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    factory_value: object,
+) -> None:
+    module = ModuleType("test_noncallable_factory")
+    module.create_planner = factory_value  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    with pytest.raises(TypeError, match="factory .* is not callable"):
+        _build(
+            "test_noncallable_factory:create_planner",
+            tmp_path,
+            NullDashboardEventSink(),
+        )
+
+
+def test_external_planner_factory_must_return_a_planner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = ModuleType("test_invalid_planner")
+    module.create_planner = lambda config: object()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    with pytest.raises(TypeError, match="without a callable solve method"):
+        _build(
+            "test_invalid_planner:create_planner",
+            tmp_path,
+            NullDashboardEventSink(),
+        )


### PR DESCRIPTION
## Summary

- accept `package.module:factory` references in `--planner` alongside the three built-in backends
- add `PlannerBuildConfig` so external factories receive the shared run configuration without depending on CLI internals
- validate import, factory, and returned planner contracts with focused errors
- preserve an externally supplied planner reference in the Dashboard launcher
- update the English and Chinese planner guides, including the current `dashboard_interaction` solve argument

## Motivation

The documentation advertises custom planners, but currently extending RPent requires editing `build_planner()` and the CLI `choices` list. That couples independent research planners and internal SDK adapters to RPent core changes.

With this change, an installed package can expose a factory and be selected directly:

```bash
rpent --planner my_package.my_planner:create_planner ...
```

Built-in `api`, `claude_code`, and `codex` behavior is unchanged, and no dependency is added.

## Validation

- `NO_PROXY=127.0.0.1,localhost pytest tests/unit_tests -q` — 239 passed
- `pre-commit run --all-files` — passed
- English docs: `sphinx-build -W --keep-going` — passed
- Chinese docs: `sphinx-build -W --keep-going` — passed
- `node --check rpent/dashboard/static/dashboard.js` — passed
- manual external-factory smoke: factory import, build config forwarding, `solve()`, and `finish` tool execution — passed
- live OpenAI-compatible Kimi-K3 smoke through RPent's existing `api` planner: 1 turn, 1 `finish` tool call, no planner error — passed

No simulator, GPU, or physical-robot run was needed for this planner-construction change.
