### PR TITLE
feat(planner): configure context limits for Codex providers

### DIFF
--- a/docs/source-en/rst_source/usage/configure_planner.rst
+++ b/docs/source-en/rst_source/usage/configure_planner.rst
@@ -116,6 +116,27 @@ Notes:
   `Claude Agent SDK docs
   <https://code.claude.com/docs/en/agent-sdk/overview>`_.
 
+Local models with Claude Code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Claude Code can use a local model server that implements the Anthropic
+Messages API. For a server exposing Qwen3.6-27B as
+``Qwen/Qwen3.6-27B``, configure:
+
+.. code-block:: bash
+
+   export ANTHROPIC_BASE_URL=http://127.0.0.1:8000
+   export ANTHROPIC_API_KEY=EMPTY
+
+   rpent --robot libero --planner claude_code \
+     --model Qwen/Qwen3.6-27B \
+     --suite libero_goal_task --task 1 --seed 0
+
+Claude Code assumes a 200,000-token context window for unrecognized model IDs.
+If the local server uses a different limit, see the `Claude Code environment
+variables <https://code.claude.com/docs/en/env-vars>`_ for its context and
+auto-compaction settings.
+
 .. _planner-codex:
 
 The ``codex`` planner
@@ -142,6 +163,52 @@ Notes:
   a custom Responses-compatible endpoint, set ``CODEX_BASE_URL`` and
   ``CODEX_API_KEY``. This backend does not read ``OPENAI_BASE_URL`` or
   ``OPENAI_API_KEY``.
+
+Local models with Codex
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Codex can use a local model server that implements the OpenAI Responses API.
+For example, start Qwen3.6-27B with vLLM:
+
+.. code-block:: bash
+
+   vllm serve /path/to/Qwen3.6-27B \
+     --served-model-name Qwen/Qwen3.6-27B \
+     --max-model-len 262144 \
+     --reasoning-parser qwen3 \
+     --enable-auto-tool-choice \
+     --tool-call-parser qwen3_coder
+
+Point Codex at the local endpoint and configure the context limits exposed by
+the server:
+
+.. code-block:: bash
+
+   export CODEX_BASE_URL=http://127.0.0.1:8000
+   export CODEX_API_KEY=EMPTY
+   export CODEX_MODEL_CONTEXT_WINDOW=262144
+   export CODEX_AUTO_COMPACT_TOKEN_LIMIT=230000
+
+   rpent --robot libero --planner codex \
+     --model Qwen/Qwen3.6-27B \
+     --suite libero_goal_task --task 1 --seed 0
+
+vLLM reports this limit as ``max_model_len`` in its OpenAI-compatible
+``/v1/models`` response, while Codex expects ``context_window`` in its own
+model-catalog format. Codex therefore uses fallback metadata for an
+unrecognized vLLM model ID. Set ``CODEX_MODEL_CONTEXT_WINDOW`` to the
+``--max-model-len`` value accepted by the running server. This runtime limit
+may be lower than the checkpoint's advertised maximum to fit the available
+GPU memory.
+
+``CODEX_AUTO_COMPACT_TOKEN_LIMIT`` controls when Codex compacts the conversation
+history. Keep it below ``CODEX_MODEL_CONTEXT_WINDOW`` to leave room for the
+next response; ``230000`` is an example for a ``262144``-token server. Both
+variables are optional; when they are unset, Codex uses its defaults.
+
+The value passed to RPent with ``--model`` must match vLLM's
+``--served-model-name``. For another model, use its recommended vLLM parser
+settings.
 
 .. _planner-check:
 

--- a/docs/source-zh/rst_source/usage/configure_planner.rst
+++ b/docs/source-zh/rst_source/usage/configure_planner.rst
@@ -104,6 +104,25 @@ RPent 通过 SDK 创建进程内 MCP 服务，并把 toolkit 的工具注册到
   `Claude Agent SDK 文档
   <https://code.claude.com/docs/en/agent-sdk/overview>`_。
 
+通过 Claude Code 使用本地模型
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Claude Code 可以连接兼容 Anthropic Messages API 的本地模型服务。假设服务将
+Qwen3.6-27B 注册为 ``Qwen/Qwen3.6-27B``，可以这样配置：
+
+.. code-block:: bash
+
+   export ANTHROPIC_BASE_URL=http://127.0.0.1:8000
+   export ANTHROPIC_API_KEY=EMPTY
+
+   rpent --robot libero --planner claude_code \
+     --model Qwen/Qwen3.6-27B \
+     --suite libero_goal_task --task 1 --seed 0
+
+对于无法识别的本地模型名称，Claude Code 默认按 200,000 token 的上下文窗口
+管理会话。如果本地服务使用其他长度，请参考 `Claude Code 环境变量文档
+<https://code.claude.com/docs/en/env-vars>`_ 配置它的上下文和自动压缩参数。
+
 .. _planner-codex:
 
 ``codex`` planner
@@ -129,6 +148,49 @@ RPent 通过 SDK 创建进程内 MCP 服务，并把 toolkit 的工具注册到
   Responses API 兼容端点，请设置 ``CODEX_BASE_URL`` 和
   ``CODEX_API_KEY``；这里不读取 ``OPENAI_BASE_URL`` 或
   ``OPENAI_API_KEY``。
