### PR TITLE
fix(franka): remove redundant primitive reset call during toolkit init

### DIFF
--- a/robots/franka/toolkit.py
+++ b/robots/franka/toolkit.py
@@ -59,7 +59,6 @@ class FrankaToolkit(Toolkit):
         )
         self._register_tools()
         self._state.reset()
-        self._primitives.reset()
         record = self._tools_module.dump_state(
             self._primitives,
             self._state,


### PR DESCRIPTION
As suggested in the title. Very simple one-line change.