### PR TITLE
refactor: unify tool scheduling, recording, and recipe export

### DIFF
--- a/docs/source-en/rst_source/development/add_primitive.rst
+++ b/docs/source-en/rst_source/development/add_primitive.rst
@@ -84,10 +84,10 @@ it. The toolkit handles capture through ``_capture_observation``; handlers
 submit frames but do not save their own episode video or duplicate the state dump.
 
 For a tool that reads existing observations, place ``@readonly`` below
-``@tool`` to skip automatic capture. Calls still execute one at a time.
+``@tool`` to allow concurrent execution and skip automatic capture.
 ``write_text_file`` and ``finish`` have no readonly marker and run exclusively;
 the executor skips observation capture for common tools and ``finish``.
-See :doc:`interfaces` for execution and cancellation.
+See :doc:`interfaces` for cancellation and scheduling.
 
 .. _add-primitive-model-based:
 

--- a/docs/source-en/rst_source/development/add_robot.rst
+++ b/docs/source-en/rst_source/development/add_robot.rst
@@ -324,9 +324,9 @@ for both action responses and ``view_env_state``.
   executor stores accepted results in ``toolkit.finish_result``.
 
 Tools submit environment-step RGB frames via ``ctx.record_frame(rgb)``.
-The base toolkit collects the frames and signals cancellation. Robot toolkits
-save Dashboard action clips during observation capture, override ``close()``
-to save the episode video, and implement ``write_recipe()`` from their trace.
+The base toolkit owns the frame buffer, Dashboard action clips, episode video,
+recipe export, and cancellation lifecycle. Use the inherited ``close()`` for
+recording cleanup; if a robot needs additional cleanup, preserve the base call.
 
 Conventions worth keeping
 -------------------------
@@ -334,8 +334,8 @@ Conventions worth keeping
 - ``output_dir`` is the runner-created working directory. Environment artifacts
   are managed by ``EnvState`` through logical names; transcripts share the same
   run directory.
-- ``@readonly`` below ``@tool`` skips automatic observation capture. Calls
-  execute one at a time. Call
+- ``@readonly`` below ``@tool`` enables shared execution and skips automatic
+  observation capture. Keep actions and ``finish`` exclusive and call
   ``ctx.check_cancelled()`` at safe boundaries in long loops.
 - Server-side values use transport-supported Python / NumPy types and remain
   torch-free.

--- a/docs/source-en/rst_source/development/architecture.rst
+++ b/docs/source-en/rst_source/development/architecture.rst
@@ -173,15 +173,15 @@ invokes them through ``execute_tool``. It adapts schemas and ``ToolResult``
 text / PNG images to its SDK; Claude Code and Codex use MCP adapters at this
 boundary. Robot handlers are independent of the planner transport.
 
-``Toolkit`` validates arguments, admits one call, injects ``ToolContext``, and
+``Toolkit`` validates arguments, schedules calls, injects ``ToolContext``, and
 captures post-action observations. Handlers use ``ctx.robot`` to access their
 session runtime and issue ``reset`` / ``step`` / ``predict`` requests through
 environment and model clients. HTTP or socket RPC carries those calls and
 NumPy observations between processes.
 
-The toolkit also owns cancellation, the frame buffer, and ``finish_result``.
-Robot-specific subclasses build observations, save videos and recipes, and
-report native success through ``solved()``. See :doc:`interfaces` for the contracts.
+The toolkit also owns cancellation, frame recording, recipe export, and
+``finish_result``. Robot-specific subclasses build observations and report
+native success through ``solved()``. See :doc:`interfaces` for the contracts.
 
 Dashboard (optional)
 --------------------
@@ -194,7 +194,7 @@ the CLI before it calls ``robot_spec.init_runtime`` once with the shared
 component names.
 The environment must provide ``robot_spec.dashboard``; it defines the task
 command and fields, runtime components, and allowed primitive controls.
-Camera tabs use the ``frame_channels`` mapping to recorded image artifacts. The Session controller waits for that robot-defined command
+Camera tabs are discovered from the PNG artifacts in each recorded step. The Session controller waits for that robot-defined command
 (``/rpent-task`` for LIBERO). For every claimed TaskRun, the Dashboard calls
 ``parse_config`` and the same ``robot_spec.init_runtime`` hook with the unique
 component names, merges the shared and unique

--- a/docs/source-en/rst_source/development/interfaces.rst
+++ b/docs/source-en/rst_source/development/interfaces.rst
@@ -85,7 +85,7 @@ Contract: read ``toolkit.list_tools()`` and adapt each ``Tool``'s ``name``,
 ``toolkit.execute_tool(name, arguments)`` and return ``PlannerResult`` when
 ``toolkit.finish_result`` is set or a run limit is reached. For asynchronous
 adapters, use ``rpent.planner.base.execute_tool`` to run the synchronous executor
-in a worker. The API and MCP adapters serialize tool calls.
+in a worker and retain it through cancellation.
 
 Native tools and Toolkit
 ------------------------
@@ -125,12 +125,12 @@ The base class adds ``read_text_file``, ``write_text_file``, ``list_dir``, and
 Memory file access goes through ``MemoryManager.authorize_read`` and
 ``authorize_write``.
 
-Execution and lifecycle
-~~~~~~~~~~~~~~~~~~~~~~~
+Scheduling and lifecycle
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each toolkit permits one active call. Overlapping direct calls return an error;
-API and MCP adapters serialize their calls. Place ``@readonly`` below ``@tool``
-to skip automatic observation capture.
+Tools run exclusively by default. Place ``@readonly`` below ``@tool`` to allow
+execution alongside other readonly tools and skip automatic observation capture.
+Pending exclusive calls take priority and keep their queue order.
 
 Non-readonly robot tools capture a new observation after execution. Common tools
 and ``finish`` are excluded from capture: ``write_text_file`` and ``finish`` run
@@ -145,19 +145,19 @@ Capture also runs after handler errors; the call remains active until capture
 and Dashboard publication finish.
 
 Long-running handlers call ``ctx.check_cancelled()`` at safe boundaries.
-``cancel_active_and_wait()`` signals the active call and waits for it to exit.
-Subsequent calls receive a fresh cancellation signal. Tools submit RGB frames
-with ``ctx.record_frame``; robot toolkits save per-action clips during capture
-and override ``close()`` to save their episode video.
+``cancel_active_and_wait()`` pauses admission, cancels pending and active calls,
+and waits for cleanup; ``resume_calls()`` reopens admission.
+``close()`` permanently closes admission, drains calls, and saves collected
+frames as ``episode.mp4``. Tools submit RGB frames with ``ctx.record_frame``;
+when Dashboard events are enabled, the executor also saves per-action clips.
 
 Each robot supplies its own ``finish`` tool. A successful call stores its
 ``status`` and ``summary`` in ``toolkit.finish_result``; it does not close
 admission. ``solved()`` reports environment success independently of the
-planner's requested finish status. Robot toolkits implement
-``write_recipe(recipe_tag)`` using their recorded state trace. LIBERO exports
-the successful attempt after the last reset; RoboCasa and RoboTwin retain
-their action filters. The runner decides whether the run qualifies for memory
-publication.
+planner's requested finish status. ``write_recipe(recipe_tag)`` exports
+successful robot calls, including perception and resets, in completion order;
+common file/image tools and ``finish`` are excluded. The runner decides whether
+the run qualifies for memory publication.
 
 Inter-process communication
 ---------------------------

--- a/docs/source-en/rst_source/development/memory.rst
+++ b/docs/source-en/rst_source/development/memory.rst
@@ -85,7 +85,8 @@ exploration may write to its configured ``_internal/inbox/<cell>/``. Access to
 another robot's repository memory is denied. These checks govern memory
 access; they do not restrict all files to the output directory.
 
-Each robot toolkit implements ``write_recipe(recipe_tag)`` from its state
-trace. LIBERO exports the successful attempt after the last reset; RoboCasa
-and RoboTwin filter recorded actions using their existing recipe rules. The
-runner decides whether the audit and recipe qualify for publication to memory.
+``Toolkit.write_recipe(recipe_tag)`` exports successful robot action and
+perception calls in completion order, including resets across attempts in the
+same session. Common file/image tools and ``finish`` are excluded. A failed
+call is not exported. The runner decides whether the resulting audit and
+recipe qualify for publication to memory.

--- a/docs/source-en/rst_source/usage/configure_planner.rst
+++ b/docs/source-en/rst_source/usage/configure_planner.rst
@@ -192,7 +192,7 @@ Any planner must:
 2. Read native tools from ``toolkit.list_tools()`` and adapt their ``name``,
    ``description``, and ``input_schema`` to the SDK. Execute calls through
    ``toolkit.execute_tool(name, arguments)``; asynchronous adapters use
-   ``rpent.planner.base.execute_tool`` to execute tools in a worker thread.
+   ``rpent.planner.base.execute_tool`` for cancellation-aware execution.
 3. Convert ``ToolResult.to_text()`` and the PNG bytes in ``ToolResult.images``
    to the SDK format, preserving ``ToolResult.is_error``.
 4. Check ``toolkit.finish_result`` and stop according to ``max_turns`` and

--- a/docs/source-zh/rst_source/development/add_primitive.rst
+++ b/docs/source-zh/rst_source/development/add_primitive.rst
@@ -79,14 +79,14 @@
 
    工具执行后，toolkit 会自动保存新的状态快照。对于 ``view_env_state``、
    ``back_project`` 等读取已有观测的工具，可以在 ``@tool`` 下方添加
-   ``@readonly``，省去这次状态捕获；调用仍按顺序执行。公共工具和 ``finish``
+   ``@readonly``，允许并行执行并省去这次状态捕获。公共工具和 ``finish``
    不触发状态捕获；``write_text_file`` 和 ``finish`` 不设置 readonly，独占执行。
 
 2. **将工具加入 toolkit。** 把函数声明加入该机器人的工具集合，例如 LIBERO 的
    ``LIBERO_TOOLS``。Toolkit 在构造时接收这组工具，并统一处理参数校验和调用。
 
 完成以上步骤后，``api``、``claude_code`` 和 ``codex`` 三种 planner
-都可以调用该工具，无需分别编写适配代码。执行和取消的约定参见
+都可以调用该工具，无需分别编写适配代码。需要支持并发或取消时，参见
 :doc:`interfaces` 中的工具集说明。
 
 .. _add-primitive-model-based:

--- a/docs/source-zh/rst_source/development/add_robot.rst
+++ b/docs/source-zh/rst_source/development/add_robot.rst
@@ -295,9 +295,8 @@ VLA 客户端和本次会话的状态。工具函数通过 ``ctx.robot`` 访问�
 - 实现 ``_capture_observation(*, command, result, elapsed_s)``，调用上述
   状态保存与观测整理函数，返回观测数据和 PNG 图片。Toolkit 会在动作执行后
   自动调用它；原始执行结果可通过 ``result.to_dict()`` 保存到步骤日志中。
-- 实现 ``solved()``，根据环境状态判断任务是否成功。工具调用与取消由基类处理。
-  机器人 toolkit 在捕获观测时保存动作视频，重写 ``close()`` 保存回合录像，
-  并通过 ``write_recipe()`` 从记录的状态导出 recipe。
+- 实现 ``solved()``，根据环境状态判断任务是否成功。工具调用、取消和录像收尾
+  由基类处理；若需要额外的关闭逻辑，在重写 ``close()`` 时保留对基类的调用。
 
 ``runtime_kwargs`` 由 ``robot_spec.py:get_toolkit`` 转发给 toolkit，用于构造
 运行时对象。其中通常包含 ``{"env": MyEnvClient(...), "model": VLAClient(...)}``

--- a/docs/source-zh/rst_source/development/architecture.rst
+++ b/docs/source-zh/rst_source/development/architecture.rst
@@ -168,8 +168,8 @@ Dashboard（可选）
 ``--dashboard-host`` 和 ``--dashboard-port`` 启动 Dashboard。Session 配置全部来自
 命令行，然后用共享 component 名称调用一次 ``robot_spec.init_runtime``。环境必须
 提供 ``robot_spec.dashboard``，由它定义
-前端使用的任务命令与字段、runtime components 和允许执行的原语。相机标签通过
-``frame_channels`` 映射到每步记录的图片工件。Session
+前端使用的任务命令与字段、runtime components 和允许执行的原语。相机标签从
+每步记录的 PNG 工件中自动发现。Session
 controller 随后等待该环境定义的命令（LIBERO 使用 ``/rpent-task``）；每次取得一个
 TaskRun 后，Dashboard 会调用 ``parse_config``，再用 unique component 名称调用
 同一个 ``robot_spec.init_runtime``，合并两次返回的客户端参数，并为本次任务新建 toolkit

--- a/docs/source-zh/rst_source/development/interfaces.rst
+++ b/docs/source-zh/rst_source/development/interfaces.rst
@@ -133,18 +133,18 @@ Planner 先通过 ``toolkit.list_tools()`` 获取工具定义，将每个工具�
 应写入观测中的日志；动作错误仍会保留。即使工具函数出错，toolkit 也会尝试
 捕获观测，让 planner 了解当前环境。
 