+
+通过 Codex 使用本地模型
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Codex 可以连接兼容 OpenAI Responses API 的本地模型服务。下面以通过 vLLM
+启动 Qwen3.6-27B 为例：
+
+.. code-block:: bash
+
+   vllm serve /path/to/Qwen3.6-27B \
+     --served-model-name Qwen/Qwen3.6-27B \
+     --max-model-len 262144 \
+     --reasoning-parser qwen3 \
+     --enable-auto-tool-choice \
+     --tool-call-parser qwen3_coder
+
+然后让 Codex 连接本地服务，并填写该服务实际开放的上下文限制：
+
+.. code-block:: bash
+
+   export CODEX_BASE_URL=http://127.0.0.1:8000
+   export CODEX_API_KEY=EMPTY
+   export CODEX_MODEL_CONTEXT_WINDOW=262144
+   export CODEX_AUTO_COMPACT_TOKEN_LIMIT=230000
+
+   rpent --robot libero --planner codex \
+     --model Qwen/Qwen3.6-27B \
+     --suite libero_goal_task --task 1 --seed 0
+
+vLLM 在兼容 OpenAI 的 ``/v1/models`` 响应中用 ``max_model_len`` 表示该上限，
+而 Codex 使用的模型目录格式要求 ``context_window`` 字段。因此，Codex 无法识别
+vLLM 返回的模型元数据时会使用备用配置。请将
+``CODEX_MODEL_CONTEXT_WINDOW`` 设置为当前 vLLM 服务的
+``--max-model-len``。这是服务实际接受的上限；为了适应可用显存，它可以低于
+checkpoint 配置中标注的最大长度。
+
+``CODEX_AUTO_COMPACT_TOKEN_LIMIT`` 用于设置 Codex 自动压缩会话历史的触发点。
+该值应小于 ``CODEX_MODEL_CONTEXT_WINDOW``，为下一次回复预留空间；当服务窗口为
+``262144`` token 时，``230000`` 是一个示例值。这两个变量都是可选的；如果未
+设置，Codex 将使用自身的默认值。
+
+RPent 的 ``--model`` 必须与 vLLM 的 ``--served-model-name`` 保持一致。使用其他
+模型时，请按照对应的 vLLM 部署说明设置解析参数。
 
 .. _planner-check:
 

--- a/rpent/planner/codex.py
+++ b/rpent/planner/codex.py
@@ -931,6 +931,12 @@ def _codex_mcp_config_overrides(
                 (f"model_providers.{PROVIDER_ID}.env_key", PROVIDER_ENV_KEY),
             ]
         )
+    model_context_window = os.environ.get("CODEX_MODEL_CONTEXT_WINDOW", None)
+    if model_context_window is not None:
+        config.append(("model_context_window", int(model_context_window)))
+    auto_compact_token_limit = os.environ.get("CODEX_AUTO_COMPACT_TOKEN_LIMIT", None)
+    if auto_compact_token_limit is not None:
+        config.append(("model_auto_compact_token_limit", int(auto_compact_token_limit)))
     return [f"{key}={json.dumps(value)}" for key, value in config]
 
 

--- a/tests/unit_tests/rpent/planner/test_codex_contracts.py
+++ b/tests/unit_tests/rpent/planner/test_codex_contracts.py
@@ -208,7 +208,11 @@ def test_http_mcp_readiness_ignores_environment_proxy(
     assert url.startswith("http://127.0.0.1:")
 
 
-def test_config_overrides_normalize_provider_url() -> None:
+def test_config_overrides_normalize_provider_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CODEX_MODEL_CONTEXT_WINDOW", raising=False)
+    monkeypatch.delenv("CODEX_AUTO_COMPACT_TOKEN_LIMIT", raising=False)
     assert _codex_mcp_config_overrides(
         mcp_url="http://fake.invalid/mcp/",
         base_url=None,
@@ -226,6 +230,20 @@ def test_config_overrides_normalize_provider_url() -> None:
         f'model_providers.{PROVIDER_ID}.base_url="https://provider.invalid/root/v1"',
         f'model_providers.{PROVIDER_ID}.wire_api="responses"',
         f'model_providers.{PROVIDER_ID}.env_key="{PROVIDER_ENV_KEY}"',
+    ]
+
+
+def test_config_overrides_include_optional_context_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODEX_MODEL_CONTEXT_WINDOW", "262144")
+    monkeypatch.setenv("CODEX_AUTO_COMPACT_TOKEN_LIMIT", "230000")
+
+    overrides = _codex_mcp_config_overrides(mcp_url=None, base_url=None)
+
+    assert overrides == [
+        "model_context_window=262144",
+        "model_auto_compact_token_limit=230000",
     ]
 
 
@@ -703,6 +721,8 @@ def test_probe_runs_read_only_and_denies_approvals(probe_codex: Any) -> None:
 def test_probe_config_attaches_no_mcp_server(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_BASE_URL", raising=False)
     monkeypatch.delenv("CODEX_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_MODEL_CONTEXT_WINDOW", raising=False)
+    monkeypatch.delenv("CODEX_AUTO_COMPACT_TOKEN_LIMIT", raising=False)
 
     overrides = _codex_mcp_config_overrides(mcp_url=None, base_url=None)
 


### PR DESCRIPTION
## Summary

- Add optional `CODEX_MODEL_CONTEXT_WINDOW` and `CODEX_AUTO_COMPACT_TOKEN_LIMIT` overrides for the Codex planner.
- Document local-model setup for Codex and Claude Code in English and Chinese.
- Keep the vLLM `--max-model-len` example consistent with the Codex context configuration.

## Testing

- `pytest tests/unit_tests/rpent/planner/test_codex_contracts.py -q` — 25 passed
- `pre-commit run --all-files`
- English and Chinese Sphinx builds with `-W`
- Verified `rpent-check-llm` against Qwen3.6-27B served by vLLM for both Codex and Claude Code