### PR TITLE
build(robotwin): converge runtime dependencies

### DIFF
--- a/docs/source-en/rst_source/usage/robotwin.rst
+++ b/docs/source-en/rst_source/usage/robotwin.rst
@@ -43,10 +43,10 @@ For networks closer to Chinese mirrors:
 
 .. note::
 
-   ``.[robotwin]`` currently installs several dependencies from fixed Git
-   commits, so the installation needs access to GitHub even when a PyPI mirror
-   is configured. These will be replaced by released package versions after
-   publication.
+   The RoboTwin and LingBot runtimes in ``.[robotwin]`` are installed from
+   released PyPI packages. cuRobo is still built from a GitHub official tag,
+   so the installation needs access to GitHub even when a PyPI mirror is
+   configured.
 
 Download assets
 ---------------

--- a/docs/source-zh/rst_source/usage/robotwin.rst
+++ b/docs/source-zh/rst_source/usage/robotwin.rst
@@ -40,9 +40,9 @@ RoboTwin 所需依赖：
 
 .. note::
 
-   ``.[robotwin]`` 目前会从 GitHub 的固定提交安装部分依赖，因此即使配置了
-   PyPI 镜像，安装时仍需能访问 GitHub。这些依赖在正式发布后将改用版本号
-   安装。
+   ``.[robotwin]`` 的 RoboTwin 与 LingBot 运行时已作为发布包安装到 PyPI；
+   cuRobo 仍从 GitHub 官方 tag 源码构建，因此即使配置了 PyPI 镜像，安装时
+   仍需能访问 GitHub。
 
 下载仿真资源
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,10 @@ robocasa = [
     "robosuite @ git+https://github.com/RLinf/robosuite.git@rpent",
 ]
 robotwin = [
-    # TODO: replace fixed owner-controlled revisions with released versions.
     "rpent[rlinf]",
-    "rlinf-robotwin-runtime @ git+https://github.com/Sonorous281/RoboTwin.git@11d2d4ba1ba4819ebf63bb91ba0c5dfd4b0f81f2",
-    "rlinf-lingbotvla @ git+https://github.com/RLinf/lingbot-vla.git@e158cce02f50dbb48b7f5bf76fdb34c1c1f97e12",
+    "rlinf-robotwin-runtime==0.1.1",
+    "rlinf-lingbotvla==0.1.1",
+    "nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@v0.7.8",
 ]
 
 [tool.uv]
@@ -150,22 +150,13 @@ conflicts = [
         { extra = "robotwin" },
     ],
     [
-        { extra = "libero" },
-        { extra = "robotwin" },
-    ],
-    [
-        { extra = "libero-pro" },
-        { extra = "robotwin" },
-    ],
-    [
-        { extra = "libero-plus" },
-        { extra = "robotwin" },
-    ],
-    [
         { extra = "robocasa" },
         { extra = "robotwin" },
     ],
 ]
+
+[tool.uv.extra-build-dependencies]
+nvidia-curobo = ["torch==2.7.1"]
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary

Converge the RoboTwin integration onto released RLinf packages and the validated upstream cuRobo release.

This replaces the previous fixed RoboTwin / LingBot Git revisions with versioned PyPI packages, and keeps cuRobo as an RPent-owned source dependency.

## Changes

- Replace fixed RoboTwin runtime Git dependency with:
  - `rlinf-robotwin-runtime==0.1.1`
- Replace fixed LingBot-VLA Git dependency with:
  - `rlinf-lingbotvla==0.1.1`
- Pin cuRobo to the validated official NVIDIA release:
  - `nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@v0.7.8`
- Ensure cuRobo is built with the validated Torch version:
  - `nvidia-curobo = ["torch==2.7.1"]`
- Remove the `libero × robotwin` and `libero-pro × robotwin` conflict declarations after fresh co-install validation.
- Keep the remaining dependency conflicts unchanged.

## Dependency layout

```text
RPent
├── rlinf-robotwin-runtime==0.1.1
├── rlinf-lingbotvla==0.1.1
└── NVlabs/curobo@v0.7.8