-读取已有观测的工具可以在 ``@tool`` 下方添加 ``@readonly``，跳过自动捕获。
-每个 toolkit 同时只允许一个调用；重叠的直接调用会返回错误。API 和 MCP
-适配器按顺序执行工具调用。
+读取已有观测的工具可以在 ``@tool`` 下方添加 ``@readonly``，允许与其他
+readonly 工具并行，并跳过自动捕获。其余工具独占执行；等待中的独占调用
+优先执行，并保持登记顺序。
 
 公共工具和 ``finish`` 不触发观测捕获。``write_text_file`` 和 ``finish``
 不设置 readonly，因此独占执行但不新增观测。LIBERO 的 ``segment`` 也不设置
 readonly，独占执行，并在保存分割附件后自动捕获一次观测。
 
 长时间运行的工具应在安全的动作边界调用 ``ctx.check_cancelled()``。收到中断后，
-``cancel_active_and_wait()`` 向当前调用发送取消信号，并等待它退出。后续调用
-使用新的取消信号。工具通过 ``ctx.record_frame`` 提交录像帧；机器人 toolkit
-在捕获观测时保存动作片段，并重写 ``close()`` 保存回合录像。
+``cancel_active_and_wait()`` 会暂停新调用，并等待已有调用取消和清理；后续可以用
+``resume_calls()`` 恢复。运行结束时，``close()`` 关闭工具集并保存通过
+``ctx.record_frame`` 收集的录像帧。
 
 每个机器人提供自己的 ``finish`` 工具。调用成功后，toolkit 将其中的 ``status``
 和 ``summary`` 保存到 ``finish_result``，供 planner 结束循环；环境是否真正成功，

--- a/docs/source-zh/rst_source/development/memory.rst
+++ b/docs/source-zh/rst_source/development/memory.rst
@@ -61,9 +61,9 @@ memory 同步到 ``memory/<robot>/``。数据集是公开的，无需 token 即�
 公共文件工具已接入这些检查；新增需要访问 memory 的工具时，可通过
 ``ctx.memory.authorize_read(path)`` 或 ``authorize_write(path)`` 获取允许访问的路径。
 
-各机器人 toolkit 通过 ``write_recipe(recipe_tag)`` 从状态记录导出 recipe。
-LIBERO 只导出最后一次 reset 后的成功尝试；RoboCasa 和 RoboTwin 保留各自的
-动作筛选规则。是否将生成的 audit 和 recipe 纳入 memory，由运行流程根据结果决定。
+运行中的 recipe 由 ``Toolkit.write_recipe(recipe_tag)`` 统一导出，记录成功的
+机器人动作与感知调用，也保留同一会话中的 reset。文件操作和 ``finish`` 不会写入
+recipe。是否将生成的 audit 和 recipe 纳入 memory，仍由运行流程根据结果决定。
 
 贡献 memory
 -----------

--- a/docs/source-zh/rst_source/usage/configure_planner.rst
+++ b/docs/source-zh/rst_source/usage/configure_planner.rst
@@ -177,7 +177,7 @@ agent SDK，可以实现 ``rpent.planner.base.Planner`` 协议，并在
 1. 接收已经渲染好的 ``system_prompt`` 和 ``user_message``。
 2. 从 ``toolkit.list_tools()`` 读取原生工具，并将其 ``name``、``description``
    和 ``input_schema`` 转为 SDK 格式。通过 ``toolkit.execute_tool(name, arguments)``
-   执行调用；异步适配器通过 ``rpent.planner.base.execute_tool`` 在线程中执行工具。
+   执行调用；异步适配器使用支持取消清理的 ``rpent.planner.base.execute_tool``。
 3. 将 ``ToolResult.to_text()`` 和 ``ToolResult.images`` 中的 PNG 字节转换为
    SDK 格式，并保留 ``ToolResult.is_error``。
 4. 检查 ``toolkit.finish_result``，按 ``max_turns`` 等限制终止循环；

--- a/robots/libero/toolkit.py
+++ b/robots/libero/toolkit.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
@@ -144,14 +143,11 @@ class LiberoToolkit(Toolkit[LiberoRuntime]):
             )
         except Exception:
             logger.exception("Dashboard failed to publish step %s", record.step_idx)
-        self._action_frame_cursor = 0
 
     def _capture_observation(
         self, *, command: dict[str, Any], result: ToolResult, elapsed_s: float
     ) -> tuple[dict[str, Any], list[bytes]]:
         """Save the full action log, then assemble the current observation response."""
-        frame_start = self._action_frame_cursor
-        self._action_frame_cursor = len(self._frames)
         logged_result = result.to_dict()
         record = dump_state(
             self._robot,
@@ -163,21 +159,6 @@ class LiberoToolkit(Toolkit[LiberoRuntime]):
             },
         )
         self._robot.solved |= record.terminated
-        if self._dashboard_events.enabled:
-            try:
-                frames = self._frames[frame_start:]
-                if frames:
-                    self._state.save(
-                        f"action_{command['action']}.mp4",
-                        frames,
-                        step=record.step_idx,
-                        fps=20,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "failed to save action clip for step %s: %s", record.step_idx, exc
-                )
-        record = self._state.get(record.step_idx)
         data, images = build_observation(self._state, record)
         if result.is_error:
             # Report the error once in this response; retain it in the saved log
@@ -197,25 +178,14 @@ class LiberoToolkit(Toolkit[LiberoRuntime]):
         return self._robot.solved
 
     def close(self) -> None:
-        """Finalize collected data and save the episode video independently."""
+        """Drain calls and save the video before finalizing collected data."""
+        super().close()
         try:
             episode = self._robot.finalize_flywheel()
             if episode is not None:
                 logger.info("flywheel episode finalized: %s", episode)
         except Exception as exc:
             logger.warning("failed to finalize flywheel episode: %s", exc)
-
-        try:
-            if self._frames:
-                self._state.save("episode.mp4", self._frames, step=None, fps=20)
-        except Exception as exc:
-            logger.warning("failed to save episode video: %s", exc)
-
-    def write_recipe(self, recipe_tag: str) -> str:
-        """Export the successful attempt from the recorded LIBERO trace."""
-        return write_recipe_from_states(
-            self._state, recipe_tag, output_dir=self._task_output_dir
-        )
 
 
 def dump_state(
@@ -423,87 +393,3 @@ def _world_from_depth(depth_metric: np.ndarray, camera_meta: dict) -> np.ndarray
         axis=-1,
     )
     return (camera_points @ extrinsic.T)[..., :3]
-
-
-def _is_primitive_action(name: object) -> bool:
-    return name in {
-        "reset",
-        "pi0_pick",
-        "pi0_doubled",
-        "move_to",
-        "rotate_wrist",
-        "rotate_pitch",
-        "move_pose",
-        "release",
-        "set_gripper",
-    }
-
-
-def write_recipe_from_states(
-    state: EnvState, recipe_tag: str, *, output_dir: Path | str
-) -> str:
-    """Find a command sequence that gets ``terminated=True``.
-
-    Export non-error LIBERO primitive commands and successful segment calls.
-    """
-    records = state.records()
-    last_reset = max(
-        (
-            record.step_idx
-            for record in records
-            if (
-                (record.command or {}).get("action") == "reset"
-                and not (isinstance(record.result, dict) and record.result.get("error"))
-            )
-        ),
-        default=-1,
-    )
-    command_events = []
-    for record in records:
-        if record.step_idx <= last_reset:
-            continue
-        command = record.command
-        result = record.result
-        if (
-            command is not None
-            and _is_primitive_action(command.get("action"))
-            and not (isinstance(result, dict) and result.get("error"))
-        ):
-            command_events.append(((record.step_idx, -1), command))
-
-        for name in sorted(record.artifacts):
-            if not (name.startswith("segment_") and name.endswith(".json")):
-                continue
-            segment = state.load(name, step=record.step_idx)
-            if segment.get("error"):
-                continue
-            if segment["mode"] == "text":
-                segment_command = {
-                    "action": "segment",
-                    "prompt": segment["prompt"],
-                    "camera": segment["camera"],
-                }
-            else:
-                segment_command = {
-                    "action": "segment",
-                    "point": segment["point"],
-                    "camera": segment["camera"],
-                }
-            event_order = (record.step_idx, int(segment["segment_index"]))
-            command_events.append((event_order, segment_command))
-
-    # Never publish a failed trajectory as a recipe. The environment trace is
-    # authoritative; an agent's self-reported finish status is not.
-    solved = any(
-        record.terminated for record in records if record.step_idx > last_reset
-    )
-    if not solved:
-        return ""
-    command_events.sort(key=lambda event: event[0])
-    recipe_name = f"{recipe_tag}_recipe.jsonl"
-    recipe_path = Path(output_dir) / recipe_name
-    recipe_path.parent.mkdir(parents=True, exist_ok=True)
-    recipe_path.write_text(
-        "".join(json.dumps(command) + "\n" for _, command in command_events)
-    )
-    return recipe_name

--- a/robots/robocasa/toolkit.py
+++ b/robots/robocasa/toolkit.py
@@ -100,7 +100,6 @@ class RoboCasaToolkit(Toolkit[RoboCasaRuntime]):
             self._dashboard_events.emit(StepRecordEvent(record=record, env_state=state))
         except Exception:
             logger.exception("Dashboard failed to publish step %s", record.step_idx)
-        self._action_frame_cursor = 0
 
     def _capture_observation(
         self,
@@ -109,29 +108,12 @@ class RoboCasaToolkit(Toolkit[RoboCasaRuntime]):
         result: ToolResult,
         elapsed_s: float,
     ) -> tuple[dict[str, Any], list[bytes]]:
-        frame_start = self._action_frame_cursor
-        self._action_frame_cursor = len(self._frames)
         logged_result = result.to_dict()
         record = dump_state(
             self._robot,
             self._state,
             log={"command": command, "result": logged_result, "elapsed_s": elapsed_s},
         )
