### PR TITLE
test(robocasa): replace full task-seed matrix with representative smoke checks

### DIFF
--- a/docs/source-en/rst_source/usage/robocasa.rst
+++ b/docs/source-en/rst_source/usage/robocasa.rst
@@ -361,6 +361,28 @@ contains the success count and accuracy for every task. The published record is
 task-level aggregate data; it does not include per-seed traces, raw trajectories,
 or failure classifications and therefore is not a per-cell audit artifact.
 
+.. _environment-smoke-tests:
+
+Environment smoke tests
+-----------------------
+
+After installing RoboCasa and its assets, run the opt-in environment smoke suite
+to check simulator installation and interfaces. It requires no planner credentials
+or VLA checkpoint:
+
+.. code-block:: bash
+
+   uv pip install pytest pytest-timeout
+   RPENT_RUN_ROBOCASA_INTEGRATION=1 \
+      pytest tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py -v
+
+The four cases cover ``OpenDrawer``, ``NavigateKitchen``, and
+``PickPlaceCounterToCabinet`` at seed 1, plus mobile-camera movement. Task checks
+verify construction/reset, 12D actions, operation cameras, navigation RGB-D/world
+map, the success predicate, and clean close. The camera check verifies pose and
+image changes after eight base steps. These real-simulator tests require a working
+GPU/EGL setup and are separate from offline CPU CI; skipped tests are not passes.
+
 Troubleshooting
 ---------------
 

--- a/docs/source-zh/rst_source/usage/robocasa.rst
+++ b/docs/source-zh/rst_source/usage/robocasa.rst
@@ -333,6 +333,26 @@ cell 按 ``<results-root>/<manifest-split>/<Task>_s<seed>/result.json`` 落盘�
 给出每个任务的成功次数和准确率。当前发布内容是任务级聚合数据，不包含 seed 级
 trace、原始轨迹或失败分类，因此不属于逐 cell 审计产物。
 
