### PR TITLE
fix(robotwin): use requested seed for language prewalk initialization

### DIFF
--- a/robots/robotwin/rlinf_env.py
+++ b/robots/robotwin/rlinf_env.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 import numpy as np
+import torch
 from rlinf.envs.robotwin.robotwin_env import RoboTwinEnv
 
 from robots.robotwin.robot_spec import RoboTwinActionType
@@ -69,6 +70,30 @@ def _execution_should_stop(status: dict[str, Any]) -> bool:
 
 class RoboTwinAgentEnv(RoboTwinEnv):
     """RPent/agent runtime extension; preserves training RoboTwinEnv unchanged."""
+
+    def _init_reset_state_ids(self) -> None:
+        """Use requested seeds for the native vector env's language prewalk.
+
+        RoboTwin generates task language while constructing ``VectorEnv``, before
+        the facade performs its explicit reset.  Both stages must use the same seed.
+        """
+        initial_env_seeds = self.cfg.get("initial_env_seeds", None)
+        if initial_env_seeds is None:
+            super()._init_reset_state_ids()
+            return
+
+        seeds = [int(seed) for seed in initial_env_seeds]
+        if len(seeds) != self.num_envs:
+            raise ValueError(
+                "initial_env_seeds must contain one seed per RoboTwin environment: "
+                f"expected {self.num_envs}, got {len(seeds)}"
+            )
+
+        self.success_seeds = None
+        self._current_seed_index = 0
+        self._generator = torch.Generator()
+        self._generator.manual_seed(self.seed)
+        self.reset_state_ids = torch.as_tensor(seeds, dtype=torch.long)
 
     @staticmethod
     def _initialize_native_evaluator_state(task: Any) -> None:

--- a/tests/unit_tests/robots/robotwin/test_seed_language_contract.py
+++ b/tests/unit_tests/robots/robotwin/test_seed_language_contract.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The RPent Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+"""Regression tests for RoboTwin exact-seed language initialization."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+rlinf_robotwin = pytest.importorskip("rlinf.envs.robotwin.robotwin_env")
+rpent_robotwin = pytest.importorskip("robots.robotwin.rlinf_env")
+RoboTwinEnv = rlinf_robotwin.RoboTwinEnv
+RoboTwinAgentEnv = rpent_robotwin.RoboTwinAgentEnv
+
+
+def _agent_env(*, initial_env_seeds, num_envs=1):
+    env = RoboTwinAgentEnv.__new__(RoboTwinAgentEnv)
+    env.cfg = {"initial_env_seeds": initial_env_seeds}
+    env.num_envs = num_envs
+    env.seed = 7
+    return env
+
+
+def test_requested_seeds_initialize_vector_env_and_language_prewalk():
+    env = _agent_env(initial_env_seeds=[100003, 100007], num_envs=2)
+
+    env._init_reset_state_ids()
+
+    assert torch.equal(env.reset_state_ids, torch.tensor([100003, 100007]))
+    assert env.success_seeds is None
+    assert env._current_seed_index == 0
+
+
+def test_initial_seed_count_must_match_environment_count():
+    env = _agent_env(initial_env_seeds=[100003], num_envs=2)
+
+    with pytest.raises(ValueError, match="expected 2, got 1"):
+        env._init_reset_state_ids()
+
+
+def test_initialization_falls_back_to_rlinf_without_requested_seeds(monkeypatch):
+    env = _agent_env(initial_env_seeds=None)
+    calls = []
+
+    monkeypatch.setattr(
+        RoboTwinEnv,
+        "_init_reset_state_ids",
+        lambda self: calls.append(self),
+    )
+
+    env._init_reset_state_ids()
+
+    assert calls == [env]


### PR DESCRIPTION
## Description

RoboTwin task language is generated during `VectorEnv` construction from its initial reset state. RPent already supplies the requested episode seed through `initial_env_seeds`, but the inherited RLinf initialization ignores that field and samples a different reset-state seed. The facade subsequently resets the scene to the requested seed, so the scene seed is correct while the cached instruction can describe the prewalk scene.

This change overrides reset-state initialization only in `RoboTwinAgentEnv` so the language prewalk and explicit episode reset use the same requested seed. It validates that one seed is provided per environment and falls back to the existing RLinf behavior when `initial_env_seeds` is absent. The RLinf training environment is unchanged.

## Testing

- `python -m pytest tests/unit_tests/robots/robotwin -q` — 7 passed
- `python -m ruff check robots/robotwin/rlinf_env.py tests/unit_tests/robots/robotwin/test_seed_language_contract.py`
- `python -m ruff format --check robots/robotwin/rlinf_env.py tests/unit_tests/robots/robotwin/test_seed_language_contract.py`
- `git diff --check`

## Manual verification

Ran real `demo_randomized` RoboTwin initialization using the packaged runtime and managed assets. For each case below, both `setup_demo` calls used the requested seed, the final scene reported the same seed, and the generated instruction matched the scene model/arm binding:

- `adjust_bottle`, seed `100003`: bottle model `base16`, left arm
- `place_object_stand`, seed `100003`: Rubik's cube `base0`, display stand `base1`, right arm
- `place_shoe`, seed `100001`: shoe `base1`, left arm

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated related documentation when needed.
- [x] I have added tests to cover my changes when needed.
- [x] All new and existing tests passed.