-        if self._dashboard_events.enabled:
-            try:
-                frames = self._frames[frame_start:]
-                if frames:
-                    self._state.save(
-                        f"action_{command['action']}.mp4",
-                        frames,
-                        step=record.step_idx,
-                        fps=20,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "failed to save action clip for step %s: %s", record.step_idx, exc
-                )
-        record = self._state.get(record.step_idx)
         data, images = build_observation(self._state, record)
         if result.is_error:
             data["log"]["result"] = {
@@ -144,18 +126,6 @@ class RoboCasaToolkit(Toolkit[RoboCasaRuntime]):
         """Read success from the final environment record, independent of finish."""
         record = self._state.latest_record()
         return bool(record is not None and record.extras.get("success", False))
-
-    def close(self) -> None:
-        """Save this robot's accumulated episode frames."""
-        try:
-            if self._frames:
-                self._state.save("episode.mp4", self._frames, step=None, fps=20)
-        except Exception as exc:
-            logger.warning("failed to save episode video: %s", exc)
-
-    def write_recipe(self, recipe_tag: str) -> str:
-        """Export non-error RoboCasa commands from the recorded trace."""
-        return write_recipe_from_states(self._state, recipe_tag)
 
 
 # Heavy npy artifacts pruned after the ``_keep_heavy`` window elapses (the
@@ -319,38 +289,3 @@ def build_observation(
             break
 
     return out, images
-
-
-_PRIMITIVE_ACTIONS = frozenset(
-    {
-        "move_to",
-        "move_delta",
-        "rotate_pitch",
-        "set_gripper",
-        "release",
-        "scripted_grasp",
-        "rldx_skill",
-        "rldx_arm",
-        "navigate_to",
-        "move_base",
-        "reset",
-    }
-)
-
-
-def write_recipe_from_states(state: EnvState, recipe_tag: str) -> str:
-    """Export non-error RoboCasa primitive commands from the state trace as JSONL."""
-    commands = []
-    for record in state.records():
-        command = record.command
-        if not isinstance(command, dict):
-            continue
-        if command.get("action") not in _PRIMITIVE_ACTIONS:
-            continue
-        result = record.result
-        if isinstance(result, dict) and result.get("error"):
-            continue
-        commands.append(command)
-    recipe_name = f"{recipe_tag}_recipe.jsonl"
-    state.save(recipe_name, commands, step=None)
-    return recipe_name

--- a/robots/robotwin/toolkit.py
+++ b/robots/robotwin/toolkit.py
@@ -98,7 +98,6 @@ class RoboTwinToolkit(Toolkit[RoboTwinRuntime]):
             self._dashboard_events.emit(StepRecordEvent(record=record, env_state=state))
         except Exception:
             logger.exception("Dashboard failed to publish step %s", record.step_idx)
-        self._action_frame_cursor = 0
 
     def _capture_observation(
         self,
@@ -107,29 +106,12 @@ class RoboTwinToolkit(Toolkit[RoboTwinRuntime]):
         result: ToolResult,
         elapsed_s: float,
     ) -> tuple[dict[str, Any], list[bytes]]:
-        frame_start = self._action_frame_cursor
-        self._action_frame_cursor = len(self._frames)
         logged_result = result.to_dict()
         record = dump_state(
             self._robot,
             self._state,
             log={"command": command, "result": logged_result, "elapsed_s": elapsed_s},
         )
-        if self._dashboard_events.enabled:
-            try:
-                frames = self._frames[frame_start:]
-                if frames:
-                    self._state.save(
-                        f"action_{command['action']}.mp4",
-                        frames,
-                        step=record.step_idx,
-                        fps=20,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "failed to save action clip for step %s: %s", record.step_idx, exc
-                )
-        record = self._state.get(record.step_idx)
         data, images = build_observation(self._state, record)
         if result.is_error:
             data["log"]["result"] = {
@@ -145,35 +127,6 @@ class RoboTwinToolkit(Toolkit[RoboTwinRuntime]):
             record is not None
             and record.state["episode_status"].get("eval_success") is True
         )
-
-    def close(self) -> None:
-        """Save this robot's accumulated episode frames."""
-        try:
-            if self._frames:
-                self._state.save("episode.mp4", self._frames, step=None, fps=20)
-        except Exception as exc:
-            logger.warning("failed to save episode video: %s", exc)
-
-    def write_recipe(self, recipe_tag: str) -> str:
-        """Export state-advancing RoboTwin primitives with no error and no
-        explicit ``success=False`` from ``EnvState.records()``."""
-        recipe = [
-            record.command
-            for record in self._state.records()
-            if isinstance(record.command, dict)
-            and record.command.get("action") in _RECIPE_ACTIONS
-            and not (
-                isinstance(record.result, dict)
-                and (
-                    record.result.get("error") or record.result.get("success") is False
-                )
-            )
-        ]
-        name = f"{recipe_tag}_recipe.jsonl"
-        saved = self._state.save(name, recipe, step=None)
-        if saved is None:
-            raise RuntimeError(f"failed to save RoboTwin recipe artifact: {name}")
-        return str(self._state.artifact_path(name, step=None))
 
 
 def _world_from_depth(
@@ -310,6 +263,3 @@ def build_observation(
             except FileNotFoundError:
                 pass
     return data, images
-
-
-_RECIPE_ACTIONS = {"lingbot_act", "move_to", "rotate_wrist", "set_gripper", "release"}

--- a/rpent/dashboard/planner_control.py
+++ b/rpent/dashboard/planner_control.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from typing import Any
 
 from rpent.dashboard.interaction import DashboardInteractionPort
+from rpent.planner.base import cancel_and_wait
 
 
 class DashboardPlannerControl:
@@ -31,17 +32,20 @@ class DashboardPlannerControl:
         *,
         interaction: DashboardInteractionPort,
         cancel_active_and_wait: Callable[[], None],
+        resume_calls: Callable[[], None],
         emit_user: Callable[[str], None],
         emit_initial_user: Callable[[], None],
         defer_message_ack: bool = False,
     ) -> None:
         self._interaction = interaction
         self._cancel_active_and_wait = cancel_active_and_wait
+        self._resume_calls = resume_calls
         self._emit_user = emit_user
         self._emit_initial_user = emit_initial_user
         self._defer_message_ack = defer_message_ack
         self._lock = asyncio.Lock()
         self._outstanding_completions = 0
+        self._interrupting = False
 
     async def start(self) -> None:
         """Open Dashboard input after the initial backend submission succeeds."""
@@ -64,6 +68,9 @@ class DashboardPlannerControl:
 
     async def complete(self, driver: Any) -> None:
         """Record one completed backend request and flush queued input."""
+        if self._interrupting:
+            self._outstanding_completions = max(0, self._outstanding_completions - 1)
+            return
         async with self._lock:
             if self._interaction.planner_activity == "ended":
                 return
@@ -75,6 +82,8 @@ class DashboardPlannerControl:
 
     async def tool_completed(self, driver: Any) -> None:
         """Flush input queued while the backend was running a tool."""
+        if self._interrupting:
+            return
         async with self._lock:
             await self._flush(driver)
 
@@ -94,7 +103,17 @@ class DashboardPlannerControl:
 
     async def cancel_active_toolkit(self) -> None:
         """Cancel and drain the active toolkit operation off the event loop."""
-        await asyncio.to_thread(self._cancel_active_and_wait)
+        await cancel_and_wait(self._cancel_active_and_wait)
+
+    async def _interrupt_driver(self, driver: Any) -> int:
+        # SDK result events must drain while _process holds the input lock.
+        # They must not wait on that lock or flush new input during cancellation.
+        self._interrupting = True
+        try:
+            await self.cancel_active_toolkit()
+            return await driver.interrupt()
+        finally:
+            self._interrupting = False
 
     async def _process(self, driver: Any) -> None:
         async with self._lock:
@@ -102,8 +121,7 @@ class DashboardPlannerControl:
                 return
             if self._interaction.task_replacement_requested:
                 try:
-                    await self.cancel_active_toolkit()
-                    await driver.interrupt()
+                    await self._interrupt_driver(driver)
                 except Exception as exc:
                     self._interaction.complete_task_replacement(
                         error=f"planner interrupt failed: {_exception_text(exc)}"
@@ -113,8 +131,10 @@ class DashboardPlannerControl:
                 return
             if self._interaction.claim_interrupt_request():
                 try:
-                    await self.cancel_active_toolkit()
-                    completed = await driver.interrupt()
+                    completed = await self._interrupt_driver(driver)
+                    if self._interaction.planner_activity == "ended":
+                        return
+                    self._resume_calls()
                     self._outstanding_completions = max(
                         0, self._outstanding_completions - completed
                     )

--- a/rpent/planner/api_loop.py
+++ b/rpent/planner/api_loop.py
@@ -57,6 +57,7 @@ from rpent.dashboard.planner_control import DashboardPlannerControl
 from rpent.planner.base import (
     REASONING_EFFORTS,
     PlannerResult,
+    cancel_and_wait,
     execute_tool,
 )
 from rpent.tools.toolkit import Toolkit
@@ -277,6 +278,14 @@ class ApiAgentLoop:
             last_error = _api_error_text(e, no_images=self._no_images)
             logger.error("agent run failed: %s", last_error)
 
+        finally:
+            try:
+                await cancel_and_wait(toolkit.cancel_active_and_wait)
+            except Exception as exc:
+                logger.exception("API toolkit cleanup failed")
+                last_error = last_error or f"Toolkit cleanup failed: {exc}"
+            messages.append({"role": "toolkit", "finish": toolkit.finish_result})
+
         return PlannerResult(
             finish_result=observer.finish_result,
             messages=messages,
@@ -311,6 +320,7 @@ class ApiAgentLoop:
         control = DashboardPlannerControl(
             interaction=interaction,
             cancel_active_and_wait=toolkit.cancel_active_and_wait,
+            resume_calls=toolkit.resume_calls,
             emit_user=emit_user,
             emit_initial_user=lambda: emit_user(user_message, initial=True),
             defer_message_ack=True,
@@ -738,7 +748,6 @@ def _build_tools(toolkit: Toolkit, *, no_images: bool = False) -> list[Tool]:
             ),
             json_schema=tool.input_schema,
             takes_ctx=False,
-            sequential=True,
         )
         for tool in tools
     ]

--- a/rpent/planner/base.py
+++ b/rpent/planner/base.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import asyncio
 import os
 import queue
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Protocol
 
@@ -48,9 +50,25 @@ def strip_mcp_prefix(name: str) -> str:
     return name.removeprefix(MCP_TOOL_PREFIX)
 
 
+async def cancel_and_wait(cancel: Callable[[], None]) -> None:
+    """Keep cancellation independent of a tool pool full of waiting calls."""
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="tool-control") as pool:
+        await asyncio.get_running_loop().run_in_executor(pool, cancel)
+
+
 async def execute_tool(toolkit: Toolkit, name: str, arguments: dict) -> ToolResult:
-    """Dispatch native tool execution off the event loop."""
-    return await asyncio.to_thread(toolkit.execute_tool, name, arguments)
+    """Retain the worker through cancellation, including queued executor jobs."""
+    worker = asyncio.create_task(
+        asyncio.to_thread(toolkit.execute_tool, name, arguments)
+    )
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        await cancel_and_wait(toolkit.cancel_active_and_wait)
+        # Jobs still in the executor queue must observe paused admission before
+        # the adapter can resume the next turn.
+        await asyncio.shield(worker)
+        raise
 
 
 class PlannerResult:

--- a/rpent/planner/claude_code.py
+++ b/rpent/planner/claude_code.py
@@ -47,6 +47,7 @@ from rpent.planner.base import (
     REASONING_EFFORTS,
     PlannerResult,
     add_mcp_prefix,
+    cancel_and_wait,
     strip_mcp_prefix,
 )
 from rpent.planner.utils.http_mcp_server import build_mcp_server, list_mcp_tools
@@ -230,13 +231,14 @@ class ClaudeCodePlanner:
                         options,
                         recorder,
                         input_queue,
+                        toolkit=toolkit,
                         emit=_emit,
                         emit_user=_emit_user,
                     )
             except asyncio.TimeoutError:
                 error = f"Claude Agent SDK timed out after {self._timeout_s}s"
                 try:
-                    await asyncio.to_thread(toolkit.cancel_active_and_wait)
+                    await cancel_and_wait(toolkit.cancel_active_and_wait)
                 except Exception as cancel_error:
                     logger.warning(
                         "failed to cancel toolkit work after Claude timeout: %s",
@@ -256,6 +258,16 @@ class ClaudeCodePlanner:
                 out_f.flush()
                 _write_jsonl(raw_f, {"type": "error", "message": error})
                 logger.info(rendered.rstrip())
+
+            finally:
+                try:
+                    await cancel_and_wait(toolkit.cancel_active_and_wait)
+                except Exception as exc:
+                    logger.exception("Claude toolkit cleanup failed")
+                    error = error or f"Toolkit cleanup failed: {exc}"
+                _write_jsonl(
+                    raw_f, {"type": "toolkit_finish", "finish": toolkit.finish_result}
+                )
 
         elapsed = time.time() - started
         text = "".join(rendered_chunks) or output_path.read_text(errors="replace")
@@ -287,6 +299,7 @@ class ClaudeCodePlanner:
         recorder: "_Recorder",
         input_queue,
         *,
+        toolkit: Toolkit,
         emit,
         emit_user,
     ) -> None:
@@ -298,7 +311,9 @@ class ClaudeCodePlanner:
         sentinel (or ``/quit``) interrupts the run; the ``finish`` tool ends it
         normally. Because a human supervises, there is no wall-clock cap here.
         """
-        adapter = _TerminalSessionAdapter(input_queue=input_queue, emit_user=emit_user)
+        adapter = _TerminalSessionAdapter(
+            toolkit=toolkit, input_queue=input_queue, emit_user=emit_user
+        )
         driver = _ClaudeSessionDriver(
             sdk=sdk,
             options=options,
@@ -324,6 +339,7 @@ class ClaudeCodePlanner:
         adapter = _ClaudeDashboardAdapter(
             interaction=dashboard_interaction,
             cancel_active_and_wait=toolkit.cancel_active_and_wait,
+            resume_calls=toolkit.resume_calls,
             emit_user=emit_user,
             emit_initial_user=lambda: emit_user(
                 initial_user_text,
@@ -392,6 +408,10 @@ class _ClaudeSessionDriver:
         self._recorder = recorder
         self._emit = emit
         self._client: Any | None = None
+        self._pending_results = 0
+        self._turns_drained = asyncio.Event()
+        self._turns_drained.set()
+        self._interrupting = False
 
     async def run(self, prompt: str, adapter: Any) -> None:
         """Open one client, submit the first query, and run one input adapter."""
@@ -430,7 +450,15 @@ class _ClaudeSessionDriver:
         """Submit one user turn to the owned client."""
         if self._client is None:
             raise RuntimeError("Claude session is not connected")
-        await self._client.query(text)
+        self._pending_results += 1
+        self._turns_drained.clear()
+        try:
+            await self._client.query(text)
+        except BaseException:
+            self._pending_results -= 1
+            if not self._pending_results:
+                self._turns_drained.set()
+            raise
 
     async def submit(self, text: str) -> int:
         """Submit Dashboard input as a new Claude query."""
@@ -441,34 +469,54 @@ class _ClaudeSessionDriver:
         """Interrupt the owned client and suppress its expected error result."""
         if self._client is None:
             raise RuntimeError("Claude session is not connected")
+        interrupted = self._pending_results
+        if not interrupted:
+            return 0
+        self._interrupting = True
         self._recorder.suppress_next_result_error = True
         try:
             await self._client.interrupt()
+            # The SDK acknowledgement alone does not close old tool requests.
+            # The consumer signals before calling control hooks (which may be
+            # waiting for this interrupt to release the Dashboard lock).
+            await asyncio.wait_for(self._turns_drained.wait(), timeout=15)
         except BaseException:
-            # A failed interrupt must not hide a later unrelated SDK error.
             self._recorder.suppress_next_result_error = False
             raise
-        # Claude emits a ResultMessage for the interrupted query, so the
-        # matching completion is accounted for by the normal message path.
-        return 0
+        finally:
+            self._interrupting = False
+        return interrupted
 
     async def _consume(self, adapter: Any) -> None:
         if self._client is None:
             raise RuntimeError("Claude session is not connected")
         async for message in self._client.receive_messages():
             self._emit(message)
+            if _kind(message) == "ResultMessage":
+                self._pending_results = max(0, self._pending_results - 1)
+                if not self._pending_results:
+                    self._turns_drained.set()
             # A successful finish tool result owns the boundary: end the
             # session without giving queued Dashboard input a chance to flush.
             if self._recorder.finish_result is not None:
                 logger.info("FINISH called: %s", self._recorder.finish_result)
                 return
+            if self._interrupting:
+                continue
             await adapter.on_message(self, message)
 
 
 class _TerminalSessionAdapter:
     """Preserve the terminal TUI's interrupt-then-query steering policy."""
 
-    def __init__(self, *, input_queue: Any, emit_user) -> None:
+    def __init__(
+        self,
+        *,
+        toolkit: Toolkit,
+        input_queue: queue.Queue[str | None],
+        emit_user: Callable[[str], None],
+    ) -> None:
+        self._toolkit = toolkit
         self._input_queue = input_queue
         self._emit_user = emit_user
 
@@ -477,18 +525,14 @@ class _TerminalSessionAdapter:
 
     async def run(self, driver: _ClaudeSessionDriver) -> None:
         while True:
-            nxt = await asyncio.to_thread(next_user_line, self._input_queue)
-            if nxt is None:
-                with contextlib.suppress(Exception):
-                    await driver.interrupt()
+            user_text = await asyncio.to_thread(next_user_line, self._input_queue)
+            await cancel_and_wait(self._toolkit.cancel_active_and_wait)
+            await driver.interrupt()
+            if user_text is None or self._toolkit.finish_result is not None:
                 return
-            self._emit_user(nxt)
-            # Keep the current terminal semantics: every steering line
-            # interrupts the in-flight turn, then enters the same session.
-            with contextlib.suppress(Exception):
-                await driver.interrupt()
-            with contextlib.suppress(Exception):
-                await driver.query(nxt)
+            self._toolkit.resume_calls()
+            self._emit_user(user_text)
+            await driver.query(user_text)
 
     async def on_message(
         self,
@@ -510,12 +554,14 @@ class _ClaudeDashboardAdapter:
         *,
         interaction: DashboardInteractionPort,
         cancel_active_and_wait: Callable[[], None],
+        resume_calls: Callable[[], None],
         emit_user: Callable[[str], None],
         emit_initial_user: Callable[[], None],
     ) -> None:
         self._control = DashboardPlannerControl(
             interaction=interaction,
             cancel_active_and_wait=cancel_active_and_wait,
+            resume_calls=resume_calls,
             emit_user=emit_user,
             emit_initial_user=emit_initial_user,
         )

--- a/rpent/planner/codex.py
+++ b/rpent/planner/codex.py
@@ -51,6 +51,7 @@ from rpent.dashboard.planner_control import DashboardPlannerControl
 from rpent.planner.base import (
     REASONING_EFFORTS,
     PlannerResult,
+    cancel_and_wait,
     strip_mcp_prefix,
 )
 from rpent.planner.utils.http_mcp_server import HttpMcpServer
@@ -220,7 +221,13 @@ class CodexPlanner:
                     _write_jsonl(raw_f, {"type": "error", "message": error})
                 logger.info(rendered.rstrip())
         finally:
-            mcp_server.stop()
+            try:
+                toolkit.cancel_active_and_wait()
+            except Exception as exc:
+                logger.exception("Codex toolkit cleanup failed")
+                error = error or f"Toolkit cleanup failed: {exc}"
+            finally:
+                mcp_server.stop()
 
         elapsed = time.time() - started
         text = state.get("text", "") or output_path.read_text(errors="replace")
@@ -300,6 +307,7 @@ class CodexPlanner:
                                 if stop_steer.is_set():
                                     return
                                 if nxt is None:
+                                    recorder.toolkit.cancel_active_and_wait()
                                     try:
                                         turn.interrupt()
                                     except Exception:
@@ -417,6 +425,7 @@ class CodexPlanner:
                 control = DashboardPlannerControl(
                     interaction=interaction,
                     cancel_active_and_wait=toolkit.cancel_active_and_wait,
+                    resume_calls=toolkit.resume_calls,
                     emit_user=emit_user,
                     emit_initial_user=lambda: emit_user(
                         initial_user_text, initial=True
@@ -456,7 +465,13 @@ class CodexPlanner:
                         {"type": "toolkit_finish", "finish": recorder.finish_result},
                     )
         finally:
-            mcp_server.stop()
+            try:
+                await cancel_and_wait(toolkit.cancel_active_and_wait)
+            except Exception as exc:
+                logger.exception("Codex toolkit cleanup failed")
+                error = error or f"Toolkit cleanup failed: {exc}"
+            finally:
+                await asyncio.to_thread(mcp_server.stop)
 
         if recorder.final_response is not None:
             last_message_path.write_text(recorder.final_response)
@@ -557,14 +572,7 @@ class _CodexDashboardSession:
         try:
             await asyncio.wait_for(done.wait(), timeout=15)
         except asyncio.TimeoutError:
-            if self._turn_task is not None:
-                self._turn_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await self._turn_task
-            self._turn = None
-            self._turn_done = None
-            self._turn_task = None
-            return 1
+            raise RuntimeError("Codex did not finish the interrupted turn") from None
         # ``_consume_turn`` reports the matching completed turn boundary.
         return 0
 

--- a/rpent/planner/utils/http_mcp_server.py
+++ b/rpent/planner/utils/http_mcp_server.py
@@ -32,7 +32,6 @@ Usage::
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import socket
 import threading
@@ -88,7 +87,6 @@ def mcp_result(result: ToolResult) -> dict[str, Any]:
 def build_mcp_server(toolkit: Toolkit) -> Server:
     """Build the MCP service shared by Claude and Codex with native validation."""
     mcp_app: Server = Server(SERVER_NAME, version="0.1.0")
-    tool_execution_lock = asyncio.Lock()
     exported_tools = list_mcp_tools(toolkit)
     exported_names = {tool.name for tool in exported_tools}
 
@@ -111,8 +109,7 @@ def build_mcp_server(toolkit: Toolkit) -> Server:
         if lookup not in exported_names:
             result = ToolResult(error=f"Unknown tool: {lookup}")
         else:
-            async with tool_execution_lock:
-                result = await execute_tool(toolkit, lookup, arguments or {})
+            result = await execute_tool(toolkit, lookup, arguments or {})
         return types.CallToolResult(**mcp_result(result))
 
     return mcp_app

--- a/rpent/tools/base.py
+++ b/rpent/tools/base.py
@@ -132,7 +132,7 @@ class ToolContext(Generic[RobotT]):
 class Tool(Generic[ParamsT]):
     """A handler and its generated parameter model, fixed before execution.
 
-    readonly skips automatic observation capture.
+    readonly allows shared execution and skips automatic observation capture.
     """
 
     name: str
@@ -183,7 +183,7 @@ def _parameter_model(
 def readonly(handler: Callable[ParamsT, ToolResult]) -> Callable[ParamsT, ToolResult]:
     """Skip automatic environment observation capture; file writes remain allowed.
 
-    Place this marker below @tool. Calls execute one at a time.
+    Place this marker below @tool. Readonly calls can execute concurrently.
     """
     setattr(handler, "_rpent_readonly", True)
     return handler
@@ -197,7 +197,8 @@ def tool(function: Callable[ParamsT, ToolResult], /) -> Tool[ParamsT]:
     Every handler declares a required keyword-only ctx, injected by the executor
     and excluded from the schema.
     Place @tool above @readonly. By default calls are exclusive; robot tools
-    other than finish capture observations afterward. @readonly disables capture.
+    other than finish capture observations afterward. @readonly allows shared
+    execution and disables capture.
     """
     # Resolve annotations in factories/tests as well as at module scope, without
     # retaining the caller's frame or namespace in the resulting Tool.

--- a/rpent/tools/toolkit.py
+++ b/rpent/tools/toolkit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Native tool execution with one active invocation per toolkit."""
+"""Native tool execution, per-toolkit scheduling, and lifecycle hooks."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Generic
+from typing import Any, Generic, Literal
 
 import numpy as np
 from pydantic import ValidationError
@@ -45,17 +45,97 @@ from rpent.utils.logging import get_logger
 logger = get_logger("tools")
 
 
-@dataclass(slots=True)
-class _ToolOperation:
+@dataclass(eq=False)
+class _Call:
+    """Scheduling state for one call; arguments stay with the executor."""
+
+    tool: Tool
     cancel_event: threading.Event = field(default_factory=threading.Event)
-    done_event: threading.Event = field(default_factory=threading.Event)
+    done: bool = False
+
+
+class _Scheduler:
+    """Run readonly tools together and exclusive tools one at a time.
+
+    Exclusive calls take priority and keep their queue order. Calls stay active
+    through capture; the condition lock only protects scheduling state, never
+    tool execution.
+    """
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._pending: list[_Call] = []
+        self._active_calls: set[_Call] = set()
+        self._state: Literal["open", "paused", "closed"] = "open"
+
+    def acquire(self, tool: Tool) -> _Call:
+        with self._condition:
+            if self._state == "closed":
+                raise RuntimeError("Toolkit is closed.")
+            if self._state == "paused":
+                raise RuntimeError("Tool calls are paused.")
+            call = _Call(tool)
+            self._pending.append(call)
+            try:
+                while True:
+                    if call.cancel_event.is_set():
+                        raise RuntimeError("Tool call cancelled.")
+                    if self._can_start(call):
+                        self._pending.remove(call)
+                        self._active_calls.add(call)
+                        return call
+                    self._condition.wait()
+            except BaseException:
+                if call in self._pending:
+                    self._pending.remove(call)
+                call.done = True
+                self._condition.notify_all()
+                raise
+
+    def _can_start(self, call: _Call) -> bool:
+        first_exclusive = next(
+            (pending for pending in self._pending if not pending.tool.readonly), None
+        )
+
+        if not call.tool.readonly:
+            return not self._active_calls and call is first_exclusive
+
+        return first_exclusive is None and all(
+            active.tool.readonly for active in self._active_calls
+        )
+
+    def release(self, call: _Call) -> None:
+        with self._condition:
+            self._active_calls.remove(call)
+            call.done = True
+            self._condition.notify_all()
+
+    def cancel_and_wait(self, *, close: bool = False) -> None:
+        with self._condition:
+            if close:
+                self._state = "closed"
+            elif self._state != "closed":
+                self._state = "paused"
+            calls = [*self._pending, *self._active_calls]
+            self._pending.clear()
+            for call in calls:
+                call.cancel_event.set()
+            self._condition.notify_all()
+            self._condition.wait_for(lambda: all(call.done for call in calls))
+
+    def resume(self) -> None:
+        with self._condition:
+            if self._active_calls:
+                raise RuntimeError("Wait for call cleanup before resuming.")
+            if self._state == "paused":
+                self._state = "open"
 
 
 class Toolkit(Generic[RobotT]):
     """A fixed tool collection and its execution resources for one planner session.
 
-    Robot tools submit RGB frames through ctx.record_frame(). Robot toolkits
-    save their action clips, episode video, and replay recipes.
+    Robot tools submit RGB frames through ctx.record_frame(). This toolkit owns
+    the frame buffer and saves action clips and the episode video.
     """
 
     def __init__(
@@ -76,9 +156,9 @@ class Toolkit(Generic[RobotT]):
         self._tools: dict[str, Tool] = {
             item.name: item for item in (*COMMON_TOOLS, *tools)
         }
-        self._operation_lock = threading.Lock()
-        self._active_operation: _ToolOperation | None = None
+        self._scheduler = _Scheduler()
         self._finish_result: dict[str, str] | None = None
+        self._recipe_commands: list[dict[str, Any]] = []
         self._frames: list[np.ndarray] = []
 
     @property
@@ -103,7 +183,7 @@ class Toolkit(Generic[RobotT]):
         self._frames.append(np.ascontiguousarray(np.asarray(rgb)))
 
     def execute_tool(self, name: str, arguments: dict) -> ToolResult:
-        """Validate and execute one call, then capture its observation."""
+        """Validate, wait, execute, and capture before releasing the call."""
         tool = self._tools.get(name)
         if tool is None:
             return ToolResult(error=f"Unknown tool: {name}")
@@ -115,14 +195,13 @@ class Toolkit(Generic[RobotT]):
             )
             details = json.dumps({"errors": errors})
             return ToolResult(error=f"Invalid arguments for {name}.\n{details}")
-        with self._operation_lock:
-            if self._active_operation is not None:
-                return ToolResult(error="another tool operation is still active")
-            operation = _ToolOperation()
-            self._active_operation = operation
+        try:
+            call = self._scheduler.acquire(tool)
+        except RuntimeError as exc:
+            return ToolResult(error=str(exc)[:500])
 
         try:
-            if operation.cancel_event.is_set():
+            if call.cancel_event.is_set():
                 return ToolResult(error="Tool call cancelled.")
             ctx = ToolContext(
                 state=self._state,
@@ -130,11 +209,13 @@ class Toolkit(Generic[RobotT]):
                 robot=self._robot,
                 output_dir=self._task_output_dir,
                 record_frame=self.record_frame,
-                _cancel_event=operation.cancel_event,
+                _cancel_event=call.cancel_event,
             )
             capture = (
                 not tool.readonly and tool not in COMMON_TOOLS and name != "finish"
             )
+            if capture and self._dashboard_events.enabled:
+                frame_start = len(self._frames)
             started = time.perf_counter()
             # Read fields directly so nested models reach the handler intact.
             kwargs = {name: getattr(args, name) for name in type(args).model_fields}
@@ -146,6 +227,7 @@ class Toolkit(Generic[RobotT]):
             if capture:
                 elapsed_s = time.perf_counter() - started
                 previous = self._state.latest_record()
+                observation_data = None
                 try:
                     observation_data, observation_images = self._capture_observation(
                         command={"action": tool.name, **args.model_dump()},
@@ -163,6 +245,26 @@ class Toolkit(Generic[RobotT]):
                     result.error = error
                 record = self._state.latest_record()
                 if record is not None and record is not previous:
+                    if self._dashboard_events.enabled:
+                        try:
+                            frames = self._frames[frame_start:]
+                            if frames:
+                                self._state.save(
+                                    f"action_{tool.name}.mp4",
+                                    frames,
+                                    step=record.step_idx,
+                                    fps=20,
+                                )
+                                if observation_data is not None:
+                                    observation_data["artifacts"] = sorted(
+                                        record.artifacts
+                                    )
+                        except Exception as exc:
+                            logger.warning(
+                                "failed to save action clip for step %s: %s",
+                                record.step_idx,
+                                exc,
+                            )
                     try:
                         self._dashboard_events.emit(
                             StepRecordEvent(record=record, env_state=self._state)
@@ -175,6 +277,10 @@ class Toolkit(Generic[RobotT]):
                 self._finish_result = {
                     key: result.data[key] for key in ("status", "summary")
                 }
+            elif tool not in COMMON_TOOLS and not result.is_error:
+                self._recipe_commands.append(
+                    {"action": tool.name, **args.model_dump(mode="json")}
+                )
             # Images are logged by their owning artifact paths, not their bytes.
             logger.info(
                 "Tool %s result: %s",
@@ -187,9 +293,7 @@ class Toolkit(Generic[RobotT]):
             )
             return result
         finally:
-            with self._operation_lock:
-                self._active_operation = None
-                operation.done_event.set()
+            self._scheduler.release(call)
 
     def _capture_observation(
         self, *, command: dict[str, Any], result: ToolResult, elapsed_s: float
@@ -198,27 +302,43 @@ class Toolkit(Generic[RobotT]):
 
         Returned data replaces the action's data and must include the recorded
         step and its artifact names. Include action details in that data where
-        needed (e.g. log.result). Robot toolkits save action video artifacts.
+        needed (e.g. log.result). The executor adds action videos to the artifacts.
         The executor appends the images and retains the action's error. Raise if
         capture fails; an already saved step is still published to the Dashboard.
         """
         raise NotImplementedError("This toolkit does not capture robot observations.")
 
     def cancel_active_and_wait(self) -> None:
-        """Request cancellation and wait for the active tool to return."""
-        with self._operation_lock:
-            operation = self._active_operation
-            if operation is None:
-                return
-            operation.cancel_event.set()
-        operation.done_event.wait()
+        self._scheduler.cancel_and_wait()
+
+    def resume_calls(self) -> None:
+        self._scheduler.resume()
 
     def close(self) -> None:
-        """Release robot resources at the end of a run. Default: no-op."""
+        """Called once by the runner to drain calls and save the episode video."""
+        self._scheduler.cancel_and_wait(close=True)
+        frames = self._frames
+        self._frames = []
+        try:
+            if frames:
+                self._state.save("episode.mp4", frames, step=None, fps=20)
+        except Exception as exc:
+            logger.warning("failed to save episode video: %s", exc)
 
     def solved(self) -> bool:
         raise NotImplementedError
 
-    def write_recipe(self, recipe_tag: str) -> str | None:
-        """Write a replay recipe for this robot, if supported."""
-        return None
+    def write_recipe(self, recipe_tag: str) -> str:
+        """Export successful robot action and perception calls in completion order.
+
+        Keep the full session, including resets. File tools and finish are
+        excluded. The caller decides whether the task qualifies for publication.
+        """
+        name = f"{recipe_tag}_recipe.jsonl"
+        path = self._task_output_dir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "".join(json.dumps(command) + "\n" for command in self._recipe_commands),
+            encoding="utf-8",
+        )
+        return name

--- a/tests/unit_tests/robots/dual_franka/test_dual_franka_tools.py
+++ b/tests/unit_tests/robots/dual_franka/test_dual_franka_tools.py
@@ -322,6 +322,11 @@ def test_toolkit_factory_validation_capture_and_cancellation(tmp_path, monkeypat
     assert read.data == result.data and read.images == result.images
     assert len(events) == 2
     toolkit.cancel_active_and_wait()
+    assert toolkit.execute_tool(
+        "move_delta", {"arm": "left", "delta_xyz": [0, 0, 0]}
+    ).is_error
+    assert len(env.moves) == 1
+    toolkit.resume_calls()
     assert not toolkit.execute_tool("view_env_state", {}).is_error
     assert "finish" not in {tool.name for tool in toolkit.list_tools()}
     assert toolkit.finish_result is None

--- a/tests/unit_tests/robots/franka/test_tools.py
+++ b/tests/unit_tests/robots/franka/test_tools.py
@@ -221,6 +221,9 @@ def test_toolkit_factory_validation_capture_and_cancellation(tmp_path, monkeypat
     assert read.data == result.data and read.images == result.images
     assert len(events) == 2
     toolkit.cancel_active_and_wait()
+    assert toolkit.execute_tool("move_delta", {"delta_xyz": [0, 0, 0]}).is_error
+    assert len(env.moves) == 1
+    toolkit.resume_calls()
     assert not toolkit.execute_tool("view_env_state", {}).is_error
     assert "finish" not in {tool.name for tool in toolkit.list_tools()}
     assert toolkit.finish_result is None

--- a/tests/unit_tests/robots/libero/conftest.py
+++ b/tests/unit_tests/robots/libero/conftest.py
@@ -135,4 +135,5 @@ def make_toolkit(tmp_path):
     for toolkit in instances:
         # Avoid video encoding in CPU contract tests; recording contents are asserted explicitly.
         toolkit._frames.clear()
-        toolkit.close()
+        if toolkit._scheduler._state != "closed":
+            toolkit.close()

--- a/tests/unit_tests/robots/libero/test_libero_integration.py
+++ b/tests/unit_tests/robots/libero/test_libero_integration.py
@@ -183,12 +183,15 @@ def test_close_handles_collection_and_video_independently(
         )
     toolkit._robot = SimpleNamespace(finalize_flywheel=finalize)
     toolkit._frames = frames
+    toolkit._scheduler = Mock()
     toolkit._state = SimpleNamespace(save=save)
     logger = Mock()
     monkeypatch.setattr(libero_toolkit, "logger", logger)
+    monkeypatch.setattr("rpent.tools.toolkit.logger", logger)
 
     toolkit.close()
 
+    toolkit._scheduler.cancel_and_wait.assert_called_once_with(close=True)
     finalize.assert_called_once_with()
     save.assert_called_once_with("episode.mp4", frames, step=None, fps=20)
     if failure == "finalize":

--- a/tests/unit_tests/robots/libero/test_libero_toolkit_contracts.py
+++ b/tests/unit_tests/robots/libero/test_libero_toolkit_contracts.py
@@ -163,7 +163,8 @@ def test_cancellation_preserves_partial_execution_capture_and_resume(
         assert stepped.wait(3)
         cancellation = pool.submit(toolkit.cancel_active_and_wait)
         # Confirm cancellation was delivered before allowing another action boundary.
-        assert toolkit._active_operation.cancel_event.wait(3)
+        for call in list(toolkit._scheduler._active_calls):
+            assert call.cancel_event.wait(3)
         release_step.set()
         result = action.result(3)
         cancellation.result(3)
@@ -172,6 +173,7 @@ def test_cancellation_preserves_partial_execution_capture_and_resume(
     assert len(toolkit._frames) == completed
     assert toolkit.state.latest_record().result == {"error": result.error}
     assert result.data["step"] == 1
+    toolkit.resume_calls()
     env.after_step = lambda: None
     assert not toolkit.execute_tool("set_gripper", {"steps": 1}).is_error
     assert len(env.actions) == completed + 1

--- a/tests/unit_tests/robots/libero/test_recipe.py
+++ b/tests/unit_tests/robots/libero/test_recipe.py
@@ -15,36 +15,80 @@
 import json
 
 
-def test_recipe_exports_only_the_successful_attempt_after_reset(make_toolkit):
-    toolkit, env, _ = make_toolkit(mode="exploration", attempts=2)
-    assert not toolkit.execute_tool("set_gripper", {"steps": 1}).is_error
-    assert toolkit.write_recipe("unsolved") == ""
-    assert not toolkit.execute_tool("reset", {"reason": "try again"}).is_error
-    env.terminated = True
-    assert not toolkit.execute_tool("set_gripper", {"steps": 2}).is_error
-
+def export(toolkit):
     name = toolkit.write_recipe("cell")
     assert name == "cell_recipe.jsonl"
-    recipe = toolkit._task_output_dir / name
-    assert [json.loads(line) for line in recipe.read_text().splitlines()] == [
-        {"action": "set_gripper", "gripper": -1.0, "steps": 2}
+    return [
+        json.loads(line)
+        for line in (toolkit._task_output_dir / name).read_text().splitlines()
     ]
 
 
-def test_recipe_excludes_failed_actions_in_a_successful_attempt(
+def test_common_files_finish_validation_and_execution_errors_are_excluded(
     make_toolkit, monkeypatch
 ):
     toolkit, env, _ = make_toolkit()
+    path = str(toolkit._task_output_dir / "note.txt")
+    for name, arguments in [
+        ("write_text_file", {"path": path, "content": "note"}),
+        ("read_text_file", {"path": path}),
+        ("list_dir", {}),
+        ("read_image", {"name": "agentview_policy.png", "step": 0}),
+    ]:
+        assert not toolkit.execute_tool(name, arguments).is_error
+    for name, arguments in [
+        ("unknown", {}),
+        ("set_gripper", {"steps": "invalid"}),
+        ("segment", {}),
+    ]:
+        assert toolkit.execute_tool(name, arguments).is_error
 
     def fail(action):
-        raise RuntimeError("action failed")
+        raise RuntimeError()
 
     with monkeypatch.context() as patch:
         patch.setattr(env, "step", fail)
-        assert toolkit.execute_tool("set_gripper", {"steps": 1}).is_error
-    env.terminated = True
-    assert not toolkit.execute_tool("set_gripper", {"steps": 2}).is_error
-    recipe = toolkit._task_output_dir / toolkit.write_recipe("cell")
-    assert [json.loads(line)["steps"] for line in recipe.read_text().splitlines()] == [
-        2
+        failed = toolkit.execute_tool("set_gripper", {"steps": 1})
+    assert failed.is_error and failed.error == ""
+    assert not toolkit.execute_tool("set_gripper", {"steps": 1}).is_error
+    assert not toolkit.execute_tool(
+        "finish", {"status": "success", "summary": "done"}
+    ).is_error
+    assert [call["action"] for call in export(toolkit)] == ["set_gripper"]
+
+
+def test_reset_is_kept_with_both_attempts_and_refused_finish_is_excluded(make_toolkit):
+    toolkit, _, _ = make_toolkit(mode="exploration", attempts=2)
+    assert toolkit.execute_tool(
+        "finish", {"status": "stuck", "summary": "first"}
+    ).is_error
+    for name, arguments in [
+        ("segment", {"prompt": "bowl"}),
+        ("set_gripper", {"steps": 1}),
+        ("reset", {"reason": "try again"}),
+        ("view_env_state", {}),
+        ("segment", {"prompt": "lid"}),
+        ("set_gripper", {"steps": 1}),
+    ]:
+        result = toolkit.execute_tool(name, arguments)
+        assert not result.is_error, result.error
+    recipe = export(toolkit)
+    assert recipe[1] == {"action": "set_gripper", "gripper": -1.0, "steps": 1}
+    assert [call["action"] for call in recipe] == [
+        "segment",
+        "set_gripper",
+        "reset",
+        "view_env_state",
+        "segment",
+        "set_gripper",
     ]
+
+
+def test_recipe_does_not_infer_tool_errors_from_environment_success(make_toolkit):
+    toolkit, env, _ = make_toolkit()
+    result = toolkit.execute_tool(
+        "pi0_doubled", {"prompt": "touch bowl", "max_chunks": 1}
+    )
+    assert not result.is_error and result.data["log"]["result"]["success"] is False
+    assert not env.terminated
+    assert [call["action"] for call in export(toolkit)] == ["pi0_doubled"]

--- a/tests/unit_tests/robots/libero/test_recording.py
+++ b/tests/unit_tests/robots/libero/test_recording.py
@@ -105,7 +105,8 @@ def test_capture_failure_never_mixes_action_frames(
             patch.setattr(env, "raw_obs", fail)
         failed = toolkit.execute_tool("set_gripper", {"steps": 2})
     assert failed.is_error and "State capture failed:" in failed.error
-    assert toolkit.write_recipe("failed") == ""
+    recipe = toolkit._task_output_dir / toolkit.write_recipe("failed")
+    assert recipe.read_text() == ""
     assert "step" not in failed.data
     if record_saved:
         assert saved == [("action_set_gripper.mp4", 1, [1, 1])]

--- a/tests/unit_tests/robots/robocasa/conftest.py
+++ b/tests/unit_tests/robots/robocasa/conftest.py
@@ -196,4 +196,5 @@ def make_toolkit(monkeypatch, tmp_path):
     yield make
     for run in runs:
         run.toolkit._frames.clear()
-        run.toolkit.close()
+        if run.toolkit._scheduler._state != "closed":
+            run.toolkit.close()

--- a/tests/unit_tests/robots/robocasa/test_robocasa_toolkit_contracts.py
+++ b/tests/unit_tests/robots/robocasa/test_robocasa_toolkit_contracts.py
@@ -157,7 +157,11 @@ def test_cancellation_stops_remaining_steps_and_uses_fresh_call_signal(
         assert entered.wait(5)
         # Request cancellation while the first step is in progress.
         stop = pool.submit(run.toolkit.cancel_active_and_wait)
-        assert run.toolkit._active_operation.cancel_event.wait(5)
+        # Wait for the scheduler to signal cancellation before releasing the step.
+        with run.toolkit._scheduler._condition:
+            assert run.toolkit._scheduler._condition.wait_for(
+                lambda: run.toolkit._scheduler._state == "paused", timeout=5
+            )
         resume.set()
         result = action.result(timeout=5)
         stop.result(timeout=5)
@@ -166,6 +170,7 @@ def test_cancellation_stops_remaining_steps_and_uses_fresh_call_signal(
     assert len(run.env.actions) == len(run.toolkit._frames) == 1
     assert result.data["task_progress"]["steps"] == 1
     run.env.on_step = lambda: None
+    run.toolkit.resume_calls()
     assert not run.toolkit.execute_tool("release", {"steps": 1}).is_error
     assert len(run.env.actions) == len(run.toolkit._frames) == 2
 

--- a/tests/unit_tests/robots/robotwin/conftest.py
+++ b/tests/unit_tests/robots/robotwin/conftest.py
@@ -155,4 +155,5 @@ def robotwin(tmp_path):
         env=env, model=model, toolkit=toolkit, output_dir=tmp_path / "run"
     )
     toolkit._frames.clear()
-    toolkit.close()
+    if toolkit._scheduler._state != "closed":
+        toolkit.close()

--- a/tests/unit_tests/rpent/dashboard/test_planner_control_contracts.py
+++ b/tests/unit_tests/rpent/dashboard/test_planner_control_contracts.py
@@ -222,6 +222,7 @@ def make_control(
     return DashboardPlannerControl(
         interaction=interaction,
         cancel_active_and_wait=cancel_active_and_wait,
+        resume_calls=lambda: events.append("toolkit-resume"),
         emit_user=lambda text: events.append(f"user:{text}"),
         emit_initial_user=lambda: events.append("initial-user"),
         defer_message_ack=defer_message_ack,
@@ -346,6 +347,7 @@ def test_interrupt_cancels_toolkit_before_backend_and_then_flushes() -> None:
     assert events[:2] == ["initial-user", "toolkit-cancel"]
     assert events[2:] == [
         "backend-interrupt",
+        "toolkit-resume",
         "submit:continue after interrupt",
         "user:continue after interrupt",
     ]
@@ -425,3 +427,31 @@ def test_end_seals_pending_messages_as_unsent() -> None:
 
     assert interaction.activity == "ended"
     assert interaction.messages[0].status == "unsent"
+
+
+def test_interrupt_allows_sdk_result_events_to_drain_without_flushing_input() -> None:
+    interaction = FakeInteraction()
+    interaction.submit("after", "new turn")
+    interaction.end_on_wait = True
+    events: list[str] = []
+    control = make_control(interaction, events)
+    driver = FakeDriver(events)
+
+    async def interrupt() -> int:
+        events.append("backend-interrupt")
+        await control.tool_completed(driver)
+        await control.complete(driver)
+        events.append("backend-drained")
+        assert not any(event.startswith("submit:") for event in events)
+        return 0
+
+    driver.interrupt = interrupt
+
+    async def scenario() -> None:
+        await control.start()
+        interaction.interrupt_requested = True
+        await asyncio.wait_for(control.run(driver), timeout=2)
+
+    asyncio.run(scenario())
+    assert events.index("backend-drained") < events.index("toolkit-resume")
+    assert events.index("toolkit-resume") < events.index("submit:new turn")

--- a/tests/unit_tests/rpent/planner/conftest.py
+++ b/tests/unit_tests/rpent/planner/conftest.py
@@ -28,4 +28,5 @@ def make_toolkit(tmp_path):
 
     yield make
     for toolkit in instances:
-        toolkit.close()
+        if toolkit._scheduler._state != "closed":
+            toolkit.close()

--- a/tests/unit_tests/rpent/planner/test_api_contracts.py
+++ b/tests/unit_tests/rpent/planner/test_api_contracts.py
@@ -219,7 +219,7 @@ def test_tool_schema_and_dispatch_are_mapped_to_pydantic_ai(
         *[tool.name for tool in toolkit.list_tools() if tool.name != "read_image"],
     ]
     assert "read_image" in [tool.name for tool in tools]
-    assert all(tool.sequential for tool in tools)
+    assert all(not tool.sequential for tool in tools)
     finish = next(tool for tool in tools if tool.name == "finish")
     assert finish.function_schema.json_schema == next(
         tool.input_schema for tool in toolkit.list_tools() if tool.name == "finish"

--- a/tests/unit_tests/rpent/planner/test_execution_lifecycle.py
+++ b/tests/unit_tests/rpent/planner/test_execution_lifecycle.py
@@ -1,0 +1,138 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from rpent.memory import MemoryManager
+from rpent.planner.base import execute_tool
+from rpent.session import EnvState
+from rpent.tools import ToolContext, Toolkit, ToolResult, readonly, tool
+
+
+@tool
+def finish(status: str, summary: str, *, ctx: ToolContext) -> ToolResult:
+    """Accept the requested outcome for this test toolkit."""
+    return ToolResult(data={"_finish": True, "status": status, "summary": summary})
+
+
+@tool
+@readonly
+def moving(*, ctx: ToolContext) -> ToolResult:
+    """Wait at a cooperative cancellation boundary."""
+    ctx.robot.entered()
+    assert ctx._cancel_event.wait(3)
+    ctx.check_cancelled()
+    raise AssertionError("cancelled handler continued")
+
+
+def test_cancel_drains_jobs_even_when_default_tool_pool_is_full(tmp_path):
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        entered = asyncio.Event()
+        queued = asyncio.Event()
+
+        class ObservedExecutor(ThreadPoolExecutor):
+            submissions = 0
+
+            def submit(self, *args, **kwargs):
+                future = super().submit(*args, **kwargs)
+                self.submissions += 1
+                if self.submissions == 2:
+                    queued.set()
+                return future
+
+        loop.set_default_executor(ObservedExecutor(max_workers=1))
+        toolkit = Toolkit(
+            state=EnvState(tmp_path),
+            memory=MemoryManager(tmp_path / "memory"),
+            robot=SimpleNamespace(
+                entered=lambda: loop.call_soon_threadsafe(entered.set)
+            ),
+            output_dir=tmp_path,
+            tools=(finish, moving),
+        )
+        try:
+            active = asyncio.create_task(execute_tool(toolkit, "moving", {}))
+            await asyncio.wait_for(entered.wait(), timeout=3)
+            pending = asyncio.create_task(execute_tool(toolkit, "moving", {}))
+            await asyncio.wait_for(queued.wait(), timeout=3)
+            pending.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(pending, timeout=3)
+            assert (
+                await asyncio.wait_for(active, timeout=3)
+            ).error == "Tool call cancelled."
+            assert (
+                toolkit.execute_tool("list_dir", {}).error == "Tool calls are paused."
+            )
+            toolkit.resume_calls()
+            assert not toolkit.execute_tool("list_dir", {}).is_error
+        finally:
+            toolkit.close()
+
+    asyncio.run(scenario())
+
+
+def test_request_cancellation_waits_for_capture_before_returning(tmp_path):
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        capturing = asyncio.Event()
+        cancelled = asyncio.Event()
+        release = threading.Event()
+
+        @tool
+        def action(*, ctx: ToolContext) -> ToolResult:
+            """Perform an action before its final observation."""
+            return ToolResult()
+
+        class CapturingToolkit(Toolkit):
+            def _capture_observation(self, **kwargs):
+                loop.call_soon_threadsafe(capturing.set)
+                assert release.wait(4)
+                return {"step": 0}, []
+
+            def cancel_active_and_wait(self):
+                loop.call_soon_threadsafe(cancelled.set)
+                super().cancel_active_and_wait()
+
+        toolkit = CapturingToolkit(
+            state=EnvState(tmp_path),
+            memory=MemoryManager(tmp_path / "memory"),
+            robot=None,
+            output_dir=tmp_path,
+            tools=(finish, action),
+        )
+        request = asyncio.create_task(execute_tool(toolkit, "action", {}))
+        try:
+            await asyncio.wait_for(capturing.wait(), timeout=3)
+            request.cancel()
+            await asyncio.wait_for(cancelled.wait(), timeout=3)
+            assert not request.done()
+            with pytest.raises(RuntimeError, match="cleanup"):
+                toolkit.resume_calls()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(request, timeout=3)
+            toolkit.resume_calls()
+            assert not toolkit.execute_tool("list_dir", {}).is_error
+        finally:
+            release.set()
+            toolkit.close()
+
+    asyncio.run(scenario())

--- a/tests/unit_tests/rpent/planner/test_http_mcp_server.py
+++ b/tests/unit_tests/rpent/planner/test_http_mcp_server.py
@@ -37,11 +37,11 @@ def finish(status: str, summary: str, *, ctx: ToolContext) -> ToolResult:
     return ToolResult(data={"_finish": True, "status": status, "summary": summary})
 
 
-def test_http_serialized_calls_keep_native_validation(tmp_path: Path) -> None:
+def test_http_shared_calls_overlap_and_keep_native_validation(tmp_path: Path) -> None:
     toolkit = Toolkit(
         state=EnvState(tmp_path),
         memory=MemoryManager(tmp_path / "memory"),
-        robot=threading.Barrier(1),
+        robot=threading.Barrier(2),
         output_dir=tmp_path,
         tools=(finish, read),
     )

--- a/tests/unit_tests/rpent/planner/test_native_adapters.py
+++ b/tests/unit_tests/rpent/planner/test_native_adapters.py
@@ -16,24 +16,31 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 
 import pytest
 from mcp import types
+from pydantic_ai.messages import ModelResponse, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import FunctionModel
 
 from rpent.dashboard.events import NullDashboardEventSink
+from rpent.memory import MemoryManager
 from rpent.planner.api_loop import (
+    ApiAgentLoop,
     _ApiRunObserver,
     _build_tools,
 )
 from rpent.planner.claude_code import (
     _build_rpent_server,
+    _ClaudeSessionDriver,
 )
 from rpent.planner.claude_code import _Recorder as ClaudeRecorder
 from rpent.planner.codex import _Recorder as CodexRecorder
-from rpent.tools import ToolContext, ToolResult, tool
+from rpent.session import EnvState
+from rpent.tools import ToolContext, Toolkit, ToolResult, tool
 from rpent.tools.base import MAX_TOOL_TEXT_BYTES
 
-from ._native_helpers import call_sdk_tool
+from ._native_helpers import call_sdk_tool, read
 
 
 @tool
@@ -94,6 +101,117 @@ def test_recorders_read_verified_finish_without_a_matching_provider_event(
         assert recorder.finish_result == toolkit.finish_result
     finally:
         toolkit.close()
+
+
+def test_claude_sdk_dispatch_is_parallel(tmp_path):
+    toolkit = Toolkit(
+        state=EnvState(tmp_path),
+        memory=MemoryManager(tmp_path / "memory"),
+        robot=threading.Barrier(2),
+        output_dir=tmp_path,
+        tools=(finish, read),
+    )
+
+    async def scenario():
+        server = _build_rpent_server(toolkit=toolkit)
+        results = await asyncio.gather(
+            call_sdk_tool(server, "read", {"number": "1"}),
+            call_sdk_tool(server, "read", {"number": "2"}),
+        )
+        assert all(not result.isError for result in results)
+        assert [json.loads(result.content[0].text)["number"] for result in results] == [
+            1,
+            2,
+        ]
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        toolkit.close()
+
+
+def test_api_sdk_dispatch_is_parallel_and_accepts_verified_finish(tmp_path):
+    toolkit = Toolkit(
+        state=EnvState(tmp_path),
+        memory=MemoryManager(tmp_path / "memory"),
+        robot=threading.Barrier(2),
+        output_dir=tmp_path,
+        tools=(finish, read),
+    )
+
+    def model(messages, info):
+        returned = [
+            part
+            for message in messages
+            for part in message.parts
+            if isinstance(part, ToolReturnPart)
+        ]
+        if not returned:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart("read", {"number": "1"}, "r1"),
+                    ToolCallPart("read", {"number": 2}, "r2"),
+                ]
+            )
+        assert all("error" not in json.loads(part.content) for part in returned)
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "finish", {"status": "failure", "summary": "complete"}, "f"
+                )
+            ]
+        )
+
+    result = ApiAgentLoop(
+        FunctionModel(model), dashboard_events=NullDashboardEventSink()
+    ).solve(system_prompt="", user_message="read", toolkit=toolkit, max_turns=3)
+    assert result.error is None
+    assert result.finish_result == {"status": "failure", "summary": "complete"}
+    assert result.stats["tool_calls"] == 3
+
+
+def test_claude_interrupt_waits_for_result_message_before_resuming(
+    make_toolkit,
+):
+    async def scenario():
+        toolkit = make_toolkit()
+        recorder = ClaudeRecorder(
+            toolkit=toolkit, max_turns=3, dashboard_events=NullDashboardEventSink()
+        )
+        driver = _ClaudeSessionDriver(
+            sdk=None, options=None, recorder=recorder, emit=recorder.observe
+        )
+        messages = asyncio.Queue()
+        acknowledgement = asyncio.Event()
+
+        class Client:
+            async def query(self, text):
+                pass
+
+            async def interrupt(self):
+                acknowledgement.set()
+
+            async def receive_messages(self):
+                while (message := await messages.get()) is not None:
+                    yield message
+
+        class Adapter:
+            async def on_message(self, driver, message):
+                raise AssertionError("old SDK completion must not flush new input")
+
+        driver._client = Client()
+        await driver.query("old turn")
+        consumer = asyncio.create_task(driver._consume(Adapter()))
+        interrupted = asyncio.create_task(driver.interrupt())
+        await acknowledgement.wait()
+        assert not interrupted.done()
+        await messages.put({"type": "ResultMessage", "is_error": True})
+        assert await asyncio.wait_for(interrupted, timeout=2) == 1
+        assert recorder.error is None
+        await messages.put(None)
+        await consumer
+
+    asyncio.run(scenario())
 
 
 def test_api_finish_accepted_during_interrupt_seals_dashboard():

--- a/tests/unit_tests/rpent/tools/test_common_tools.py
+++ b/tests/unit_tests/rpent/tools/test_common_tools.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 
 import numpy as np
 import pytest
@@ -41,13 +43,30 @@ def toolkit(tmp_path, monkeypatch):
     instance.close()
 
 
-def test_read_text_file_and_list_dir_use_native_results(toolkit, tmp_path):
-    (tmp_path / "note.txt").write_text("tool reads", encoding="utf-8")
-    text_result = toolkit.execute_tool("read_text_file", {"path": "note.txt"})
-    directory_result = toolkit.execute_tool("list_dir", {})
+def test_read_text_file_and_list_dir_execute_in_parallel(
+    toolkit, tmp_path, monkeypatch
+):
+    (tmp_path / "note.txt").write_text("parallel reads", encoding="utf-8")
+    both_reading = Barrier(2)
+    authorize_read = toolkit.memory.authorize_read
+
+    def synchronize_reads(path):
+        resolved = authorize_read(path)
+        # Both handlers must enter before either can complete. A serial
+        # executor breaks the barrier and returns tool errors.
+        both_reading.wait(timeout=3)
+        return resolved
+
+    monkeypatch.setattr(toolkit.memory, "authorize_read", synchronize_reads)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        text = pool.submit(toolkit.execute_tool, "read_text_file", {"path": "note.txt"})
+        directory = pool.submit(toolkit.execute_tool, "list_dir", {})
+        text_result = text.result(timeout=5)
+        directory_result = directory.result(timeout=5)
+
     assert not text_result.is_error
     assert not directory_result.is_error
-    assert text_result.data["content"] == "tool reads"
+    assert text_result.data["content"] == "parallel reads"
     assert "note.txt" in directory_result.data["files"]
 
 

--- a/tests/unit_tests/rpent/tools/test_recipe.py
+++ b/tests/unit_tests/rpent/tools/test_recipe.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+from rpent.memory import MemoryManager
+from rpent.session import EnvState
+from rpent.tools import Toolkit, ToolResult, readonly, tool
+
+
+def export(toolkit):
+    path = toolkit._task_output_dir / toolkit.write_recipe("cell")
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+@tool
+@readonly
+def sense(label: str, *, ctx) -> ToolResult:
+    """Read a sensor."""
+    if label == "slow":
+        ctx.robot.started.set()
+        assert ctx.robot.release.wait(5)
+    return ToolResult(data={"label": label})
+
+
+@tool
+def finish(status: str, summary: str, *, ctx) -> ToolResult:
+    """Finish this session."""
+    return ToolResult(data={"status": status, "summary": summary})
+
+
+def test_generic_parallel_perception_is_recorded_without_new_state_steps(tmp_path):
+    runtime = SimpleNamespace(started=threading.Event(), release=threading.Event())
+    state = EnvState(tmp_path / "observations")
+    toolkit = Toolkit(
+        state=state,
+        memory=MemoryManager(tmp_path / "memory"),
+        robot=runtime,
+        output_dir=tmp_path / "recipe",
+        tools=(sense, finish),
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            slow = executor.submit(toolkit.execute_tool, "sense", {"label": "slow"})
+            try:
+                assert runtime.started.wait(5)
+                fast = executor.submit(toolkit.execute_tool, "sense", {"label": "fast"})
+                assert not fast.result(timeout=5).is_error
+            finally:
+                runtime.release.set()
+            assert not slow.result(timeout=5).is_error
+        assert state.records() == []
+        assert export(toolkit) == [
+            {"action": "sense", "label": "fast"},
+            {"action": "sense", "label": "slow"},
+        ]
+    finally:
+        toolkit.close()

--- a/tests/unit_tests/rpent/tools/test_recording.py
+++ b/tests/unit_tests/rpent/tools/test_recording.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import numpy as np
+
+from rpent.memory import MemoryManager
+from rpent.session import EnvState
+from rpent.tools import ToolContext, Toolkit, ToolResult, tool
+
+
+@tool
+def finish(status: str, summary: str, *, ctx: ToolContext) -> ToolResult:
+    """Accept the requested outcome for this test toolkit."""
+    return ToolResult(data={"_finish": True, "status": status, "summary": summary})
+
+
+def common_toolkit(tmp_path):
+    return Toolkit(
+        state=EnvState(tmp_path),
+        memory=MemoryManager(tmp_path / "memory"),
+        robot=object(),
+        output_dir=tmp_path,
+        tools=(finish,),
+    )
+
+
+def values(frames):
+    return [int(frame[0, 0, 0]) for frame in frames]
+
+
+def rgb(value):
+    return np.full((8, 8, 3), value, dtype=np.uint8)[:, ::-1]
+
+
+def test_close_uses_toolkit_frames_and_clears_before_save(tmp_path, monkeypatch):
+    toolkit = common_toolkit(tmp_path)
+    toolkit.record_frame(rgb(1))
+    toolkit.record_frame(rgb(2))
+    saved = []
+
+    def save(name, frames, **kwargs):
+        assert toolkit._frames == []
+        assert all(frame.flags.c_contiguous for frame in frames)
+        saved.append((name, values(frames), kwargs))
+
+    monkeypatch.setattr(toolkit.state, "save", save)
+    toolkit.close()
+    assert saved == [("episode.mp4", [1, 2], {"step": None, "fps": 20})]
+    assert toolkit.execute_tool("list_dir", {}).error == "Toolkit is closed."
+
+
+def test_empty_close_and_save_failure_keep_calls_closed(tmp_path, monkeypatch, caplog):
+    toolkit = common_toolkit(tmp_path)
+    save = Mock(side_effect=OSError("disk unavailable"))
+    monkeypatch.setattr(toolkit.state, "save", save)
+    toolkit.close()
+    save.assert_not_called()
+    toolkit = common_toolkit(tmp_path / "second")
+    monkeypatch.setattr(toolkit.state, "save", save)
+    toolkit.record_frame(rgb(1))
+    toolkit.close()
+    assert toolkit._frames == []
+    assert "failed to save episode video" in caplog.text
+    assert toolkit.execute_tool("list_dir", {}).error == "Toolkit is closed."

--- a/tests/unit_tests/rpent/tools/test_scheduling.py
+++ b/tests/unit_tests/rpent/tools/test_scheduling.py
@@ -12,50 +12,482 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
+"""Deterministic CPU scheduling checks using events and queue registration."""
+
 from concurrent.futures import ThreadPoolExecutor
+from threading import Event, get_ident
+from types import SimpleNamespace
+
+import pytest
 
 from rpent.memory import MemoryManager
 from rpent.session import EnvState
-from rpent.tools import ToolContext, Toolkit, ToolResult, readonly, tool
+from rpent.tools import (
+    ToolContext,
+    Toolkit,
+    ToolResult,
+    readonly,
+    tool,
+)
 
 
-def test_overlapping_calls_are_rejected_and_cancel_waits_for_active_call(tmp_path):
-    entered = threading.Event()
-    release = threading.Event()
-    contexts = []
+@tool
+@readonly
+def read(key: str, *, ctx: ToolContext) -> ToolResult:
+    """Read through the test's controlled callback."""
+    return ctx.robot.invoke(key, ctx)
 
-    @tool
-    @readonly
-    def read(*, ctx: ToolContext) -> ToolResult:
-        """Read until the current operation reaches its cancellation boundary."""
-        contexts.append(ctx)
-        entered.set()
-        assert release.wait(5)
-        ctx.check_cancelled()
-        return ToolResult(data={"ok": True})
 
-    toolkit = Toolkit(
-        state=EnvState(tmp_path),
-        memory=MemoryManager(tmp_path / "memory"),
-        robot=None,
-        output_dir=tmp_path,
-        tools=(read,),
+@tool
+def write(key: str, *, ctx: ToolContext) -> ToolResult:
+    """Act through the test's controlled callback."""
+    return ctx.robot.invoke(key, ctx)
+
+
+@tool
+def finish(status: str, summary: str, *, ctx: ToolContext) -> ToolResult:
+    """Finish with this robot's test outcome."""
+    ctx.robot.invoke("finish", ctx)
+    return ToolResult(data={"_finish": True, "status": "failure", "summary": summary})
+
+
+class ScheduledToolkit(Toolkit):
+    def __init__(self, root, invoke):
+        self.captures = 0
+        self.capture_hook = None
+        super().__init__(
+            state=EnvState(root),
+            memory=MemoryManager(root / "memory"),
+            robot=SimpleNamespace(invoke=invoke),
+            output_dir=root,
+            tools=(
+                finish,
+                read,
+                write,
+            ),
+        )
+
+    def _capture_observation(self, *, result, **kwargs):
+        if self.capture_hook:
+            self.capture_hook()
+        step = self.captures
+        self.captures += 1
+        data = {"step": step}
+        return data, []
+
+
+class Harness:
+    def __init__(self, root):
+        self.started = {}
+        self.hooks = {}
+        self.order = []
+        self.gates = []
+        self.pool = ThreadPoolExecutor(max_workers=12)
+        self.toolkit = ScheduledToolkit(root, self.invoke)
+        self.queue_changed = Event()
+        scheduler = self.toolkit._scheduler
+        original_can_start = scheduler._can_start
+
+        def observe_queue(call):
+            allowed = original_can_start(call)
+            if not allowed:
+                self.queue_changed.set()
+            return allowed
+
+        scheduler._can_start = observe_queue
+
+    def event(self, key):
+        return self.started.setdefault(key, Event())
+
+    def gate(self):
+        gate = Event()
+        self.gates.append(gate)
+        return gate
+
+    def invoke(self, key, ctx):
+        self.order.append(key)
+        self.event(key).set()
+        if key in self.hooks:
+            self.hooks[key](ctx)
+        return ToolResult(data={"key": key})
+
+    def submit(self, name, key):
+        self.event(key)
+        return self.pool.submit(self.toolkit.execute_tool, name, {"key": key})
+
+    def wait_for_queued(self, count=1):
+        """Wait for submissions to queue while active calls are held by test gates."""
+        scheduler = self.toolkit._scheduler
+        while True:
+            with scheduler._condition:
+                if len(scheduler._pending) == count:
+                    return
+                self.queue_changed.clear()
+            assert self.queue_changed.wait(2), f"Expected {count} queued calls."
+
+    def wait(self, key):
+        assert self.event(key).wait(2), f"Call {key} never started."
+
+    def block(self, key, gate):
+        def wait(ctx):
+            assert gate.wait(4), f"Gate for {key} not released."
+
+        self.hooks[key] = wait
+
+
+@pytest.fixture
+def harness(tmp_path):
+    value = Harness(tmp_path)
+    yield value
+    for gate in value.gates:
+        gate.set()
+    if value.toolkit._scheduler._state != "closed":
+        value.toolkit.close()
+    value.pool.shutdown(wait=True)
+
+
+def test_shared_calls_overlap_and_waiting_writer_blocks_new_readers(harness):
+    gate = harness.gate()
+    for key in ("a", "b"):
+        harness.block(key, gate)
+    a = harness.submit("read", "a")
+    b = harness.submit("read", "b")
+    harness.wait("a")
+    harness.wait("b")
+    writer = harness.submit("write", "w")
+    harness.wait_for_queued()
+    c = harness.submit("read", "c")
+    harness.wait_for_queued(2)
+    assert not harness.event("w").is_set()
+    assert not harness.event("c").is_set()
+    gate.set()
+    assert all(not f.result(3).is_error for f in (a, b, writer, c))
+    assert harness.order[-2:] == ["w", "c"]
+
+
+def test_writers_keep_registration_order_and_can_pass_waiting_reads(harness):
+    gate = harness.gate()
+    harness.block("active", gate)
+    active = harness.submit("write", "active")
+    harness.wait("active")
+    futures = []
+    for name, key in (("read", "a"), ("write", "b"), ("read", "c"), ("write", "d")):
+        futures.append(harness.submit(name, key))
+        harness.wait_for_queued(len(futures))
+    gate.set()
+    for future in [active, *futures]:
+        assert not future.result(3).is_error
+    assert harness.order[:3] == ["active", "b", "d"]
+    assert set(harness.order[3:]) == {"a", "c"}
+
+
+def test_finish_uses_exclusive_order_and_keeps_admission_open(harness):
+    gate = harness.gate()
+    harness.block("active", gate)
+    active = harness.submit("write", "active")
+    harness.wait("active")
+    reader = harness.submit("read", "reader")
+    harness.wait_for_queued()
+    finishing = harness.pool.submit(
+        harness.toolkit.execute_tool,
+        "finish",
+        {"status": "success", "summary": "requested"},
     )
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        active = pool.submit(toolkit.execute_tool, "read", {})
+    harness.wait_for_queued(2)
+    writer = harness.submit("write", "writer")
+    harness.wait_for_queued(3)
+    gate.set()
+    for future in (active, reader, writer):
+        assert not future.result(3).is_error
+    result = finishing.result(3)
+    assert not result.is_error
+    assert harness.order == ["active", "finish", "writer", "reader"]
+    expected = {"status": "failure", "summary": "requested"}
+    assert harness.toolkit.finish_result == expected
+    assert harness.toolkit.captures == 2
+    result.data["status"] = "changed"
+    saved = harness.toolkit.finish_result
+    saved["summary"] = "changed"
+    assert harness.toolkit.finish_result == expected
+    assert not harness.toolkit.execute_tool("write", {"key": "new"}).is_error
+
+
+def test_file_write_is_exclusive_and_does_not_capture(harness, tmp_path):
+    gate = harness.gate()
+    harness.block("active", gate)
+    active = harness.submit("read", "active")
+    harness.wait("active")
+    path = tmp_path / "note.txt"
+    write = harness.pool.submit(
+        harness.toolkit.execute_tool,
+        "write_text_file",
+        {"path": str(path), "content": "saved"},
+    )
+    harness.wait_for_queued()
+    assert not path.exists()
+    gate.set()
+    assert not active.result(3).is_error
+    result = write.result(3)
+    assert not result.is_error
+    assert result.data == {"path": str(path), "bytes_written": 5}
+    assert path.read_text() == "saved"
+    assert harness.toolkit.captures == 0
+
+
+def test_other_tools_cannot_record_a_finish_result(harness):
+    harness.toolkit._robot.invoke = lambda key, ctx: ToolResult(
+        data={"_finish": True, "status": "success", "summary": "ordinary result"}
+    )
+    assert not harness.toolkit.execute_tool("read", {"key": "probe"}).is_error
+    assert harness.toolkit.finish_result is None
+
+
+@pytest.mark.parametrize("name", ["read", "write"])
+def test_cancel_stops_waiting_calls_and_waits_for_active_cleanup(harness, name):
+    cancelled = harness.gate()
+    cleanup_gate = harness.gate()
+
+    def loop(ctx):
         try:
-            assert entered.wait(5)
-            rejected = toolkit.execute_tool("read", {})
-            assert rejected.error == "another tool operation is still active"
-            assert len(contexts) == 1
-            cancelled = pool.submit(toolkit.cancel_active_and_wait)
-            assert contexts[0]._cancel_event.wait(5)
-            assert not cancelled.done()
+            assert ctx._cancel_event.wait(3)
+            ctx.check_cancelled()
         finally:
-            release.set()
-        assert active.result(5).error == "Tool call cancelled."
-        cancelled.result(5)
-    assert not toolkit.execute_tool("read", {}).is_error
-    assert len(contexts) == 2
-    assert not contexts[1]._cancel_event.is_set()
+            cancelled.set()
+            assert cleanup_gate.wait(4)
+
+    harness.hooks["active"] = loop
+    active = harness.submit(name, "active")
+    harness.wait("active")
+    waiting = harness.submit("write", "waiting")
+    harness.wait_for_queued()
+    stop = harness.pool.submit(harness.toolkit.cancel_active_and_wait)
+    assert cancelled.wait(2)
+    assert waiting.result(2).error == "Tool call cancelled."
+    assert not harness.event("waiting").is_set()
+    assert not stop.done()
+    assert (
+        harness.toolkit.execute_tool("read", {"key": "paused"}).error
+        == "Tool calls are paused."
+    )
+    with pytest.raises(RuntimeError, match="cleanup"):
+        harness.toolkit.resume_calls()
+    cleanup_gate.set()
+    assert active.result(3).error == "Tool call cancelled."
+    stop.result(3)
+    assert harness.toolkit.captures == (1 if name == "write" else 0)
+    harness.toolkit.resume_calls()
+    assert not harness.toolkit.execute_tool("read", {"key": "new"}).is_error
+
+
+def test_all_active_shared_calls_receive_cancellation(harness):
+    def loop(ctx):
+        assert ctx._cancel_event.wait(3)
+        ctx.check_cancelled()
+
+    harness.hooks.update(a=loop, b=loop)
+    futures = [harness.submit("read", key) for key in ("a", "b")]
+    harness.wait("a")
+    harness.wait("b")
+    harness.toolkit.cancel_active_and_wait()
+    assert [f.result(2).error for f in futures] == ["Tool call cancelled."] * 2
+
+
+def test_exclusive_admission_is_retained_through_final_capture(harness):
+    capture_started = harness.gate()
+    capture_gate = harness.gate()
+
+    def capture():
+        capture_started.set()
+        assert capture_gate.wait(4)
+
+    harness.toolkit.capture_hook = capture
+    active = harness.submit("write", "write")
+    assert capture_started.wait(2)
+    reader = harness.submit("read", "reader")
+    harness.wait_for_queued()
+    assert not harness.event("reader").is_set()
+    capture_gate.set()
+    assert not active.result(3).is_error
+    assert not reader.result(3).is_error
+
+
+def test_close_waits_for_final_capture_before_saving_video(harness, monkeypatch):
+    capture_started = harness.gate()
+    capture_gate = harness.gate()
+    cleaned = Event()
+
+    def capture():
+        capture_started.set()
+        assert capture_gate.wait(4)
+
+    harness.toolkit.capture_hook = capture
+    harness.toolkit.record_frame([[[0, 0, 0]]])
+    monkeypatch.setattr(
+        harness.toolkit.state, "save", lambda *args, **kwargs: cleaned.set()
+    )
+    active = harness.submit("write", "write")
+    assert capture_started.wait(2)
+    closing = harness.pool.submit(harness.toolkit.close)
+    scheduler = harness.toolkit._scheduler
+    with scheduler._condition:
+        assert scheduler._condition.wait_for(
+            lambda: scheduler._state == "closed", timeout=2
+        )
+    assert not cleaned.is_set()
+    assert not closing.done()
+    assert (
+        harness.toolkit.execute_tool("read", {"key": "late"}).error
+        == "Toolkit is closed."
+    )
+    capture_gate.set()
+    active.result(3)
+    closing.result(3)
+    assert cleaned.is_set()
+    harness.toolkit.cancel_active_and_wait()
+    harness.toolkit.resume_calls()
+    assert (
+        harness.toolkit.execute_tool("read", {"key": "closed"}).error
+        == "Toolkit is closed."
+    )
+
+
+def test_toolkits_do_not_share_execution_locks(harness, tmp_path):
+    gate = harness.gate()
+    harness.block("blocked", gate)
+    active = harness.submit("write", "blocked")
+    harness.wait("blocked")
+    other = ScheduledToolkit(tmp_path / "other", lambda key, ctx: ToolResult())
+    try:
+        assert not other.execute_tool("write", {"key": "independent"}).is_error
+    finally:
+        gate.set()
+        other.close()
+    assert not active.result(3).is_error
+
+
+def test_cancel_between_admission_and_handler_skips_execution_and_capture(
+    harness, monkeypatch
+):
+    admitted = harness.gate()
+    start_gate = harness.gate()
+    scheduler = harness.toolkit._scheduler
+    original = scheduler.acquire
+
+    def acquire(tool):
+        call = original(tool)
+        admitted.set()
+        assert start_gate.wait(4)
+        return call
+
+    monkeypatch.setattr(scheduler, "acquire", acquire)
+    future = harness.submit("write", "never_start")
+    assert admitted.wait(2)
+    stopping = harness.pool.submit(harness.toolkit.cancel_active_and_wait)
+    with scheduler._condition:
+        assert scheduler._condition.wait_for(
+            lambda: scheduler._state == "paused", timeout=2
+        )
+    start_gate.set()
+    assert future.result(3).error == "Tool call cancelled."
+    stopping.result(3)
+    assert harness.toolkit.captures == 0
+    assert not harness.event("never_start").is_set()
+
+
+def test_overlapping_cancellation_requests_wait_for_active_cleanup(
+    harness, monkeypatch
+):
+    cancelled = harness.gate()
+    cleanup_gate = harness.gate()
+
+    def loop(ctx):
+        try:
+            assert ctx._cancel_event.wait(3)
+            ctx.check_cancelled()
+        finally:
+            cancelled.set()
+            assert cleanup_gate.wait(4)
+
+    harness.hooks["active"] = loop
+    active = harness.submit("write", "active")
+    harness.wait("active")
+    scheduler = harness.toolkit._scheduler
+    original_wait = scheduler._condition.wait
+    waiting = set()
+    both_waiting = Event()
+
+    def wait_done(timeout=None):
+        waiting.add(get_ident())
+        if len(waiting) == 2:
+            both_waiting.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(scheduler._condition, "wait", wait_done)
+    first = harness.pool.submit(harness.toolkit.cancel_active_and_wait)
+    assert cancelled.wait(2)
+    second = harness.pool.submit(harness.toolkit.cancel_active_and_wait)
+    assert both_waiting.wait(2)
+    with pytest.raises(RuntimeError, match="cleanup"):
+        harness.toolkit.resume_calls()
+    assert not first.done() and not second.done()
+    cleanup_gate.set()
+    assert active.result(3).error == "Tool call cancelled."
+    first.result(3)
+    second.result(3)
+    harness.toolkit.resume_calls()
+    assert not harness.toolkit.execute_tool("read", {"key": "resumed"}).is_error
+
+
+def test_resume_does_not_revive_cancelled_waiters_or_extend_old_cancellation(
+    harness, monkeypatch
+):
+    scheduler = harness.toolkit._scheduler
+    active_gate = harness.gate()
+    rejection_gate = harness.gate()
+    new_gate = harness.gate()
+    old_woken = Event()
+    old_thread = None
+    original_wait = scheduler._condition.wait
+
+    def delay_old_waiter(timeout=None):
+        nonlocal old_thread
+        if old_thread is None:
+            old_thread = get_ident()
+        result = original_wait(timeout)
+        if get_ident() != old_thread:
+            return result
+        scheduler._condition.release()
+        try:
+            old_woken.set()
+            assert rejection_gate.wait(4)
+        finally:
+            scheduler._condition.acquire()
+        return result
+
+    monkeypatch.setattr(scheduler._condition, "wait", delay_old_waiter)
+    harness.block("active", active_gate)
+    active = harness.submit("write", "active")
+    harness.wait("active")
+    old = harness.submit("write", "old")
+    harness.wait_for_queued()
+    stopping = harness.pool.submit(harness.toolkit.cancel_active_and_wait)
+    assert old_woken.wait(2)
+    active_gate.set()
+    active.result(3)
+    assert not stopping.done()
+    harness.toolkit.resume_calls()
+
+    def new_call(ctx):
+        assert new_gate.wait(4)
+        ctx.check_cancelled()
+
+    harness.hooks["new"] = new_call
+    new = harness.submit("read", "new")
+    harness.wait("new")
+    rejection_gate.set()
+    assert old.result(3).error == "Tool call cancelled."
+    assert not harness.event("old").is_set()
+    stopping.result(3)
+    assert not new.done()
+    new_gate.set()
+    assert not new.result(3).is_error


### PR DESCRIPTION
## Description

Part 3 of the split from #158; depends on #173.

- Add readonly parallelism, ordered exclusive calls, and cancellation/drain/resume handling.
- Centralize action/episode recording and recipe export in `Toolkit`.
- Update planner interruption and finalize Flywheel collection after calls drain.

Recipes include successful action and perception calls across resets.

## Testing

- Unit tests: **498 passed, 5 skipped** (missing Franka/LeRobot dependencies).
- Pre-commit and English/Chinese docs passed; 11 GPU E2E tests collect.

## Manual verification

GPU/simulator and real-robot cancellation/recording runs are pending.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated related documentation when needed.
- [x] I have added tests to cover my changes when needed.
- [x] All new and existing tests passed.