+.. _environment-smoke-tests:
+
+环境冒烟测试
+------------
+
+安装 RoboCasa 及其 assets 后，可显式启用环境冒烟测试，检查仿真器安装与接口。
+测试不需要 planner 凭据或 VLA checkpoint：
+
+.. code-block:: bash
+
+   uv pip install pytest pytest-timeout
+   RPENT_RUN_ROBOCASA_INTEGRATION=1 \
+      pytest tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py -v
+
+共四项测试：``OpenDrawer``、``NavigateKitchen``、``PickPlaceCounterToCabinet``
+各使用 seed 1，另加一项移动相机测试。任务测试检查构造/reset、12D action、
+操作相机、导航 RGB-D/world map、成功判定及关闭流程；相机测试检查底盘执行
+八步动作后的相机位姿与画面变化。这些真实仿真测试需要可用的 GPU/EGL 环境，
+与离线 CPU CI 分开运行；跳过不能计作通过。
+
 常见错误
 --------
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,28 +64,27 @@ Run the complete suite with:
 pytest tests/unit_tests -v
 ```
 
-Real simulator checks live under `integration_tests` and are always opt-in;
-they are not part of the offline CI suite. For example, after installing the
-RoboCasa extra and assets, run its representative environment checks with:
+## RoboCasa environment smoke tests
+
+The opt-in RoboCasa smoke suite verifies simulator installation and environment
+interfaces without loading a planner or VLA checkpoint. Install the RoboCasa
+extra and assets, then run:
 
 ```bash
 RPENT_RUN_ROBOCASA_INTEGRATION=1 \
   pytest tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py -v
 ```
 
-The suite has four cases: `OpenDrawer`, `NavigateKitchen`, and
-`PickPlaceCounterToCabinet` at seed 1, plus a separate mobile-camera movement
-check. These cover articulated fixtures, navigation, and object placement using
-the shared environment interface. Each task checks construction/reset, the 12D
-action interface, operation cameras, navigation RGB-D/world map, the success
-predicate, and clean close. The camera regression checks pose and image changes
-after eight base steps.
+The four cases cover `OpenDrawer`, `NavigateKitchen`, and
+`PickPlaceCounterToCabinet` at seed 1, plus mobile-camera movement. Task checks
+verify construction/reset, 12D actions, operation cameras, navigation RGB-D/world
+map, the success predicate, and clean close. The camera check verifies pose and
+image changes after eight base steps.
 
-These are code and installation checks, not a full evaluation: repeated seeds
-and similar tasks are deliberately omitted. They do not invoke a planner or VLA
-model. The fast Target50 protocol tests still validate all 50 tasks and the
-340-cell manifest; benchmark reproduction remains a separate procedure described
-in the [RoboCasa usage documentation](../docs/source-en/rst_source/usage/robocasa.rst).
+See the RoboCasa usage guide in
+[English](../docs/source-en/rst_source/usage/robocasa.rst#environment-smoke-tests)
+or [Chinese](../docs/source-zh/rst_source/usage/robocasa.rst#environment-smoke-tests)
+for setup and test prerequisites.
 
 ## Embodied GPU E2E tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,16 +66,26 @@ pytest tests/unit_tests -v
 
 Real simulator checks live under `integration_tests` and are always opt-in;
 they are not part of the offline CI suite. For example, after installing the
-RoboCasa extra and assets, run its 340-cell Target50 environment contract with:
+RoboCasa extra and assets, run its representative environment checks with:
 
 ```bash
 RPENT_RUN_ROBOCASA_INTEGRATION=1 \
   pytest tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py -v
 ```
 
-This opt-in test constructs and resets every manifest task/seed cell, verifies
-the 12D action interface, operation cameras, navigation RGB-D/world map,
-success predicate, and clean close. It does not invoke a planner or VLA model.
+The suite has four cases: `OpenDrawer`, `NavigateKitchen`, and
+`PickPlaceCounterToCabinet` at seed 1, plus a separate mobile-camera movement
+check. These cover articulated fixtures, navigation, and object placement using
+the shared environment interface. Each task checks construction/reset, the 12D
+action interface, operation cameras, navigation RGB-D/world map, the success
+predicate, and clean close. The camera regression checks pose and image changes
+after eight base steps.
+
+These are code and installation checks, not a full evaluation: repeated seeds
+and similar tasks are deliberately omitted. They do not invoke a planner or VLA
+model. The fast Target50 protocol tests still validate all 50 tasks and the
+340-cell manifest; benchmark reproduction remains a separate procedure described
+in the [RoboCasa README](../robots/robocasa/README.md#target50-reproduction).
 
 ## Embodied GPU E2E tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,7 +85,7 @@ These are code and installation checks, not a full evaluation: repeated seeds
 and similar tasks are deliberately omitted. They do not invoke a planner or VLA
 model. The fast Target50 protocol tests still validate all 50 tasks and the
 340-cell manifest; benchmark reproduction remains a separate procedure described
-in the [RoboCasa README](../robots/robocasa/README.md#target50-reproduction).
+in the [RoboCasa usage documentation](../docs/source-en/rst_source/usage/robocasa.rst).
 
 ## Embodied GPU E2E tests
 

--- a/tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py
+++ b/tests/integration_tests/robots/robocasa/test_target50_runtime_smoke.py
@@ -12,29 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Opt-in real-environment smoke coverage for every Target50 task."""
+"""Opt-in runtime contract checks on representative RoboCasa scenes."""
 
 from __future__ import annotations
 
-import json
 import os
-from pathlib import Path
 
 import numpy as np
 import pytest
-
-REPO_ROOT = Path(__file__).resolve().parents[4]
-MANIFEST_PATH = REPO_ROOT / "robots" / "robocasa" / "eval" / "target50.json"
-
-
-def _target50_cells() -> list[tuple[str, int]]:
-    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-    return [
-        (task, seed)
-        for split in manifest["splits"].values()
-        for task in split["tasks"]
-        for seed in split["seeds"]
-    ]
 
 
 class _DirectRpc:
@@ -55,11 +40,14 @@ class _DirectRpc:
 
 @pytest.mark.timeout(180)
 @pytest.mark.parametrize(
-    ("task_name", "seed"),
-    _target50_cells(),
-    ids=lambda value: str(value),
+    "task_name",
+    [
+        "OpenDrawer",  # Articulated fixture state.
+        "NavigateKitchen",  # Mobile-base navigation goal.
+        "PickPlaceCounterToCabinet",  # Object placement and containment.
+    ],
 )
-def test_target50_environment_contract(task_name, seed, monkeypatch):
+def test_target50_environment_contract(task_name, monkeypatch):
     if os.environ.get("RPENT_RUN_ROBOCASA_INTEGRATION") != "1":
         pytest.skip("set RPENT_RUN_ROBOCASA_INTEGRATION=1 to run RoboCasa smoke tests")
 
@@ -74,7 +62,7 @@ def test_target50_environment_contract(task_name, seed, monkeypatch):
     facade = RoboCasaEnvFacade(
         task_name=task_name,
         split="target",
-        seed=seed,
+        seed=1,
         camera_h=64,
         camera_w=64,
     )


### PR DESCRIPTION
## Summary
Keep RoboCasa installation/interface smoke coverage focused on **four representative cases**, replacing the former 341-case runtime matrix. Lightweight static tests continue to validate the full Target50 protocol.

Rebased onto `main` at `af522552f1a2b78aff76f8e8559c907a36f40003`. The remote branch's existing changes were preserved before rebasing, and the `tests/README.md` conflict was resolved without removing the upstream GPU E2E documentation or code. Four files differ from main: the smoke test, its shared README, and the English/Chinese RoboCasa usage pages. No production behavior or evaluation parameters change.

## Current coverage
| Case | Purpose |
| --- | --- |
| OpenDrawer, seed 1 | Articulated fixture and shared environment lifecycle |
| NavigateKitchen, seed 1 | Mobile-base navigation |
| PickPlaceCounterToCabinet, seed 1 | Object placement and containment |
| Mobile camera, OpenDrawer seed 1 | Camera pose and image change after eight base steps |

Task checks cover construction/reset, task language, 12D actions, operation cameras, navigation RGB-D/world map, finite values, success predicates and closing. The suite is explicitly opt-in and does not load a planner or VLA checkpoint. Per-case timeouts and cleanup remain intact.

## Review follow-up (2026-09-12)
- `91ce332`: shorten the shared README to the smoke suite's current purpose, command and coverage; remove migration explanations and discussion of omitted cases.
- Add matching English and Chinese usage sections with setup requirements and the opt-in command; link both from the shared test README.
- Preserve main's checkpoint-backed GPU E2E documentation verbatim and leave that separate suite unchanged.
- Reply individually to both reviewer comments without resolving the threads on their behalf.

## Validation on the rebased branch
- Python 3.10 CPU unit suite: **403 passed, 5 skipped**, with one third-party deprecation warning. No test failures. A command-local loopback `NO_PROXY` accommodated the workstation's HTTPX MCP test; no proxy source/configuration changes.
- Runtime smoke collection: **exactly 4 cases**. Without opt-in, **4 skipped**, not runtime passes.
- `pre-commit run --all-files`: passed.
- English and Chinese Sphinx builds with `-E -a -W --keep-going`: passed.
- Rendered smoke anchors, commands, task names and prerequisite checks: passed in both languages. README source links, unchanged upstream GPU E2E section, whitespace and added-line credential/server-path/conflict-marker checks: passed.
- The smoke test file is byte-for-byte unchanged from the previous PR head. No GPU or planner/policy evaluation was rerun for this documentation/rebase follow-up.

Earlier validation on the previous source/dependency combination passed the four non-root RTX 4090 environment checks in **48.78 seconds**. That remains earlier evidence, not a claim of a fresh run on this rebase or of policy accuracy.

## Boundaries
The full 50-task/340-cell protocol retains its static checks. Formal evaluation and checkpoint-backed E2E testing are separate from these installation smoke tests. HF memory, checkpoints, planner behavior, experiment settings and published results are unchanged. No runner, new CI GPU requirement or new runtime test matrix is added.
